### PR TITLE
string.trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `string` module gains the `trim` function.
 - The error type for `atom.from_string` has been renamed to `FromStringError`.
 - The `string` module gains `contains` and `repeat` functions.
 - The `expect` module has been renamed to `should`. Functions in the module

--- a/gen/src/gleam@string.erl
+++ b/gen/src/gleam@string.erl
@@ -1,7 +1,7 @@
 -module(gleam@string).
 -compile(no_auto_import).
 
--export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2, erl_trim/1, trim/1]).
+-export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2, trim/1]).
 
 is_empty(Str) ->
     Str =:= <<""/utf8>>.
@@ -63,8 +63,8 @@ join(Strings, Separator) ->
         gleam@iodata:from_strings(gleam@list:intersperse(Strings, Separator))
     ).
 
-erl_trim(A) ->
-    gleam_stdlib:string_trim(A).
+erl_trim(A, B) ->
+    string:trim(A, B).
 
 trim(String) ->
-    erl_trim(String).
+    erl_trim(String, both).

--- a/gen/src/gleam@string.erl
+++ b/gen/src/gleam@string.erl
@@ -1,7 +1,7 @@
 -module(gleam@string).
 -compile(no_auto_import).
 
--export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2]).
+-export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2, trim/1]).
 
 is_empty(Str) ->
     Str =:= <<""/utf8>>.
@@ -62,3 +62,6 @@ join(Strings, Separator) ->
     gleam@iodata:to_string(
         gleam@iodata:from_strings(gleam@list:intersperse(Strings, Separator))
     ).
+
+trim(A) ->
+    gleam_stdlib:string_trim(A).

--- a/gen/src/gleam@string.erl
+++ b/gen/src/gleam@string.erl
@@ -1,7 +1,7 @@
 -module(gleam@string).
 -compile(no_auto_import).
 
--export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2, trim/1]).
+-export([is_empty/1, length/1, reverse/1, replace/3, lowercase/1, uppercase/1, compare/2, contains/2, split/2, append/2, concat/1, repeat/2, join/2, erl_trim/1, trim/1]).
 
 is_empty(Str) ->
     Str =:= <<""/utf8>>.
@@ -63,5 +63,8 @@ join(Strings, Separator) ->
         gleam@iodata:from_strings(gleam@list:intersperse(Strings, Separator))
     ).
 
-trim(A) ->
+erl_trim(A) ->
     gleam_stdlib:string_trim(A).
+
+trim(String) ->
+    erl_trim(String).

--- a/gen/test/gleam@int_test.erl
+++ b/gen/test/gleam@int_test.erl
@@ -1,14 +1,14 @@
 -module(gleam@int_test).
 -compile(no_auto_import).
 
--export([to_string/0, parse/0, to_base_string/0, compare_test/0, min_test/0, max_test/0, is_even_test/0, is_odd_test/0]).
+-export([to_string_test/0, parse_test/0, to_base_string_test/0, compare_test/0, min_test/0, max_test/0, is_even_test/0, is_odd_test/0]).
 
-to_string() ->
+to_string_test() ->
     gleam@should:equal(gleam@int:to_string(123), <<"123"/utf8>>),
     gleam@should:equal(gleam@int:to_string(-123), <<"-123"/utf8>>),
     gleam@should:equal(gleam@int:to_string(123), <<"123"/utf8>>).
 
-parse() ->
+parse_test() ->
     gleam@should:equal(gleam@int:parse(<<"123"/utf8>>), {ok, 123}),
     gleam@should:equal(gleam@int:parse(<<"-123"/utf8>>), {ok, -123}),
     gleam@should:equal(gleam@int:parse(<<"0123"/utf8>>), {ok, 123}),
@@ -16,7 +16,7 @@ parse() ->
     gleam@should:equal(gleam@int:parse(<<"what"/utf8>>), {error, nil}),
     gleam@should:equal(gleam@int:parse(<<"1.23"/utf8>>), {error, nil}).
 
-to_base_string() ->
+to_base_string_test() ->
     gleam@should:equal(gleam@int:to_base_string(100, 16), <<"64"/utf8>>),
     gleam@should:equal(gleam@int:to_base_string(-100, 16), <<"-64"/utf8>>).
 

--- a/gen/test/gleam@string_test.erl
+++ b/gen/test/gleam@string_test.erl
@@ -1,7 +1,7 @@
 -module(gleam@string_test).
 -compile(no_auto_import).
 
--export([length_test/0, lowercase_test/0, uppercase_test/0, reverse_test/0, split_test/0, replace_test/0, append_test/0, compare_test/0, contains_test/0, concat_test/0, repeat_test/0, join_test/0]).
+-export([length_test/0, lowercase_test/0, uppercase_test/0, reverse_test/0, split_test/0, replace_test/0, append_test/0, compare_test/0, contains_test/0, concat_test/0, repeat_test/0, join_test/0, trim_test/0]).
 
 length_test() ->
     gleam@should:equal(gleam@string:length(<<"ß↑e̊"/utf8>>), 3),
