### PR TITLE
Add dynamic.element for decoding tuples

### DIFF
--- a/gen/src/gleam@dynamic.erl
+++ b/gen/src/gleam@dynamic.erl
@@ -1,7 +1,7 @@
 -module(gleam@dynamic).
 -compile(no_auto_import).
 
--export([from/1, unsafe_coerce/1, string/1, int/1, float/1, atom/1, bool/1, thunk/1, list/2, field/2]).
+-export([from/1, unsafe_coerce/1, string/1, int/1, float/1, atom/1, bool/1, thunk/1, list/2, field/2, element/2]).
 
 from(A) ->
     gleam_stdlib:identity(A).
@@ -38,3 +38,6 @@ list(Dynamic, DecoderType) ->
 
 field(A, B) ->
     gleam_stdlib:decode_field(A, B).
+
+element(A, B) ->
+    gleam_stdlib:decode_element(A, B).

--- a/gen/test/gleam@dynamic_test.erl
+++ b/gen/test/gleam@dynamic_test.erl
@@ -1,7 +1,7 @@
 -module(gleam@dynamic_test).
 -compile(no_auto_import).
 
--export([string_test/0, int_test/0, float_test/0, thunk_test/0, bool_test/0, atom_test/0, list_test/0, field_test/0]).
+-export([string_test/0, int_test/0, float_test/0, thunk_test/0, bool_test/0, atom_test/0, list_test/0, field_test/0, element_test/0]).
 
 string_test() ->
     gleam@expect:equal(
@@ -168,3 +168,29 @@ field_test() ->
     ),
     gleam@expect:is_error(gleam@dynamic:field(gleam@dynamic:from(1), OkAtom)),
     gleam@expect:is_error(gleam@dynamic:field(gleam@dynamic:from([]), [])).
+
+element_test() ->
+    {ok, OkAtom} = gleam@atom:from_string(<<"ok">>),
+    {ok, ErrorAtom} = gleam@atom:from_string(<<"ok">>),
+    OkOneStruct = {OkAtom, 1},
+    gleam@expect:equal(
+        gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), 0),
+        {ok, gleam@dynamic:from(OkAtom)}
+    ),
+    gleam@expect:equal(
+        gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), 1),
+        {ok, gleam@dynamic:from(1)}
+    ),
+    gleam@expect:is_error(
+        gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), 2)
+    ),
+    gleam@expect:is_error(
+        gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), -1)
+    ),
+    gleam@expect:is_error(gleam@dynamic:element(gleam@dynamic:from(1), 0)),
+    gleam@expect:is_error(
+        gleam@dynamic:element(
+            gleam@dynamic:from(gleam@map:insert(gleam@map:new(), 1, OkAtom)),
+            0
+        )
+    ).

--- a/gen/test/gleam@dynamic_test.erl
+++ b/gen/test/gleam@dynamic_test.erl
@@ -171,7 +171,6 @@ field_test() ->
 
 element_test() ->
     {ok, OkAtom} = gleam@atom:from_string(<<"ok">>),
-    {ok, ErrorAtom} = gleam@atom:from_string(<<"ok">>),
     OkOneStruct = {OkAtom, 1},
     gleam@expect:equal(
         gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), 0),
@@ -188,10 +187,9 @@ element_test() ->
         gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), -1)
     ),
     gleam@expect:is_error(gleam@dynamic:element(gleam@dynamic:from(1), 0)),
-    gleam@expect:equal(
+    gleam@expect:is_error(
         gleam@dynamic:element(
             gleam@dynamic:from(gleam@map:insert(gleam@map:new(), 1, OkAtom)),
             0
-        ),
-        {error, nil}
+        )
     ).

--- a/gen/test/gleam@dynamic_test.erl
+++ b/gen/test/gleam@dynamic_test.erl
@@ -188,9 +188,10 @@ element_test() ->
         gleam@dynamic:element(gleam@dynamic:from(OkOneStruct), -1)
     ),
     gleam@expect:is_error(gleam@dynamic:element(gleam@dynamic:from(1), 0)),
-    gleam@expect:is_error(
+    gleam@expect:equal(
         gleam@dynamic:element(
             gleam@dynamic:from(gleam@map:insert(gleam@map:new(), 1, OkAtom)),
             0
-        )
+        ),
+        {error, nil}
     ).

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -49,5 +49,5 @@ pub fn list(from dynamic, containing decoder_type) {
 pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, String)
   = "gleam_stdlib" "decode_field"
 
-pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, Nil)
+pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, String)
   = "gleam_stdlib" "decode_element"

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -48,3 +48,6 @@ pub fn list(from dynamic, containing decoder_type) {
 
 pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, String)
   = "gleam_stdlib" "decode_field"
