### PR TITLE
changes that make the formatter happy, if not me

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -308,6 +308,7 @@ type Direction {
   Leading
 
   Trailing
+
   Both
 }
 
@@ -346,10 +347,10 @@ pub fn pad_right(string: String, to length: Int, with pad_string: String) {
   erl_pad(string, length, Trailing, pad_string)
 }
 
-///
 external fn erl_trim(String, Direction) -> String =
   "string" "trim"
 
+///
 ///
 /// Get rid of whitespace on both sides of a String.
 ///


### PR DESCRIPTION
Seeing as the formatter is part of core, I think this change should be merged to get builds green and once the fix is pushed to the formatter the odd format here should get cleaned up automatically once the updated formatter (0.8.1/0.9.0) is run over this library