### PR TITLE
Add a binary module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- `binary` module created with `from_string`, `byte_size`, `part`,
+  `int_to_u32` and `int_from_u32`.
+
 ## 0.9.0 - 2020-05-26
 
 - Created the `iterator` module with the `unfold`, `repeatedly`, `repeat`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- `binary` module created with `from_string`, `byte_size`, `part`,
+- `binary` module created with `from_string`, `byte_size`, `append`, `part`,
   `int_to_u32` and `int_from_u32`.
 
 ## 0.9.0 - 2020-05-26

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -9,14 +9,18 @@ pub external fn from_string(String) -> Binary =
 
 /// Returns an integer which is the number of bytes in the binary.
 pub external fn byte_size(Binary) -> Int =
-"erlang" "byte_size"
+  "erlang" "byte_size"
 
 /// Extracts the part of a binary.
 ///
 /// Binary part will start at given position and continue up to specified length.
 /// A negative length can be used to extract bytes at the end of a binary:
-pub external fn part(string: Binary, position: Int, length: Int) -> Result(Binary, Nil) =
-"binary_native" "part"
+pub external fn part(
+  string: Binary,
+  position: Int,
+  length: Int,
+) -> Result(Binary, Nil) =
+  "binary_native" "part"
 
 /// Convert integer to unsigned 32 bits.
 ///

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -1,0 +1,23 @@
+//// Working with raw binary data.
+//// The Binary type should be used instead of a String type when not utf8 encoded.
+
+pub external type Binary
+
+/// Convert a utf8 String type into a raw Binary type.
+pub external fn from_string(String) -> Binary =
+  "gleam_stdlib" "identity"
+
+/// Extracts the part of a binary.
+///
+/// Binary part will start at given position and continue up to specified length.
+/// A negative length can be used to extract bytes at the end of a binary:
+pub external fn part(string: Binary, position: Int, length: Int) -> Binary = "binary" "part"
+
+
+/// Returns an integer which is the number of bytes in the binary.
+pub external fn byte_size(Binary) -> Int =
+  "erlang" "byte_size"
+
+// Not sure these will be necessary with bit syntax for for now I think they are
+pub external fn int_to_u32(Int) -> Result(Binary, Nil) = "binary_native" "int_to_u32"
+pub external fn int_from_u32(Binary) -> Result(Int, Nil) = "binary_native" "int_from_u32"

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -11,13 +11,16 @@ pub external fn from_string(String) -> Binary =
 ///
 /// Binary part will start at given position and continue up to specified length.
 /// A negative length can be used to extract bytes at the end of a binary:
-pub external fn part(string: Binary, position: Int, length: Int) -> Binary = "binary" "part"
-
+pub external fn part(string: Binary, position: Int, length: Int) -> Binary =
+  "binary" "part"
 
 /// Returns an integer which is the number of bytes in the binary.
 pub external fn byte_size(Binary) -> Int =
   "erlang" "byte_size"
 
 // Not sure these will be necessary with bit syntax for for now I think they are
-pub external fn int_to_u32(Int) -> Result(Binary, Nil) = "binary_native" "int_to_u32"
-pub external fn int_from_u32(Binary) -> Result(Int, Nil) = "binary_native" "int_from_u32"
+pub external fn int_to_u32(Int) -> Result(Binary, Nil) =
+  "binary_native" "int_to_u32"
+
+pub external fn int_from_u32(Binary) -> Result(Int, Nil) =
+  "binary_native" "int_from_u32"

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -18,7 +18,8 @@ pub external fn byte_size(Binary) -> Int =
 ///    > append(to: "butter", suffix: "fly")
 ///    "butterfly"
 ///
-pub external fn append(first: Binary, second: Binary) -> Binary = "binary_native" "append"
+pub external fn append(first: Binary, second: Binary) -> Binary =
+  "binary_native" "append"
 
 /// Extracts part of a binary.
 ///

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -7,20 +7,25 @@ pub external type Binary
 pub external fn from_string(String) -> Binary =
   "gleam_stdlib" "identity"
 
+/// Returns an integer which is the number of bytes in the binary.
+pub external fn byte_size(Binary) -> Int =
+"erlang" "byte_size"
+
 /// Extracts the part of a binary.
 ///
 /// Binary part will start at given position and continue up to specified length.
 /// A negative length can be used to extract bytes at the end of a binary:
-pub external fn part(string: Binary, position: Int, length: Int) -> Binary =
-  "binary" "part"
+pub external fn part(string: Binary, position: Int, length: Int) -> Result(Binary, Nil) =
+"binary_native" "part"
 
-/// Returns an integer which is the number of bytes in the binary.
-pub external fn byte_size(Binary) -> Int =
-  "erlang" "byte_size"
-
-// Not sure these will be necessary with bit syntax for for now I think they are
+/// Convert integer to unsigned 32 bits.
+///
+/// Returns an error if integer is less than zero or equal to or larger than 2^32.
 pub external fn int_to_u32(Int) -> Result(Binary, Nil) =
   "binary_native" "int_to_u32"
 
