### PR TITLE
Implementing many more string functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- The `string` module gains `slice`, `drop_left`, `drop_right`, `starts_with`,
+  `ends_with`, `pad_left`, `pad_right`, `trim`, `trim_left`, `trim_right`,
+  `to_graphemes`, `from_graphemes`, `next_grapheme`.
 - The error type for `atom.from_string` has been renamed to `FromStringError`.
 - The `string` module gains `contains` and `repeat` functions.
 - The `expect` module has been renamed to `should`. Functions in the module

--- a/gen/src/gleam@string.erl
+++ b/gen/src/gleam@string.erl
@@ -1,10 +1,10 @@
 -module(gleam@string).
 -compile(no_auto_import).
 
--export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2]).
+-export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, slice/3, drop_left/2, drop_right/2, contains/2, starts_with/2, ends_with/2, split/2, append/2, concat/1, repeat/2, join/2, pad_left/3, pad_right/3, trim/1, trim_left/1, trim_right/1, to_graphemes/1, next_grapheme/1]).
 
 is_empty(Str) ->
-    Str =:= <<"">>.
+    Str =:= <<""/utf8>>.
 
 length(A) ->
     string:length(A).
@@ -26,11 +26,54 @@ uppercase(A) ->
 compare(A, B) ->
     gleam_stdlib:compare_strings(A, B).
 
-erl_contains(A, B) ->
+erl_string_slice(A, B, C) ->
+    string:slice(A, B, C).
+
+slice(String, Start, Length) ->
+    case Start < 0 orelse Length =< 0 of
+        true ->
+            <<""/utf8>>;
+
+        false ->
+            erl_string_slice(String, Start, Length)
+    end.
+
+erl_string_slice_to_infinity(A, B) ->
+    string:slice(A, B).
+
+drop_left(From, UpTo) ->
+    case UpTo =< 0 of
+        true ->
+            From;
+
+        false ->
+            erl_string_slice_to_infinity(From, UpTo)
+    end.
+
+drop_right(From, Drop) ->
+    case Drop =< 0 of
+        true ->
+            From;
+
+        false ->
+            Start = length(From) - Drop,
+            case Start =< 0 of
+                true ->
+                    <<""/utf8>>;
+
+                false ->
+                    erl_string_slice(From, 0, Start)
+            end
+    end.
+
+contains(A, B) ->
     gleam_stdlib:string_contains(A, B).
 
-contains(Haystack, Needle) ->
-    erl_contains(Haystack, Needle).
+starts_with(A, B) ->
+    gleam_stdlib:string_starts_with(A, B).
+
+ends_with(A, B) ->
+    gleam_stdlib:string_ends_with(A, B).
 
 split(X, Substring) ->
     gleam@list:map(
@@ -43,8 +86,8 @@ append(First, Second) ->
         gleam@iodata:append(gleam@iodata:new(First), Second)
     ).
 
-concat(Strings) ->
-    gleam@iodata:to_string(gleam@iodata:from_strings(Strings)).
+concat(A) ->
+    unicode:characters_to_binary(A).
 
 repeat_help(Chunk, Result, Repeats) ->
     case Repeats =< 0 of
@@ -62,3 +105,73 @@ join(Strings, Separator) ->
     gleam@iodata:to_string(
         gleam@iodata:from_strings(gleam@list:intersperse(Strings, Separator))
     ).
+
+pad_fill_help(Result, Chunk, ChunkLength, ToFill) ->
+    One = 1,
+    case true of
+        true when One > ToFill ->
+            concat(Result);
+
+        true when ToFill > ChunkLength ->
+            pad_fill_help(
+                [Chunk | Result],
+                Chunk,
+                ChunkLength,
+                ToFill
+                - ChunkLength
+            );
+
+        true ->
+            concat(gleam@list:reverse([slice(Chunk, 0, ToFill) | Result]))
+    end.
+
+pad_help(Pad, ToLength, With, PadSide) ->
+    One = 1,
+    PadLen = length(Pad),
+    WithLen = length(With),
+    case true of
+        true when PadLen > WithLen ->
+            Pad;
+
+        true when One > WithLen ->
+            Pad;
+
+        true ->
+            case PadSide of
+                left ->
+                    concat(
+                        [pad_fill_help([], With, WithLen, ToLength - PadLen),
+                         Pad]
+                    );
+
+                right ->
+                    concat(
+                        [Pad,
+                         pad_fill_help([], With, WithLen, ToLength - PadLen)]
+                    )
+            end
+    end.
+
+pad_left(Pad, ToLength, With) ->
+    pad_help(Pad, ToLength, With, left).
+
+pad_right(Pad, ToLength, With) ->
+    pad_help(Pad, ToLength, With, right).
+
+erl_string_trim(A, B) ->
+    string:trim(A, B).
+
+trim(String) ->
+    erl_string_trim(String, both).
+
+trim_left(String) ->
+    erl_string_trim(String, leading).
+
+trim_right(String) ->
+    erl_string_trim(String, trailing).
+
+to_graphemes(A) ->
+    gleam_stdlib:string_to_graphemes(A).
+
+next_grapheme(A) ->
+    gleam_stdlib:string_next_grapheme(A).

--- a/gen/test/gleam@atom_test.erl
+++ b/gen/test/gleam@atom_test.erl
@@ -4,38 +4,40 @@
 -export([from_string_test/0, create_from_string_test/0, to_string_test/0]).
 
 from_string_test() ->
-    gleam@should:be_ok(gleam@atom:from_string(<<"ok">>)),
-    gleam@should:be_ok(gleam@atom:from_string(<<"expect">>)),
+    gleam@should:be_ok(gleam@atom:from_string(<<"ok"/utf8>>)),
+    gleam@should:be_ok(gleam@atom:from_string(<<"expect"/utf8>>)),
     gleam@should:equal(
-        gleam@atom:from_string(<<"this is not an atom we have seen before">>),
+        gleam@atom:from_string(
+            <<"this is not an atom we have seen before"/utf8>>
+        ),
         {error, atom_not_loaded}
     ).
 
 create_from_string_test() ->
     gleam@should:equal(
-        {ok, gleam@atom:create_from_string(<<"ok">>)},
-        gleam@atom:from_string(<<"ok">>)
+        {ok, gleam@atom:create_from_string(<<"ok"/utf8>>)},
+        gleam@atom:from_string(<<"ok"/utf8>>)
     ),
     gleam@should:equal(
-        {ok, gleam@atom:create_from_string(<<"expect">>)},
-        gleam@atom:from_string(<<"expect">>)
+        {ok, gleam@atom:create_from_string(<<"expect"/utf8>>)},
+        gleam@atom:from_string(<<"expect"/utf8>>)
     ),
     gleam@should:equal(
         {ok,
          gleam@atom:create_from_string(
-             <<"this is another atom we have not seen before">>
+             <<"this is another atom we have not seen before"/utf8>>
          )},
         gleam@atom:from_string(
-            <<"this is another atom we have not seen before">>
+            <<"this is another atom we have not seen before"/utf8>>
         )
     ).
 
 to_string_test() ->
     gleam@should:equal(
-        gleam@atom:to_string(gleam@atom:create_from_string(<<"ok">>)),
-        <<"ok">>
+        gleam@atom:to_string(gleam@atom:create_from_string(<<"ok"/utf8>>)),
+        <<"ok"/utf8>>
     ),
     gleam@should:equal(
-        gleam@atom:to_string(gleam@atom:create_from_string(<<"expect">>)),
-        <<"expect">>
+        gleam@atom:to_string(gleam@atom:create_from_string(<<"expect"/utf8>>)),
+        <<"expect"/utf8>>
     ).

