### PR TITLE
Add link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![CI](https://github.com/gleam-lang/stdlib/workflows/CI/badge.svg?branch=master)
 
 Gleam's standard library!
+Documentation available on [hex.pm](https://hexdocs.pm/gleam_stdlib/).
 
 ## Quick reference
 


### PR DESCRIPTION
Fixes #40 

I would also update the Repo URl on github to the same link as suggested