+/// Convert unsigned 32 bits to Integer
+///
+/// Returns an error if the binary is not 32 bits in length.
 pub external fn int_from_u32(Binary) -> Result(Int, Nil) =
   "binary_native" "int_from_u32"

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -11,7 +11,7 @@ pub external fn from_string(String) -> Binary =
 pub external fn byte_size(Binary) -> Int =
   "erlang" "byte_size"
 
-/// Extracts the part of a binary.
+/// Extracts part of a binary.
 ///
 /// Binary part will start at given position and continue up to specified length.
 /// A negative length can be used to extract bytes at the end of a binary:
@@ -22,13 +22,13 @@ pub external fn part(
 ) -> Result(Binary, Nil) =
   "binary_native" "part"
 
-/// Convert integer to unsigned 32 bits.
+/// Convert an integer to unsigned 32 bits.
 ///
 /// Returns an error if integer is less than zero or equal to or larger than 2^32.
 pub external fn int_to_u32(Int) -> Result(Binary, Nil) =
   "binary_native" "int_to_u32"
 
-/// Convert unsigned 32 bits to Integer
+/// Convert unsigned 32 bits to an integer
 ///
 /// Returns an error if the binary is not 32 bits in length.
 pub external fn int_from_u32(Binary) -> Result(Int, Nil) =

--- a/src/gleam/binary.gleam
+++ b/src/gleam/binary.gleam
@@ -11,6 +11,15 @@ pub external fn from_string(String) -> Binary =
 pub external fn byte_size(Binary) -> Int =
   "erlang" "byte_size"
 
+/// Create a new binary by joining two binaries.
+///
+/// ## Examples
+///
+///    > append(to: "butter", suffix: "fly")
+///    "butterfly"
+///
+pub external fn append(first: Binary, second: Binary) -> Binary = "binary_native" "append"
+
 /// Extracts part of a binary.
 ///
 /// Binary part will start at given position and continue up to specified length.

--- a/src/gleam/binary_native.erl
+++ b/src/gleam/binary_native.erl
@@ -1,5 +1,8 @@
 -module (binary_native).
--export ([int_to_u32/1, int_from_u32/1, part/3]).
+-export ([int_to_u32/1, int_from_u32/1, append/2, part/3]).
+
+append(First, Second) ->
+  <<First/binary, Second/binary>>.
 
 part(Bin, Pos, Len) ->
   try {ok, binary:part(Bin, Pos, Len)} catch

--- a/src/gleam/binary_native.erl
+++ b/src/gleam/binary_native.erl
@@ -1,5 +1,10 @@
 -module (binary_native).
--export ([int_to_u32/1, int_from_u32/1]).
+-export ([int_to_u32/1, int_from_u32/1, part/3]).
+
+part(Bin, Pos, Len) ->
+  try {ok, binary:part(Bin, Pos, Len)} catch
+    error:badarg -> {error, nil}
+  end.
 
 int_to_u32(I) when 0 =< I, I < 4294967296 ->
   {ok, <<I:32>>};

--- a/src/gleam/binary_native.erl
+++ b/src/gleam/binary_native.erl
@@ -1,0 +1,12 @@
+-module (binary_native).
+-export ([int_to_u32/1, int_from_u32/1]).
+
+int_to_u32(I) when 0 =< I, I < 4294967296 ->
+  {ok, <<I:32>>};
+int_to_u32(_) ->
+  {error, nil}.
+
+int_from_u32(<<I:32>>) ->
+  {ok, I};
+int_from_u32(_) ->
+  {error, nil}.

--- a/test/gleam/binary_test.gleam
+++ b/test/gleam/binary_test.gleam
@@ -2,41 +2,40 @@ import gleam/binary
 import gleam/should
 
 pub fn length_test() {
-    binary.byte_size(binary.from_string("hello"))
-    |> should.equal(5)
+  binary.byte_size(binary.from_string("hello"))
+  |> should.equal(5)
 
-    binary.byte_size(binary.from_string(""))
-    |> should.equal(0)
-
+  binary.byte_size(binary.from_string(""))
+  |> should.equal(0)
 }
 
 pub fn part_test() {
-    binary.from_string("hello")
-    |> binary.part(0, 5)
-    |> should.equal(binary.from_string("hello"))
+  binary.from_string("hello")
+  |> binary.part(0, 5)
+  |> should.equal(binary.from_string("hello"))
 
-    binary.from_string("hello")
-    |> binary.part(0, 0)
-    |> should.equal(binary.from_string(""))
+  binary.from_string("hello")
+  |> binary.part(0, 0)
+  |> should.equal(binary.from_string(""))
 
-    binary.from_string("hello")
-    |> binary.part(2, 2)
-    |> should.equal(binary.from_string("ll"))
+  binary.from_string("hello")
+  |> binary.part(2, 2)
+  |> should.equal(binary.from_string("ll"))
 
-    binary.from_string("hello")
-    |> binary.part(5, -2)
-    |> should.equal(binary.from_string("lo"))
+  binary.from_string("hello")
+  |> binary.part(5, -2)
+  |> should.equal(binary.from_string("lo"))
 }
 
 pub fn u32_test() {
-    let Ok(bin) = binary.int_to_u32(0)
-    should.equal(4, binary.byte_size(bin))
-    should.equal(Ok(0), binary.int_from_u32(bin))
+  let Ok(bin) = binary.int_to_u32(0)
+  should.equal(4, binary.byte_size(bin))
+  should.equal(Ok(0), binary.int_from_u32(bin))
 
-    let Ok(bin) = binary.int_to_u32(4294967295)
-    should.equal(4, binary.byte_size(bin))
-    should.equal(Ok(4294967295), binary.int_from_u32(bin))
+  let Ok(bin) = binary.int_to_u32(4294967295)
+  should.equal(4, binary.byte_size(bin))
+  should.equal(Ok(4294967295), binary.int_from_u32(bin))
 
-    should.equal(Error(Nil), binary.int_from_u32(binary.from_string("")))
-    should.equal(Error(Nil), binary.int_from_u32(binary.from_string("12345")))
+  should.equal(Error(Nil), binary.int_from_u32(binary.from_string("")))
+  should.equal(Error(Nil), binary.int_from_u32(binary.from_string("12345")))
 }