--- a/gen/test/gleam@dynamic_test.erl
+++ b/gen/test/gleam@dynamic_test.erl
@@ -5,20 +5,20 @@
 
 string_test() ->
     gleam@should:equal(
-        gleam@dynamic:string(gleam@dynamic:from(<<"">>)),
-        {ok, <<"">>}
+        gleam@dynamic:string(gleam@dynamic:from(<<""/utf8>>)),
+        {ok, <<""/utf8>>}
     ),
     gleam@should:equal(
-        gleam@dynamic:string(gleam@dynamic:from(<<"Hello">>)),
-        {ok, <<"Hello">>}
+        gleam@dynamic:string(gleam@dynamic:from(<<"Hello"/utf8>>)),
+        {ok, <<"Hello"/utf8>>}
     ),
     gleam@should:equal(
         gleam@dynamic:string(gleam@dynamic:from(1)),
-        {error, <<"Expected a String, got `1`">>}
+        {error, <<"Expected a String, got `1`"/utf8>>}
     ),
     gleam@should:equal(
         gleam@dynamic:string(gleam@dynamic:from([])),
-        {error, <<"Expected a String, got `[]`">>}
+        {error, <<"Expected a String, got `[]`"/utf8>>}
     ).
 
 int_test() ->
@@ -26,11 +26,11 @@ int_test() ->
     gleam@should:equal(gleam@dynamic:int(gleam@dynamic:from(2)), {ok, 2}),
     gleam@should:equal(
         gleam@dynamic:int(gleam@dynamic:from(1.0)),
-        {error, <<"Expected an Int, got `1.0`">>}
+        {error, <<"Expected an Int, got `1.0`"/utf8>>}
     ),
     gleam@should:equal(
         gleam@dynamic:int(gleam@dynamic:from([])),
-        {error, <<"Expected an Int, got `[]`">>}
+        {error, <<"Expected an Int, got `[]`"/utf8>>}
     ).
 
 float_test() ->
@@ -38,11 +38,11 @@ float_test() ->
     gleam@should:equal(gleam@dynamic:float(gleam@dynamic:from(2.2)), {ok, 2.2}),
     gleam@should:equal(
         gleam@dynamic:float(gleam@dynamic:from(1)),
-        {error, <<"Expected a Float, got `1`">>}
+        {error, <<"Expected a Float, got `1`"/utf8>>}
     ),
     gleam@should:equal(
         gleam@dynamic:float(gleam@dynamic:from([])),
-        {error, <<"Expected a Float, got `[]`">>}
+        {error, <<"Expected a Float, got `[]`"/utf8>>}
     ).
 
 thunk_test() ->
@@ -71,25 +71,25 @@ bool_test() ->
     ),
     gleam@should:equal(
         gleam@dynamic:bool(gleam@dynamic:from(1)),
-        {error, <<"Expected a Bool, got `1`">>}
+        {error, <<"Expected a Bool, got `1`"/utf8>>}
     ),
     gleam@should:equal(
         gleam@dynamic:bool(gleam@dynamic:from([])),
-        {error, <<"Expected a Bool, got `[]`">>}
+        {error, <<"Expected a Bool, got `[]`"/utf8>>}
     ).
 
 atom_test() ->
     gleam@should:equal(
         gleam@dynamic:atom(
-            gleam@dynamic:from(gleam@atom:create_from_string(<<"">>))
+            gleam@dynamic:from(gleam@atom:create_from_string(<<""/utf8>>))
         ),
-        {ok, gleam@atom:create_from_string(<<"">>)}
+        {ok, gleam@atom:create_from_string(<<""/utf8>>)}
     ),
     gleam@should:equal(
         gleam@dynamic:atom(
-            gleam@dynamic:from(gleam@atom:create_from_string(<<"ok">>))
+            gleam@dynamic:from(gleam@atom:create_from_string(<<"ok"/utf8>>))
         ),
-        {ok, gleam@atom:create_from_string(<<"ok">>)}
+        {ok, gleam@atom:create_from_string(<<"ok"/utf8>>)}
     ),
     gleam@should:be_error(gleam@dynamic:atom(gleam@dynamic:from(1))),
     gleam@should:be_error(gleam@dynamic:atom(gleam@dynamic:from([]))).
@@ -127,22 +127,23 @@ list_test() ->
     ),
     gleam@should:be_error(
         gleam@dynamic:list(
-            gleam@dynamic:from([<<"">>]),
+            gleam@dynamic:from([<<""/utf8>>]),
             fun gleam@dynamic:int/1
         )
     ),
     gleam@should:be_error(
         gleam@dynamic:list(
             gleam@dynamic:from(
-                [gleam@dynamic:from(1), gleam@dynamic:from(<<"not an int">>)]
+                [gleam@dynamic:from(1),
+                 gleam@dynamic:from(<<"not an int"/utf8>>)]
             ),
             fun gleam@dynamic:int/1
         )
     ).
 
 field_test() ->