@@ -97,4 +97,10 @@ join_test() ->
     gleam@should:equal(
         gleam@string:join([<<"Hello"/utf8>>, <<"world!"/utf8>>], <<"-"/utf8>>),
         <<"Hello-world!"/utf8>>
+    ).
+
+trim_test() ->
+    gleam@should:equal(
+        gleam@string:trim(<<"  hats  \n"/utf8>>),
+        <<"hats"/utf8>>
     ).

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -310,8 +310,12 @@ pub fn join(strings: List(String), with separator: String) -> String {
 //
 // pub fn pad_right(string: String, to size: Int, with: String) {}
 
-pub external fn erl_trim(String) -> String =
-  "gleam_stdlib" "string_trim"
+type Direction {
+  Both
+}
+
+external fn erl_trim(String, Direction) -> String =
+  "string" "trim"
 
 /// Get rid of whitespace on both sides of a String.
 ///
@@ -321,7 +325,7 @@ pub external fn erl_trim(String) -> String =
 ///
 ///
 pub fn trim(string: String) -> String {
-  erl_trim(string)
+  erl_trim(string, Both)
 }
 
 // TODO

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -310,6 +310,9 @@ pub fn join(strings: List(String), with separator: String) -> String {
 //
 // pub fn pad_right(string: String, to size: Int, with: String) {}
 
+pub external fn erl_trim(String) -> String =
+  "gleam_stdlib" "string_trim"
+
 /// Get rid of whitespace on both sides of a String.
 ///
 /// ## Examples
@@ -317,8 +320,9 @@ pub fn join(strings: List(String), with separator: String) -> String {
 ///    "hats"
 ///
 ///
-pub external fn trim(String) -> String =
-  "gleam_stdlib" "string_trim"
+pub fn trim(string: String) -> String {
+  erl_trim(string)
+}
 
 // TODO
 // Get rid of whitespace on the left of a String.

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -309,7 +309,7 @@ pub fn join(strings: List(String), with separator: String) -> String {
 //
 //
 // pub fn pad_right(string: String, to size: Int, with: String) {}
-// TODO
+
 // Get rid of whitespace on both sides of a String.
 //
 // ## Examples
@@ -317,7 +317,9 @@ pub fn join(strings: List(String), with separator: String) -> String {
 //    "hats"
 //
 //
-// pub fn trim(string: String) -> String {}
+pub external fn trim(String) -> String =
+  "gleam_stdlib" "string_trim"
+
 // TODO
 // Get rid of whitespace on the left of a String.
 //

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -310,13 +310,13 @@ pub fn join(strings: List(String), with separator: String) -> String {
 //
 // pub fn pad_right(string: String, to size: Int, with: String) {}
 
-// Get rid of whitespace on both sides of a String.
-//
-// ## Examples
-//    > trim("  hats  \n")
-//    "hats"
-//
-//
+/// Get rid of whitespace on both sides of a String.
+///
+/// ## Examples
+///    > trim("  hats  \n")
+///    "hats"
+///
+///
 pub external fn trim(String) -> String =
   "gleam_stdlib" "string_trim"
 

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -7,7 +7,7 @@
          iodata_append/2, iodata_prepend/2, identity/1, decode_int/1,
          decode_string/1, decode_bool/1, decode_float/1, decode_thunk/1, decode_atom/1,
          decode_list/1, decode_field/2, decode_element/2, parse_int/1, parse_float/1, compare_strings/2,
-         string_contains/2, string_trim/1]).
+         string_contains/2]).
 
 should_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 should_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -127,5 +127,3 @@ string_contains(Haystack, Needle) ->
     _ ->
       true
   end.
-
-string_trim(String) -> string:trim(String, both).

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -7,7 +7,7 @@
          iodata_append/2, iodata_prepend/2, identity/1, decode_int/1,
          decode_string/1, decode_bool/1, decode_float/1, decode_thunk/1, decode_atom/1,
          decode_list/1, decode_field/2, decode_element/2, parse_int/1, parse_float/1, compare_strings/2,
-         string_contains/2]).
+         string_contains/2, string_trim/1]).
 
 should_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 should_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -127,3 +127,5 @@ string_contains(Haystack, Needle) ->
     _ ->
       true
   end.
+
+string_trim(String) -> string:trim(String, both).

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -109,3 +109,9 @@ pub fn join_test() {
   |> string.join(with: "-")
   |> should.equal("Hello-world!")
 }
+
+pub fn trim_test() {
+  "  hats  \n"
+  |> string.trim()
+  |> should.equal("hats")
+}


### PR DESCRIPTION
Given the fact that I am still getting my feet wet with both Erlang and Gleam I made this small addition.
Feedback is welcome so that I can start adding more.

I am assuming that:
- Gleam models its stdlib somewhat after Elm
- Mapping to Erlang stdlib is generally preferable above a pure Gleam implementation for performance reasons