--- a/test/gleam/binary_test.gleam
+++ b/test/gleam/binary_test.gleam
@@ -1,0 +1,42 @@
+import gleam/binary
+import gleam/should
+
+pub fn length_test() {
+    binary.byte_size(binary.from_string("hello"))
+    |> should.equal(5)
+
+    binary.byte_size(binary.from_string(""))
+    |> should.equal(0)
+
+}
+
+pub fn part_test() {
+    binary.from_string("hello")
+    |> binary.part(0, 5)
+    |> should.equal(binary.from_string("hello"))
+
+    binary.from_string("hello")
+    |> binary.part(0, 0)
+    |> should.equal(binary.from_string(""))
+
+    binary.from_string("hello")
+    |> binary.part(2, 2)
+    |> should.equal(binary.from_string("ll"))
+
+    binary.from_string("hello")
+    |> binary.part(5, -2)
+    |> should.equal(binary.from_string("lo"))
+}
+
+pub fn u32_test() {
+    let Ok(bin) = binary.int_to_u32(0)
+    should.equal(4, binary.byte_size(bin))
+    should.equal(Ok(0), binary.int_from_u32(bin))
+
+    let Ok(bin) = binary.int_to_u32(4294967295)
+    should.equal(4, binary.byte_size(bin))
+    should.equal(Ok(4294967295), binary.int_from_u32(bin))
+
+    should.equal(Error(Nil), binary.int_from_u32(binary.from_string("")))
+    should.equal(Error(Nil), binary.int_from_u32(binary.from_string("12345")))
+}

--- a/test/gleam/binary_test.gleam
+++ b/test/gleam/binary_test.gleam
@@ -9,6 +9,17 @@ pub fn length_test() {
   |> should.equal(0)
 }
 
+pub fn append_test() {
+  binary.from_string("Test")
+  |> binary.append(binary.from_string(" Me"))
+  |> should.equal(binary.from_string("Test Me"))
+
+  let Ok(zero_32bit) = binary.int_to_u32(0)
+  zero_32bit
+  |> binary.append(binary.from_string(""))
+  |> should.equal(zero_32bit)
+}
+
 pub fn part_test() {
   binary.from_string("hello")
   |> binary.part(0, 5)

--- a/test/gleam/binary_test.gleam
+++ b/test/gleam/binary_test.gleam
@@ -12,19 +12,35 @@ pub fn length_test() {
 pub fn part_test() {
   binary.from_string("hello")
   |> binary.part(0, 5)
-  |> should.equal(binary.from_string("hello"))
+  |> should.equal(Ok(binary.from_string("hello")))
 
   binary.from_string("hello")
   |> binary.part(0, 0)
-  |> should.equal(binary.from_string(""))
+  |> should.equal(Ok(binary.from_string("")))
 
   binary.from_string("hello")
   |> binary.part(2, 2)
-  |> should.equal(binary.from_string("ll"))
+  |> should.equal(Ok(binary.from_string("ll")))
 
   binary.from_string("hello")
   |> binary.part(5, -2)
-  |> should.equal(binary.from_string("lo"))
+  |> should.equal(Ok(binary.from_string("lo")))
+
+  binary.from_string("")
+  |> binary.part(0, 0)
+  |> should.equal(Ok(binary.from_string("")))
+
+  binary.from_string("hello")
+  |> binary.part(6, 0)
+  |> should.equal(Error(Nil))
+
+  binary.from_string("hello")
+  |> binary.part(-1, 1)
+  |> should.equal(Error(Nil))
+
+  binary.from_string("hello")
+  |> binary.part(1, 6)
+  |> should.equal(Error(Nil))
 }
 
 pub fn u32_test() {


### PR DESCRIPTION
Module defining binary types and a few operations,
Even though there is no syntax to define a binary this is useful as the correct type to return in a variety of places. My personal usecase include hashing base32 encoding and reading from TCP sockets 