-    {ok, OkAtom} = gleam@atom:from_string(<<"ok">>),
-    {ok, ErrorAtom} = gleam@atom:from_string(<<"error">>),
+    {ok, OkAtom} = gleam@atom:from_string(<<"ok"/utf8>>),
+    {ok, ErrorAtom} = gleam@atom:from_string(<<"error"/utf8>>),
     gleam@should:equal(
         gleam@dynamic:field(
             gleam@dynamic:from(gleam@map:insert(gleam@map:new(), OkAtom, 1)),
@@ -170,7 +171,7 @@ field_test() ->
     gleam@should:be_error(gleam@dynamic:field(gleam@dynamic:from([]), [])).
 
 element_test() ->
-    {ok, OkAtom} = gleam@atom:from_string(<<"ok">>),
+    {ok, OkAtom} = gleam@atom:from_string(<<"ok"/utf8>>),
     OkOneTuple = {OkAtom, 1},
     gleam@should:equal(
         gleam@dynamic:element(gleam@dynamic:from(OkOneTuple), 0),

--- a/gen/test/gleam@float_test.erl
+++ b/gen/test/gleam@float_test.erl
@@ -4,16 +4,19 @@
 -export([parse_test/0, to_string_test/0, compare_test/0, ceiling_test/0, floor_test/0, round_test/0, truncate_test/0, min_test/0, max_test/0]).
 
 parse_test() ->
-    gleam@should:equal(gleam@float:parse(<<"1.23">>), {ok, 1.23}),
-    gleam@should:equal(gleam@float:parse(<<"5.0">>), {ok, 5.0}),
-    gleam@should:equal(gleam@float:parse(<<"0.123456789">>), {ok, 0.123456789}),
-    gleam@should:equal(gleam@float:parse(<<"">>), {error, nil}),
-    gleam@should:equal(gleam@float:parse(<<"what">>), {error, nil}),
-    gleam@should:equal(gleam@float:parse(<<"1">>), {error, nil}).
+    gleam@should:equal(gleam@float:parse(<<"1.23"/utf8>>), {ok, 1.23}),
+    gleam@should:equal(gleam@float:parse(<<"5.0"/utf8>>), {ok, 5.0}),
+    gleam@should:equal(
+        gleam@float:parse(<<"0.123456789"/utf8>>),
+        {ok, 0.123456789}
+    ),
+    gleam@should:equal(gleam@float:parse(<<""/utf8>>), {error, nil}),
+    gleam@should:equal(gleam@float:parse(<<"what"/utf8>>), {error, nil}),
+    gleam@should:equal(gleam@float:parse(<<"1"/utf8>>), {error, nil}).
 
 to_string_test() ->
-    gleam@should:equal(gleam@float:to_string(123.0), <<"123.0">>),
-    gleam@should:equal(gleam@float:to_string(-8.1), <<"-8.1">>).
+    gleam@should:equal(gleam@float:to_string(123.0), <<"123.0"/utf8>>),
+    gleam@should:equal(gleam@float:to_string(-8.1), <<"-8.1"/utf8>>).
 
 compare_test() ->
     gleam@should:equal(gleam@float:compare(0.0, 0.0), eq),

--- a/gen/test/gleam@function_test.erl
+++ b/gen/test/gleam@function_test.erl
@@ -15,31 +15,34 @@ compose_test() ->
         ),
         fun gleam@int:to_string/1
     ),
-    gleam@should:equal(HeadToString([1]), <<"1">>),
-    gleam@should:equal(HeadToString([]), <<"0">>).
+    gleam@should:equal(HeadToString([1]), <<"1"/utf8>>),
+    gleam@should:equal(HeadToString([]), <<"0"/utf8>>).
 
 flip_test() ->
     Fun = fun(S, I) ->
         gleam@string:append(
             gleam@string:append(
                 gleam@string:append(
-                    gleam@string:append(<<"String: '">>, S),
-                    <<"', Int: '">>
+                    gleam@string:append(<<"String: '"/utf8>>, S),
+                    <<"', Int: '"/utf8>>
                 ),
                 gleam@int:to_string(I)
             ),
-            <<"'">>
+            <<"'"/utf8>>
         )
     end,
     FlippedFun = gleam@function:flip(Fun),
-    gleam@should:equal(Fun(<<"Bob">>, 1), <<"String: 'Bob', Int: '1'">>),
     gleam@should:equal(
-        FlippedFun(2, <<"Alice">>),
-        <<"String: 'Alice', Int: '2'">>
+        Fun(<<"Bob"/utf8>>, 1),
+        <<"String: 'Bob', Int: '1'"/utf8>>
+    ),
+    gleam@should:equal(
+        FlippedFun(2, <<"Alice"/utf8>>),
+        <<"String: 'Alice', Int: '2'"/utf8>>
     ).
 
 identity_test() ->
     gleam@should:equal(gleam@function:identity(1), 1),
-    gleam@should:equal(gleam@function:identity(<<"">>), <<"">>),
+    gleam@should:equal(gleam@function:identity(<<""/utf8>>), <<""/utf8>>),
     gleam@should:equal(gleam@function:identity([]), []),
     gleam@should:equal(gleam@function:identity({1, 2.0}), {1, 2.0}).

--- a/gen/test/gleam@int_test.erl
+++ b/gen/test/gleam@int_test.erl
@@ -4,21 +4,21 @@
 -export([to_string/0, parse/0, to_base_string/0, compare_test/0, min_test/0, max_test/0, is_even_test/0, is_odd_test/0]).
 
 to_string() ->
-    gleam@should:equal(gleam@int:to_string(123), <<"123">>),
-    gleam@should:equal(gleam@int:to_string(-123), <<"-123">>),
-    gleam@should:equal(gleam@int:to_string(123), <<"123">>).
+    gleam@should:equal(gleam@int:to_string(123), <<"123"/utf8>>),
+    gleam@should:equal(gleam@int:to_string(-123), <<"-123"/utf8>>),
+    gleam@should:equal(gleam@int:to_string(123), <<"123"/utf8>>).
 
 parse() ->
-    gleam@should:equal(gleam@int:parse(<<"123">>), {ok, 123}),
-    gleam@should:equal(gleam@int:parse(<<"-123">>), {ok, -123}),
-    gleam@should:equal(gleam@int:parse(<<"0123">>), {ok, 123}),
-    gleam@should:equal(gleam@int:parse(<<"">>), {error, nil}),
-    gleam@should:equal(gleam@int:parse(<<"what">>), {error, nil}),
-    gleam@should:equal(gleam@int:parse(<<"1.23">>), {error, nil}).
+    gleam@should:equal(gleam@int:parse(<<"123"/utf8>>), {ok, 123}),
+    gleam@should:equal(gleam@int:parse(<<"-123"/utf8>>), {ok, -123}),
+    gleam@should:equal(gleam@int:parse(<<"0123"/utf8>>), {ok, 123}),
+    gleam@should:equal(gleam@int:parse(<<""/utf8>>), {error, nil}),
+    gleam@should:equal(gleam@int:parse(<<"what"/utf8>>), {error, nil}),
+    gleam@should:equal(gleam@int:parse(<<"1.23"/utf8>>), {error, nil}).
 
 to_base_string() ->
-    gleam@should:equal(gleam@int:to_base_string(100, 16), <<"64">>),
-    gleam@should:equal(gleam@int:to_base_string(-100, 16), <<"-64">>).
+    gleam@should:equal(gleam@int:to_base_string(100, 16), <<"64"/utf8>>),
+    gleam@should:equal(gleam@int:to_base_string(-100, 16), <<"-64"/utf8>>).
 
 compare_test() ->
     gleam@should:equal(gleam@int:compare(0, 0), eq),

--- a/gen/test/gleam@iodata_test.erl
+++ b/gen/test/gleam@iodata_test.erl
@@ -6,88 +6,98 @@
 iodata_test() ->
     Data = gleam@iodata:prepend(
         gleam@iodata:append(
-            gleam@iodata:append(gleam@iodata:new(<<"ello">>), <<",">>),
-            <<" world!">>
+            gleam@iodata:append(gleam@iodata:new(<<"ello"/utf8>>), <<","/utf8>>),
+            <<" world!"/utf8>>
         ),
-        <<"H">>
+        <<"H"/utf8>>
     ),
-    gleam@should:equal(gleam@iodata:to_string(Data), <<"Hello, world!">>),
+    gleam@should:equal(gleam@iodata:to_string(Data), <<"Hello, world!"/utf8>>),
     gleam@should:equal(gleam@iodata:byte_size(Data), 13),
     Data1 = gleam@iodata:prepend_iodata(
         gleam@iodata:append_iodata(
             gleam@iodata:append_iodata(
-                gleam@iodata:new(<<"ello">>),
-                gleam@iodata:new(<<",">>)
+                gleam@iodata:new(<<"ello"/utf8>>),
+                gleam@iodata:new(<<","/utf8>>)
             ),
             gleam@iodata:concat(
-                [gleam@iodata:new(<<" wo">>), gleam@iodata:new(<<"rld!">>)]
+                [gleam@iodata:new(<<" wo"/utf8>>),
+                 gleam@iodata:new(<<"rld!"/utf8>>)]
             )
         ),
-        gleam@iodata:new(<<"H">>)
+        gleam@iodata:new(<<"H"/utf8>>)
     ),
-    gleam@should:equal(gleam@iodata:to_string(Data1), <<"Hello, world!">>),
+    gleam@should:equal(gleam@iodata:to_string(Data1), <<"Hello, world!"/utf8>>),
     gleam@should:equal(gleam@iodata:byte_size(Data1), 13).
 
 lowercase_test() ->
     gleam@should:equal(
         gleam@iodata:to_string(
             gleam@iodata:lowercase(
-                gleam@iodata:from_strings([<<"Gleam">>, <<"Gleam">>])
+                gleam@iodata:from_strings([<<"Gleam"/utf8>>, <<"Gleam"/utf8>>])
             )
         ),
-        <<"gleamgleam">>
+        <<"gleamgleam"/utf8>>
     ).
 
 uppercase_test() ->
     gleam@should:equal(
         gleam@iodata:to_string(
             gleam@iodata:uppercase(
-                gleam@iodata:from_strings([<<"Gleam">>, <<"Gleam">>])
+                gleam@iodata:from_strings([<<"Gleam"/utf8>>, <<"Gleam"/utf8>>])
             )
         ),
-        <<"GLEAMGLEAM">>
+        <<"GLEAMGLEAM"/utf8>>
     ).
 
 split_test() ->
     gleam@should:equal(
-        gleam@iodata:split(gleam@iodata:new(<<"Gleam,Erlang,Elixir">>), <<",">>),
-        [gleam@iodata:new(<<"Gleam">>),
-         gleam@iodata:new(<<"Erlang">>),
-         gleam@iodata:new(<<"Elixir">>)]
+        gleam@iodata:split(
+            gleam@iodata:new(<<"Gleam,Erlang,Elixir"/utf8>>),
+            <<","/utf8>>
+        ),
+        [gleam@iodata:new(<<"Gleam"/utf8>>),
+         gleam@iodata:new(<<"Erlang"/utf8>>),
+         gleam@iodata:new(<<"Elixir"/utf8>>)]
     ),
     gleam@should:equal(
         gleam@iodata:split(
-            gleam@iodata:from_strings([<<"Gleam, Erl">>, <<"ang,Elixir">>]),
-            <<", ">>
+            gleam@iodata:from_strings(
+                [<<"Gleam, Erl"/utf8>>, <<"ang,Elixir"/utf8>>]
+            ),
+            <<", "/utf8>>
         ),
-        [gleam@iodata:new(<<"Gleam">>),
-         gleam@iodata:from_strings([<<"Erl">>, <<"ang,Elixir">>])]
+        [gleam@iodata:new(<<"Gleam"/utf8>>),
+         gleam@iodata:from_strings([<<"Erl"/utf8>>, <<"ang,Elixir"/utf8>>])]
     ).
 
 is_equal_test() ->
     gleam@should:be_true(
         gleam@iodata:is_equal(
-            gleam@iodata:new(<<"12">>),
-            gleam@iodata:from_strings([<<"1">>, <<"2">>])
+            gleam@iodata:new(<<"12"/utf8>>),
+            gleam@iodata:from_strings([<<"1"/utf8>>, <<"2"/utf8>>])
         )
     ),
     gleam@should:be_true(
         gleam@iodata:is_equal(
-            gleam@iodata:new(<<"12">>),
-            gleam@iodata:new(<<"12">>)
+            gleam@iodata:new(<<"12"/utf8>>),
+            gleam@iodata:new(<<"12"/utf8>>)
         )
     ),
     gleam@should:be_false(
         gleam@iodata:is_equal(
-            gleam@iodata:new(<<"12">>),
-            gleam@iodata:new(<<"2">>)
+            gleam@iodata:new(<<"12"/utf8>>),
+            gleam@iodata:new(<<"2"/utf8>>)
         )
     ).
 
 is_empty_test() ->
-    gleam@should:be_true(gleam@iodata:is_empty(gleam@iodata:new(<<"">>))),
-    gleam@should:be_false(gleam@iodata:is_empty(gleam@iodata:new(<<"12">>))),
+    gleam@should:be_true(gleam@iodata:is_empty(gleam@iodata:new(<<""/utf8>>))),
+    gleam@should:be_false(
+        gleam@iodata:is_empty(gleam@iodata:new(<<"12"/utf8>>))
+    ),
     gleam@should:be_true(gleam@iodata:is_empty(gleam@iodata:from_strings([]))),
     gleam@should:be_true(
-        gleam@iodata:is_empty(gleam@iodata:from_strings([<<"">>, <<"">>]))
+        gleam@iodata:is_empty(
+            gleam@iodata:from_strings([<<""/utf8>>, <<""/utf8>>])
+        )
     ).

--- a/gen/test/gleam@list_test.erl
+++ b/gen/test/gleam@list_test.erl
@@ -218,8 +218,8 @@ index_map_test() ->
     ),
     F = fun(I1, X1) -> gleam@string:append(X1, gleam@int:to_string(I1)) end,
     gleam@should:equal(
-        gleam@list:index_map([<<"a">>, <<"b">>, <<"c">>], F),
-        [<<"a0">>, <<"b1">>, <<"c2">>]
+        gleam@list:index_map([<<"a"/utf8>>, <<"b"/utf8>>, <<"c"/utf8>>], F),
+        [<<"a0"/utf8>>, <<"b1"/utf8>>, <<"c2"/utf8>>]
     ).
 
 range_test() ->
