### PR TITLE
Add leading underscore to unused Erlang arg

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, warnings_as_errors]}.
 {src_dirs, ["src", "gen/src"]}.
 
 {profiles, [

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -78,7 +78,7 @@ decode_element(Data, Position) when is_tuple(Data) ->
     Value ->
       {ok, Value}
   end;
-decode_element(Data, Position) -> decode_error_msg("a Tuple", Data).
+decode_element(Data, _Position) -> decode_error_msg("a Tuple", Data).
 
 parse_int(String) ->
   case string:to_integer(binary:bin_to_list(String)) of


### PR DESCRIPTION
I pulled the `master` branch into my project to use `dynamic.element` and noticed this warning:

```
===> Compiling gleam_stdlib
_build/default/lib/gleam_stdlib/src/gleam_stdlib.erl:81: Warning: variable 'Position' is unused
```

This should fix it!