+
+pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, String)
+  = "gleam_stdlib" "decode_element"

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -49,5 +49,5 @@ pub fn list(from dynamic, containing decoder_type) {
 pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, String)
   = "gleam_stdlib" "decode_field"
 
-pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, String)
+pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, Nil)
   = "gleam_stdlib" "decode_element"

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -70,17 +70,15 @@ decode_field(Data, Key) ->
       decode_error_msg(io_lib:format("a map with key `~p`", [Key]), Data)
   end.
 
-decode_element(Data, Position) ->
+decode_element(Data, Position) when is_tuple(Data) ->
   case catch element(Position + 1, Data) of
     {'EXIT', _Reason} ->
-      {error, nil};
+      {error, "Element position is out-of-bounds"};
 
     Value ->
-      {ok, Value};
-
-    _ ->
-      {error, nil}
-  end.
+      {ok, Value}
+  end;
+decode_element(Data, Position) -> decode_error_msg("a Tuple", Data).
 
 parse_int(String) ->
   case string:to_integer(binary:bin_to_list(String)) of

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -6,7 +6,7 @@
          atom_create_from_string/1, atom_to_string/1, map_get/2,
          iodata_append/2, iodata_prepend/2, identity/1, decode_int/1,
          decode_string/1, decode_bool/1, decode_float/1, decode_thunk/1, decode_atom/1,
-         decode_list/1, decode_field/2, parse_int/1, parse_float/1, compare_strings/2]).
+         decode_list/1, decode_field/2, decode_element/2, parse_int/1, parse_float/1, compare_strings/2]).
 
 expect_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 expect_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -68,6 +68,18 @@ decode_field(Data, Key) ->
 
     _ ->
       decode_error_msg(io_lib:format("a map with key `~p`", [Key]), Data)
+  end.
+
+decode_element(Data, Position) ->
+  case catch element(Position + 1, Data) of
+    {'EXIT', _Reason} ->
+      {error, nil};
+
+    Value ->
+      {ok, Value};
+
+    _ ->
+      {error, nil}
   end.
 
 parse_int(String) ->

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -221,3 +221,40 @@ pub fn field_test() {
   |> dynamic.field(_, [])
   |> expect.is_error
 }
+
+pub fn element_test() {
+  let Ok(ok_atom) = atom.from_string("ok")
+  let Ok(error_atom) = atom.from_string("ok")
+  let ok_one_struct = struct(ok_atom, 1)
+
+  ok_one_struct
+  |> dynamic.from
+  |> dynamic.element(_, 0)
+  |> expect.equal(_, Ok(dynamic.from(ok_atom)))
+
+  ok_one_struct
+  |> dynamic.from
+  |> dynamic.element(_, 1)
+  |> expect.equal(_, Ok(dynamic.from(1)))
+
+  ok_one_struct
+  |> dynamic.from
+  |> dynamic.element(_, 2)
+  |> expect.is_error
+
+  ok_one_struct
+  |> dynamic.from
+  |> dynamic.element(_, -1)
+  |> expect.is_error
+
+  1
+  |> dynamic.from
+  |> dynamic.element(_, 0)
+  |> expect.is_error
+
+  map.new()
+  |> map.insert(_, 1, ok_atom)
+  |> dynamic.from
+  |> dynamic.element(_, 0)
+  |> expect.is_error
+}

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -256,5 +256,5 @@ pub fn element_test() {
   |> map.insert(_, 1, ok_atom)
   |> dynamic.from
   |> dynamic.element(_, 0)
-  |> expect.is_error
+  |> expect.equal(_, Error(Nil))
 }

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -224,7 +224,6 @@ pub fn field_test() {
 
 pub fn element_test() {
   let Ok(ok_atom) = atom.from_string("ok")
-  let Ok(error_atom) = atom.from_string("ok")
   let ok_one_struct = struct(ok_atom, 1)
 
   ok_one_struct
@@ -256,5 +255,5 @@ pub fn element_test() {
   |> map.insert(_, 1, ok_atom)
   |> dynamic.from
   |> dynamic.element(_, 0)
-  |> expect.equal(_, Error(Nil))
+  |> expect.is_error
 }


### PR DESCRIPTION
Hello!

I was writing some Gleam bindings to an Erlang library and realized that I wanted to be able to decode a tuple, but couldn't (or at least couldn't figure out how to) with existing decoding functions in `gleam/dynamic`.

This adds a new function to the `dynamic` module, called `element` in the spirit of the other decoding function names (e.g. `field`), which takes a `from: Dynamic` (which is hopefully a tuple!) and a `position: Int`, and returns a result with either the element from that tuple at that position (if it is in bounds), or an error with a helpful message.

Any feedback appreciated!