@@ -235,8 +235,8 @@ repeat_test() ->
     gleam@should:equal(gleam@list:repeat(1, 0), []),
     gleam@should:equal(gleam@list:repeat(2, 3), [2, 2, 2]),
     gleam@should:equal(
-        gleam@list:repeat(<<"x">>, 5),
-        [<<"x">>, <<"x">>, <<"x">>, <<"x">>, <<"x">>]
+        gleam@list:repeat(<<"x"/utf8>>, 5),
+        [<<"x"/utf8>>, <<"x"/utf8>>, <<"x"/utf8>>, <<"x"/utf8>>, <<"x"/utf8>>]
     ).
 
 split_test() ->
@@ -285,7 +285,7 @@ split_while_test() ->
     ).
 
 key_find_test() ->
-    Proplist = [{0, <<"1">>}, {1, <<"2">>}],
-    gleam@should:equal(gleam@list:key_find(Proplist, 0), {ok, <<"1">>}),
-    gleam@should:equal(gleam@list:key_find(Proplist, 1), {ok, <<"2">>}),
+    Proplist = [{0, <<"1"/utf8>>}, {1, <<"2"/utf8>>}],
+    gleam@should:equal(gleam@list:key_find(Proplist, 0), {ok, <<"1"/utf8>>}),
+    gleam@should:equal(gleam@list:key_find(Proplist, 1), {ok, <<"2"/utf8>>}),
     gleam@should:equal(gleam@list:key_find(Proplist, 2), {error, nil}).

--- a/gen/test/gleam@map_test.erl
+++ b/gen/test/gleam@map_test.erl
@@ -34,14 +34,16 @@ insert_test() ->
     gleam@should:equal(
         gleam@map:insert(
             gleam@map:insert(
-                gleam@map:insert(gleam@map:new(), <<"a">>, 0),
-                <<"b">>,
+                gleam@map:insert(gleam@map:new(), <<"a"/utf8>>, 0),
+                <<"b"/utf8>>,
                 1
             ),
-            <<"c">>,
+            <<"c"/utf8>>,
             2
         ),
-        gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}])
+        gleam@map:from_list(
+            [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+        )
     ).
 
 map_values_test() ->
@@ -56,15 +58,19 @@ map_values_test() ->
 keys_test() ->
     gleam@should:equal(
         gleam@map:keys(
-            gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}])
+            gleam@map:from_list(
+                [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+            )
         ),
-        [<<"a">>, <<"b">>, <<"c">>]
+        [<<"a"/utf8>>, <<"b"/utf8>>, <<"c"/utf8>>]
     ).
 
 values_test() ->
     gleam@should:equal(
         gleam@map:values(
-            gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}])
+            gleam@map:from_list(
+                [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+            )
         ),
         [0, 1, 2]
     ).
@@ -72,34 +78,48 @@ values_test() ->
 take_test() ->
     gleam@should:equal(
         gleam@map:take(
-            gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}]),
-            [<<"a">>, <<"b">>, <<"d">>]
+            gleam@map:from_list(
+                [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+            ),
+            [<<"a"/utf8>>, <<"b"/utf8>>, <<"d"/utf8>>]
         ),
-        gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}])
+        gleam@map:from_list([{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}])
     ).
 
 drop_test() ->
     gleam@should:equal(
         gleam@map:drop(
-            gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}]),
-            [<<"a">>, <<"b">>, <<"d">>]
+            gleam@map:from_list(
+                [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+            ),
+            [<<"a"/utf8>>, <<"b"/utf8>>, <<"d"/utf8>>]
         ),
-        gleam@map:from_list([{<<"c">>, 2}])
+        gleam@map:from_list([{<<"c"/utf8>>, 2}])
     ).
 
 merge_test() ->
-    A = gleam@map:from_list([{<<"a">>, 2}, {<<"c">>, 4}, {<<"d">>, 3}]),
-    B = gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}]),
+    A = gleam@map:from_list(
+        [{<<"a"/utf8>>, 2}, {<<"c"/utf8>>, 4}, {<<"d"/utf8>>, 3}]
+    ),
+    B = gleam@map:from_list(
+        [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+    ),
     gleam@should:equal(
         gleam@map:merge(A, B),
         gleam@map:from_list(
-            [{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}, {<<"d">>, 3}]
+            [{<<"a"/utf8>>, 0},
+             {<<"b"/utf8>>, 1},
+             {<<"c"/utf8>>, 2},
+             {<<"d"/utf8>>, 3}]
         )
     ),
     gleam@should:equal(
         gleam@map:merge(B, A),
         gleam@map:from_list(
-            [{<<"a">>, 2}, {<<"b">>, 1}, {<<"c">>, 4}, {<<"d">>, 3}]
+            [{<<"a"/utf8>>, 2},
+             {<<"b"/utf8>>, 1},
+             {<<"c"/utf8>>, 4},
+             {<<"d"/utf8>>, 3}]
         )
     ).
 
@@ -107,16 +127,20 @@ delete_test() ->
     gleam@should:equal(
         gleam@map:delete(
             gleam@map:delete(
-                gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}]),
-                <<"a">>
+                gleam@map:from_list(
+                    [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+                ),
+                <<"a"/utf8>>
             ),
-            <<"d">>
+            <<"d"/utf8>>
         ),
-        gleam@map:from_list([{<<"b">>, 1}, {<<"c">>, 2}])
+        gleam@map:from_list([{<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}])
     ).
 
 update_test() ->
-    Dict = gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}]),
+    Dict = gleam@map:from_list(
+        [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+    ),
     IncOrZero = fun(X) -> case X of
             {ok, I} ->
                 I + 1;
@@ -125,26 +149,39 @@ update_test() ->
                 0
         end end,
     gleam@should:equal(
-        gleam@map:update(Dict, <<"a">>, IncOrZero),
-        gleam@map:from_list([{<<"a">>, 1}, {<<"b">>, 1}, {<<"c">>, 2}])
-    ),
-    gleam@should:equal(
-        gleam@map:update(Dict, <<"b">>, IncOrZero),
-        gleam@map:from_list([{<<"a">>, 0}, {<<"b">>, 2}, {<<"c">>, 2}])
-    ),
-    gleam@should:equal(
-        gleam@map:update(Dict, <<"z">>, IncOrZero),
+        gleam@map:update(Dict, <<"a"/utf8>>, IncOrZero),
         gleam@map:from_list(
-            [{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}, {<<"z">>, 0}]
+            [{<<"a"/utf8>>, 1}, {<<"b"/utf8>>, 1}, {<<"c"/utf8>>, 2}]
+        )
+    ),
+    gleam@should:equal(
+        gleam@map:update(Dict, <<"b"/utf8>>, IncOrZero),
+        gleam@map:from_list(
+            [{<<"a"/utf8>>, 0}, {<<"b"/utf8>>, 2}, {<<"c"/utf8>>, 2}]
+        )
+    ),
+    gleam@should:equal(
+        gleam@map:update(Dict, <<"z"/utf8>>, IncOrZero),
+        gleam@map:from_list(
+            [{<<"a"/utf8>>, 0},
+             {<<"b"/utf8>>, 1},
+             {<<"c"/utf8>>, 2},
+             {<<"z"/utf8>>, 0}]
         )
     ).
 
 fold_test() ->
     Dict = gleam@map:from_list(
-        [{<<"a">>, 0}, {<<"b">>, 1}, {<<"c">>, 2}, {<<"d">>, 3}]
+        [{<<"a"/utf8>>, 0},
+         {<<"b"/utf8>>, 1},
+         {<<"c"/utf8>>, 2},
+         {<<"d"/utf8>>, 3}]
     ),
     Add = fun(_, V, Acc) -> V + Acc end,
     gleam@should:equal(gleam@map:fold(Dict, 0, Add), 6),
     Concat = fun(K, _, Acc1) -> gleam@string:append(Acc1, K) end,
-    gleam@should:equal(gleam@map:fold(Dict, <<"">>, Concat), <<"abcd">>),
+    gleam@should:equal(
+        gleam@map:fold(Dict, <<""/utf8>>, Concat),
+        <<"abcd"/utf8>>
+    ),
     gleam@should:equal(gleam@map:fold(gleam@map:from_list([]), 0, Add), 0).

--- a/gen/test/gleam@pair_test.erl
+++ b/gen/test/gleam@pair_test.erl
@@ -5,14 +5,14 @@
 
 first_test() ->
     gleam@should:equal(gleam@pair:first({1, 2}), 1),
-    gleam@should:equal(gleam@pair:first({<<"abc">>, []}), <<"abc">>).
+    gleam@should:equal(gleam@pair:first({<<"abc"/utf8>>, []}), <<"abc"/utf8>>).
 
 second_test() ->
     gleam@should:equal(gleam@pair:second({1, 2}), 2),
-    gleam@should:equal(gleam@pair:second({<<"abc">>, []}), []).
+    gleam@should:equal(gleam@pair:second({<<"abc"/utf8>>, []}), []).
 
 swap_test() ->
-    gleam@should:equal(gleam@pair:swap({1, <<"2">>}), {<<"2">>, 1}).
+    gleam@should:equal(gleam@pair:swap({1, <<"2"/utf8>>}), {<<"2"/utf8>>, 1}).
 
 map_first_test() ->
     Inc = fun(A) -> A + 1 end,

--- a/gen/test/gleam@result_test.erl
+++ b/gen/test/gleam@result_test.erl
@@ -14,8 +14,8 @@ is_error_test() ->
 map_test() ->
     gleam@should:equal(gleam@result:map({ok, 1}, fun(X) -> X + 1 end), {ok, 2}),
     gleam@should:equal(
-        gleam@result:map({ok, 1}, fun(_) -> <<"2">> end),
-        {ok, <<"2">>}
+        gleam@result:map({ok, 1}, fun(_) -> <<"2"/utf8>> end),
+        {ok, <<"2"/utf8>>}
     ),
     gleam@should:equal(
         gleam@result:map({error, 1}, fun(X1) -> X1 + 1 end),
@@ -28,8 +28,11 @@ map_error_test() ->
         {ok, 1}
     ),
     gleam@should:equal(
-        gleam@result:map_error({error, 1}, fun(X1) -> {<<"ok">>, X1 + 1} end),
-        {error, {<<"ok">>, 2}}
+        gleam@result:map_error(
+            {error, 1},
+            fun(X1) -> {<<"ok"/utf8>>, X1 + 1} end
+        ),
+        {error, {<<"ok"/utf8>>, 2}}
     ).
 
 flatten_test() ->
@@ -51,8 +54,8 @@ then_test() ->
         {ok, 2}
     ),
     gleam@should:equal(
-        gleam@result:then({ok, 1}, fun(_) -> {ok, <<"type change">>} end),
-        {ok, <<"type change">>}
+        gleam@result:then({ok, 1}, fun(_) -> {ok, <<"type change"/utf8>>} end),
+        {ok, <<"type change"/utf8>>}
     ),
     gleam@should:equal(
         gleam@result:then({ok, 1}, fun(_) -> {error, 1} end),
@@ -61,4 +64,4 @@ then_test() ->
 
 unwrap_test() ->
     gleam@should:equal(gleam@result:unwrap({ok, 1}, 50), 1),
-    gleam@should:equal(gleam@result:unwrap({error, <<"nope">>}, 50), 50).
+    gleam@should:equal(gleam@result:unwrap({error, <<"nope"/utf8>>}, 50), 50).

--- a/gen/test/gleam@string_test.erl
+++ b/gen/test/gleam@string_test.erl
@@ -1,76 +1,273 @@
 -module(gleam@string_test).
 -compile(no_auto_import).
 
--export([length_test/0, lowercase_test/0, uppercase_test/0, reverse_test/0, split_test/0, replace_test/0, append_test/0, compare_test/0, contains_test/0, concat_test/0, repeat_test/0, join_test/0]).
+-export([length_test/0, lowercase_test/0, uppercase_test/0, reverse_test/0, split_test/0, replace_test/0, append_test/0, compare_test/0, contains_test/0, concat_test/0, repeat_test/0, join_test/0, slice_test/0, drop_left_test/0, drop_right_test/0, starts_with_test/0, ends_with_test/0, pad_left_test/0, pad_right_test/0, trim_test/0, trim_left_test/0, trim_right_test/0, to_graphemes_test/0, next_grapheme_test/0]).
 
 length_test() ->
-    gleam@should:equal(gleam@string:length(<<"ß↑e̊">>), 3),
-    gleam@should:equal(gleam@string:length(<<"Gleam">>), 5),
-    gleam@should:equal(gleam@string:length(<<"">>), 0).
+    gleam@should:equal(gleam@string:length(<<"ß↑e̊"/utf8>>), 3),
+    gleam@should:equal(gleam@string:length(<<"Gleam"/utf8>>), 5),
+    gleam@should:equal(gleam@string:length(<<""/utf8>>), 0).
 
 lowercase_test() ->
-    gleam@should:equal(gleam@string:lowercase(<<"Gleam">>), <<"gleam">>).
+    gleam@should:equal(
+        gleam@string:lowercase(<<"Gleam"/utf8>>),
+        <<"gleam"/utf8>>
+    ).
 
 uppercase_test() ->
-    gleam@should:equal(gleam@string:uppercase(<<"Gleam">>), <<"GLEAM">>).
+    gleam@should:equal(
+        gleam@string:uppercase(<<"Gleam"/utf8>>),
+        <<"GLEAM"/utf8>>
+    ).
 
 reverse_test() ->
-    gleam@should:equal(gleam@string:reverse(<<"Gleam">>), <<"maelG">>).
+    gleam@should:equal(
+        gleam@string:reverse(<<"Gleam"/utf8>>),
+        <<"maelG"/utf8>>
+    ).
 
 split_test() ->
     gleam@should:equal(
-        gleam@string:split(<<"Gleam,Erlang,Elixir">>, <<",">>),
-        [<<"Gleam">>, <<"Erlang">>, <<"Elixir">>]
+        gleam@string:split(<<"Gleam,Erlang,Elixir"/utf8>>, <<","/utf8>>),
+        [<<"Gleam"/utf8>>, <<"Erlang"/utf8>>, <<"Elixir"/utf8>>]
     ),
     gleam@should:equal(
-        gleam@string:split(<<"Gleam, Erlang,Elixir">>, <<", ">>),
-        [<<"Gleam">>, <<"Erlang,Elixir">>]
+        gleam@string:split(<<"Gleam, Erlang,Elixir"/utf8>>, <<", "/utf8>>),
+        [<<"Gleam"/utf8>>, <<"Erlang,Elixir"/utf8>>]
     ).
 
 replace_test() ->
     gleam@should:equal(
-        gleam@string:replace(<<"Gleam,Erlang,Elixir">>, <<",">>, <<"++">>),
-        <<"Gleam++Erlang++Elixir">>
+        gleam@string:replace(
+            <<"Gleam,Erlang,Elixir"/utf8>>,
+            <<","/utf8>>,
+            <<"++"/utf8>>
+        ),
+        <<"Gleam++Erlang++Elixir"/utf8>>
     ).
 
 append_test() ->
     gleam@should:equal(
-        gleam@string:append(<<"Test">>, <<" Me">>),
-        <<"Test Me">>
+        gleam@string:append(<<"Test"/utf8>>, <<" Me"/utf8>>),
+        <<"Test Me"/utf8>>
     ).
 
 compare_test() ->
-    gleam@should:equal(gleam@string:compare(<<"">>, <<"">>), eq),
-    gleam@should:equal(gleam@string:compare(<<"a">>, <<"">>), gt),
-    gleam@should:equal(gleam@string:compare(<<"a">>, <<"A">>), gt),
-    gleam@should:equal(gleam@string:compare(<<"A">>, <<"B">>), lt),
-    gleam@should:equal(gleam@string:compare(<<"t">>, <<"ABC">>), gt).
+    gleam@should:equal(gleam@string:compare(<<""/utf8>>, <<""/utf8>>), eq),
+    gleam@should:equal(gleam@string:compare(<<"a"/utf8>>, <<""/utf8>>), gt),
+    gleam@should:equal(gleam@string:compare(<<"a"/utf8>>, <<"A"/utf8>>), gt),
+    gleam@should:equal(gleam@string:compare(<<"A"/utf8>>, <<"B"/utf8>>), lt),
+    gleam@should:equal(gleam@string:compare(<<"t"/utf8>>, <<"ABC"/utf8>>), gt).
 
 contains_test() ->
-    gleam@should:equal(gleam@string:contains(<<"gleam">>, <<"ea">>), true),
-    gleam@should:equal(gleam@string:contains(<<"gleam">>, <<"x">>), false),
     gleam@should:equal(
-        gleam@string:contains(<<"bellwether">>, <<"bell">>),
+        gleam@string:contains(<<"gleam"/utf8>>, <<"ea"/utf8>>),
+        true
+    ),
+    gleam@should:equal(
+        gleam@string:contains(<<"gleam"/utf8>>, <<"x"/utf8>>),
+        false
+    ),
+    gleam@should:equal(
+        gleam@string:contains(<<"bellwether"/utf8>>, <<"bell"/utf8>>),
         true
     ).
 
 concat_test() ->
     gleam@should:equal(
-        gleam@string:concat([<<"Hello">>, <<", ">>, <<"world!">>]),
-        <<"Hello, world!">>
+        gleam@string:concat(
+            [<<"Hello"/utf8>>, <<", "/utf8>>, <<"world!"/utf8>>]
+        ),
+        <<"Hello, world!"/utf8>>
     ).
 
 repeat_test() ->
-    gleam@should:equal(gleam@string:repeat(<<"hi">>, 3), <<"hihihi">>),
-    gleam@should:equal(gleam@string:repeat(<<"hi">>, 0), <<"">>),
-    gleam@should:equal(gleam@string:repeat(<<"hi">>, -1), <<"">>).
+    gleam@should:equal(
+        gleam@string:repeat(<<"hi"/utf8>>, 3),
+        <<"hihihi"/utf8>>
+    ),
+    gleam@should:equal(gleam@string:repeat(<<"hi"/utf8>>, 0), <<""/utf8>>),
+    gleam@should:equal(gleam@string:repeat(<<"hi"/utf8>>, -1), <<""/utf8>>).
 
 join_test() ->
     gleam@should:equal(
-        gleam@string:join([<<"Hello">>, <<"world!">>], <<", ">>),
-        <<"Hello, world!">>
+        gleam@string:join([<<"Hello"/utf8>>, <<"world!"/utf8>>], <<", "/utf8>>),
+        <<"Hello, world!"/utf8>>
     ),
     gleam@should:equal(
-        gleam@string:join([<<"Hello">>, <<"world!">>], <<"-">>),
-        <<"Hello-world!">>
+        gleam@string:join([<<"Hello"/utf8>>, <<"world!"/utf8>>], <<"-"/utf8>>),
+        <<"Hello-world!"/utf8>>
     ).
+
+slice_test() ->
+    Unicode = <<"Hello 👨‍👩‍👧‍👧, I 愛 you."/utf8>>,
+    gleam@should:equal(gleam@string:slice(Unicode, 0, 5), <<"Hello"/utf8>>),
+    gleam@should:equal(
+        gleam@string:slice(Unicode, 6, 4),
+        <<"👨‍👩‍👧‍👧, I"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:slice(Unicode, 9, 1000),
+        <<"I 愛 you."/utf8>>
+    ),
+    gleam@should:equal(gleam@string:slice(Unicode, 1000, 1000), <<""/utf8>>),
+    gleam@should:equal(gleam@string:slice(Unicode, 5, -1), <<""/utf8>>),
+    gleam@should:equal(gleam@string:slice(Unicode, -5, 1), <<""/utf8>>).
+
+drop_left_test() ->
+    Unicode = <<"Hello 👨‍👩‍👧‍👧!"/utf8>>,
+    gleam@should:equal(
+        gleam@string:drop_left(Unicode, 6),
+        <<"👨‍👩‍👧‍👧!"/utf8>>
+    ),
+    gleam@should:equal(gleam@string:drop_left(Unicode, 7), <<"!"/utf8>>),
+    gleam@should:equal(gleam@string:drop_left(Unicode, 1000), <<""/utf8>>),
+    gleam@should:equal(gleam@string:drop_left(Unicode, -1), Unicode).
+
+drop_right_test() ->
+    Unicode = <<"Hello 👨‍👩‍👧‍👧!"/utf8>>,
+    gleam@should:equal(gleam@string:drop_right(Unicode, 6), <<"He"/utf8>>),
+    gleam@should:equal(gleam@string:drop_right(Unicode, 7), <<"H"/utf8>>),
+    gleam@should:equal(gleam@string:drop_right(Unicode, 1000), <<""/utf8>>),
+    gleam@should:equal(gleam@string:drop_right(Unicode, -1), Unicode).
+
+starts_with_test() ->
+    Unicode = <<"Hello 👨‍👩‍👧‍👧, I 愛 you."/utf8>>,
+    gleam@should:equal(
+        gleam@string:starts_with(Unicode, <<"Hello "/utf8>>),
+        true
+    ),
+    gleam@should:equal(
+        gleam@string:starts_with(
+            Unicode,
+            <<"Hello 👨‍👩‍👧‍👧,"/utf8>>
+        ),
+        true
+    ),
+    gleam@should:equal(
+        gleam@string:starts_with(<<"Hello"/utf8>>, Unicode),
+        false
+    ),
+    gleam@should:equal(
+        gleam@string:starts_with(<<""/utf8>>, <<""/utf8>>),
+        true
+    ).
+
+ends_with_test() ->
+    Unicode = <<"Hello 👨‍👩‍👧‍👧, I 愛 you."/utf8>>,
+    gleam@should:equal(gleam@string:ends_with(Unicode, <<"you."/utf8>>), true),
+    gleam@should:equal(
+        gleam@string:ends_with(Unicode, <<"I 愛 you."/utf8>>),
+        true
+    ),
+    gleam@should:equal(gleam@string:ends_with(<<"you."/utf8>>, Unicode), false),
+    gleam@should:equal(gleam@string:ends_with(<<""/utf8>>, <<""/utf8>>), true).
+
+pad_left_test() ->
+    gleam@should:equal(
+        gleam@string:pad_left(<<"愛"/utf8>>, 10, <<"*"/utf8>>),
+        <<"*********愛"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_left(<<"愛"/utf8>>, 10, <<"abcd"/utf8>>),
+        <<"abcdabcda愛"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_left(
+            <<"愛"/utf8>>,
+            5,
+            <<"👨‍👩‍👧‍👧🌵"/utf8>>
+        ),
+        <<"👨‍👩‍👧‍👧🌵👨‍👩‍👧‍👧🌵愛"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_left(<<"1234"/utf8>>, -1, <<"x"/utf8>>),
+        <<"1234"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_left(<<"1234"/utf8>>, 1, <<"x"/utf8>>),
+        <<"1234"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_left(<<""/utf8>>, 5, <<"-"/utf8>>),
+        <<"-----"/utf8>>
+    ).
+
+pad_right_test() ->
+    gleam@should:equal(
+        gleam@string:pad_right(<<"愛"/utf8>>, 10, <<"*"/utf8>>),
+        <<"愛*********"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_right(<<"愛"/utf8>>, 10, <<"abcd"/utf8>>),
+        <<"愛abcdabcda"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_right(
+            <<"愛"/utf8>>,
+            5,
+            <<"👨‍👩‍👧‍👧🌵"/utf8>>
+        ),
+        <<"愛👨‍👩‍👧‍👧🌵👨‍👩‍👧‍👧🌵"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_right(<<"1234"/utf8>>, -1, <<"x"/utf8>>),
+        <<"1234"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_right(<<"1234"/utf8>>, 1, <<"x"/utf8>>),
+        <<"1234"/utf8>>
+    ),
+    gleam@should:equal(
+        gleam@string:pad_right(<<""/utf8>>, 5, <<"-"/utf8>>),
+        <<"-----"/utf8>>
+    ).
+
+trim_test() ->
+    gleam@should:equal(
+        gleam@string:trim(<<"\f\v\t\s\n\r  愛  \f\v\t\s\n\r"/utf8>>),
+        <<"愛"/utf8>>
+    ).
+
+trim_left_test() ->
+    gleam@should:equal(
+        gleam@string:trim_left(<<"\f\v\t\s\n\r  愛  \f\v\t\s\n\r"/utf8>>),
+        <<"愛  \f\v\t\s\n\r"/utf8>>
+    ).
+
+trim_right_test() ->
+    gleam@should:equal(
+        gleam@string:trim_right(<<"\f\v\t\s\n\r  愛  \f\v\t\s\n\r"/utf8>>),
+        <<"\f\v\t\s\n\r  愛"/utf8>>
+    ).
+
+to_graphemes_test() ->
+    gleam@should:equal(
+        gleam@string:to_graphemes(<<"abcd"/utf8>>),
+        [<<"a"/utf8>>, <<"b"/utf8>>, <<"c"/utf8>>, <<"d"/utf8>>]
+    ),
+    gleam@should:equal(
+        gleam@string:to_graphemes(
+            <<"--👨‍👩‍👧‍👧--🌵--"/utf8>>
+        ),
+        [<<"-"/utf8>>,
+         <<"-"/utf8>>,
+         <<"👨‍👩‍👧‍👧"/utf8>>,
+         <<"-"/utf8>>,
+         <<"-"/utf8>>,
+         <<"🌵"/utf8>>,
+         <<"-"/utf8>>,
+         <<"-"/utf8>>]
+    ),
+    gleam@should:equal(gleam@string:to_graphemes(<<""/utf8>>), []).
+
+next_grapheme_test() ->
+    gleam@should:equal(
+        gleam@string:next_grapheme(<<"abc"/utf8>>),
+        {ok, {<<"a"/utf8>>, <<"bc"/utf8>>}}
+    ),
+    gleam@should:equal(
+        gleam@string:next_grapheme(<<"👨‍👩‍👧‍👧-🌵"/utf8>>),
+        {ok, {<<"👨‍👩‍👧‍👧"/utf8>>, <<"-🌵"/utf8>>}}
+    ),
+    gleam@should:equal(gleam@string:next_grapheme(<<""/utf8>>), {error, nil}).

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -1,6 +1,7 @@
 import gleam/string
 import gleam/should
 import gleam/order
+import gleam/result.{Option}
 
 pub fn length_test() {
   string.length("ß↑e̊")
@@ -68,21 +69,21 @@ pub fn compare_test() {
 }
 
 pub fn contains_test() {
-    "gleam"
-    |> string.contains(_, "ea")
-    |> should.equal(_, True)
+  "gleam"
+  |> string.contains(_, "ea")
+  |> should.equal(_, True)
 
-    "gleam"
-    |> string.contains(_, "x")
-    |> should.equal(_, False)
+  "gleam"
+  |> string.contains(_, "x")
+  |> should.equal(_, False)
 
-    string.contains(does: "bellwether", contain: "bell")
-    |> should.equal(_, True)
+  string.contains(does: "bellwether", contain: "bell")
+  |> should.equal(_, True)
 }
 
 pub fn concat_test() {
   [
-    "Hello", ", ", "world!",
+  "Hello", ", ", "world!",
   ]
   |> string.concat
   |> should.equal(_, "Hello, world!")
@@ -104,14 +105,220 @@ pub fn repeat_test() {
 
 pub fn join_test() {
   [
-    "Hello", "world!",
+  "Hello", "world!",
   ]
   |> string.join(_, with: ", ")
   |> should.equal(_, "Hello, world!")
 
   [
-    "Hello", "world!",
+  "Hello", "world!",
   ]
   |> string.join(_, with: "-")
   |> should.equal(_, "Hello-world!")
+}
+
+
+pub fn slice_test() {
+  let unicode = "Hello 👨‍👩‍👧‍👧, I 愛 you."
+    // Named params
+  string.slice(unicode, start: 0, length: 5)
+  |> should.equal(_, "Hello")
+    // Slicing across multibyte grapheme clusters
+  unicode
+  |> string.slice(_, 6, 4)
+  |> should.equal(_, "👨‍👩‍👧‍👧, I")
+    // Length extends past end of string
+  unicode
+  |> string.slice(_, 9, 1000)
+  |> should.equal(_, "I 愛 you.")
+    // Selection extends past end of string
+  unicode
+  |> string.slice(_, 1000, 1000)
+  |> should.equal(_, "")
+    // Negative length
+  unicode
+  |> string.slice(_, 5, -1)
+  |> should.equal(_, "")
+    // Negative index
+  unicode
+  |> string.slice(_, -5, 1)
+  |> should.equal(_, "")
+}
+
+pub fn drop_left_test() {
+  let unicode = "Hello 👨‍👩‍👧‍👧!"
+    // Named paramaters
+  string.drop_left(from: unicode, up_to: 6)
+  |> should.equal(_, "👨‍👩‍👧‍👧!")
+    // Drop across multibyte grapheme cluster
+  unicode
+  |> string.drop_left(_, 7)
+  |> should.equal(_, "!")
+    // Drop past end of sting
+  unicode
+  |> string.drop_left(_, 1000)
+  |> should.equal(_, "")
+    // Drop negative number
+  unicode
+  |> string.drop_left(_, -1)
+  |> should.equal(_, unicode)
+}
+
+pub fn drop_right_test() {
+  let unicode = "Hello 👨‍👩‍👧‍👧!"
+    // Named paramaters
+  string.drop_right(from: unicode, drop: 6)
+  |> should.equal(_, "He")
+    // Drop across multibyte grapheme cluster
+  unicode
+  |> string.drop_right(_, 7)
+  |> should.equal(_, "H")
+    // Drop past end of sting
+  unicode
+  |> string.drop_right(_, 1000)
+  |> should.equal(_, "")
+    // Drop negative number
+  unicode
+  |> string.drop_right(_, -1)
+  |> should.equal(_, unicode)
+}
+
+pub fn starts_with_test() {
+  let unicode = "Hello 👨‍👩‍👧‍👧, I 愛 you."
+    // Named paramaters
+  string.starts_with(does: unicode, start_with: "Hello ")
+  |> should.equal(_, True)
+    // Across grapheme clusters
+  unicode
+  |> string.starts_with(_, "Hello 👨‍👩‍👧‍👧,")
+  |> should.equal(_, True)
+    // Inverse not true
+  "Hello"
+  |> string.starts_with(_, unicode)
+  |> should.equal(_, False)
+    // Empty string
+  ""
+  |> string.starts_with(_, "")
+  |> should.equal(_, True)
+}
+
+pub fn ends_with_test() {
+  let unicode = "Hello 👨‍👩‍👧‍👧, I 愛 you."
+    // Named paramaters
+  string.ends_with(does: unicode, end_with: "you.")
+  |> should.equal(_, True)
+    // Across grapheme clusters
+  unicode
+  |> string.ends_with(_, "I 愛 you.")
+  |> should.equal(_, True)
+    // Inverse not true
+  "you."
+  |> string.ends_with(_, unicode)
+  |> should.equal(_, False)
+    // Empty string
+  ""
+  |> string.ends_with(_, "")
+  |> should.equal(_, True)
+}
+
+pub fn pad_left_test() {
+    // Named paramaters
+  string.pad_left(pad: "愛", to_length: 10, with: "*")
+  |> should.equal(_, "*********愛")
+    // Multi char filler
+  "愛"
+  |> string.pad_left(_, 10, "abcd")
+  |> should.equal(_, "abcdabcda愛")
+    // Multi grapheme filler
+  "愛"
+  |> string.pad_left(_, 5, "👨‍👩‍👧‍👧🌵")
+  |> should.equal(_, "👨‍👩‍👧‍👧🌵👨‍👩‍👧‍👧🌵愛")
+    // Negative to_length
+  "1234"
+  |> string.pad_left(_, -1, "x")
+  |> should.equal(_, "1234")
+    // to_length positive but shorter than input length
+  "1234"
+  |> string.pad_left(_, 1, "x")
+  |> should.equal(_, "1234")
+    // empty input
+  ""
+  |> string.pad_left(_, 5, "-")
+  |> should.equal(_, "-----")
+}
+
+pub fn pad_right_test() {
+    // Named paramaters
+  string.pad_right(pad: "愛", to_length: 10, with: "*")
+  |> should.equal(_, "愛*********")
+    // Multi char filler
+  "愛"
+  |> string.pad_right(_, 10, "abcd")
+  |> should.equal(_, "愛abcdabcda")
+    // Multi grapheme filler
+  "愛"
+  |> string.pad_right(_, 5, "👨‍👩‍👧‍👧🌵")
+  |> should.equal(_, "愛👨‍👩‍👧‍👧🌵👨‍👩‍👧‍👧🌵")
+    // Negative to_length
+  "1234"
+  |> string.pad_right(_, -1, "x")
+  |> should.equal(_, "1234")
+    // to_length positive but shorter than input length
+  "1234"
+  |> string.pad_right(_, 1, "x")
+  |> should.equal(_, "1234")
+    // empty input
+  ""
+  |> string.pad_right(_, 5, "-")
+  |> should.equal(_, "-----")
+}
+
+
+pub fn trim_test(){
+    // Only testing the most common as this falls directly through to erlang.
+  "\f\v\t\s\n\r  愛  \f\v\t\s\n\r"
+  |> string.trim
+  |> should.equal(_, "愛")
+}
+
+pub fn trim_left_test(){
+  "\f\v\t\s\n\r  愛  \f\v\t\s\n\r"
+  |> string.trim_left
+  |> should.equal(_, "愛  \f\v\t\s\n\r")
+}
+
+pub fn trim_right_test(){
+  "\f\v\t\s\n\r  愛  \f\v\t\s\n\r"
+  |> string.trim_right
+  |> should.equal(_, "\f\v\t\s\n\r  愛")
+}
+
+pub fn to_graphemes_test(){
+    // basic latin
+  "abcd"
+  |> string.to_graphemes
+  |> should.equal(_, ["a", "b", "c", "d"])
+    // Unicode with glapheme clusters
+  "--👨‍👩‍👧‍👧--🌵--"
+  |> string.to_graphemes
+  |> should.equal(_, ["-","-","👨‍👩‍👧‍👧", "-", "-", "🌵", "-", "-"])
+    // Empty string
+  ""
+  |> string.to_graphemes
+  |> should.equal(_, [])
+}
+
+pub fn next_grapheme_test(){
+    // basic
+  "abc"
+  |> string.next_grapheme
+  |> should.equal(_, Ok( tuple("a", "bc")))
+    // unicode
+  "👨‍👩‍👧‍👧-🌵"
+  |> string.next_grapheme
+  |> should.equal(_, Ok( tuple("👨‍👩‍👧‍👧", "-🌵")))
+    // empty string
+  ""
+  |> string.next_grapheme
+  |> should.equal(_, Error(Nil))
 }


### PR DESCRIPTION
Now that gleam has utf-8 support many more string functions are easy to implement.

This PR is rather large as it includes all of the generated files that are effected by the change from `<<"">>` to `<<""/utf8>>`. Do you want to keep generated files in here for some reason? It might be best to remove them from the repo and gitignore them.

As a side note, i don't believe gleam needs the `iodata` module anymore as we should be able to implement all the string functions without it which might simplify things a bit!

I gave the hand written erlang both specs: http://erlang.org/doc/reference_manual/typespec.html
and docs http://erlang.org/doc/apps/edoc/chapter.html#function-tags

Hope this helps and sorry if it's too much! Happy to get it to whatever state works for this org.