### PR TITLE
Regex module

### DIFF
--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -126,3 +126,22 @@ pub external fn split(Regex, String) -> List(String) =
 ///
 pub external fn scan(Regex, String) -> List(Match) =
   "gleam_stdlib" "regex_scan"
+
+/// Replace matches.
+///
+/// ## Examples
+///
+///    > let Ok(re) = regex.from_string("e+")
+///    > regex.replace(re, "Gleeeeam", "e")
+///    "Gleam"
+///
+///    > let Ok(re) = regex.from_string("([aeiou])")
+///    > regex.replace(re, "hello", "<\\1>")
+///    "h<e>ll<o>"
+///
+///    > let Ok(re) = regex.from_string("\\.(\\d)$")
+///    > regex.replace(re, "500.5", ".\\g{1}0")
+///    "500.50"
+///
+pub external fn replace(Regex, String, String) -> String =
+  "gleam_stdlib" "regex_replace"

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -1,0 +1,128 @@
+//// This module contains regular expression matching functions for strings.
+//// The matching algorithms of the library are based on the PCRE library, but not
+//// all of the PCRE library is interfaced and some parts of the library go beyond
+//// what PCRE offers. Currently PCRE version 8.40 (release date 2017-01-11) is used.
+
+import gleam/option.{Option}
+
+pub external type Regex
+
+/// The details about a particular match:
+///
+/// - match — the full string of the match.
+/// - index — the index of the match in the original string.
+/// - number — each match is numbered, starting from 1
+/// - submatches — a Regex can have subpatterns, sup-parts that are in parentheses.
+///
+pub type Match {
+  Match(
+    match: String,
+    index: Int,
+    number: Int,
+    submatches: List(Option(String)),
+  )
+}
+
+/// When a regular expression fails to compile:
+///
+/// - error — a descriptive error message
+/// - index — the index of the cause in the regex string
+///
+pub type FromStringError {
+  FromStringError(error: String, index: Int)
+}
+
+/// Create a new Regex.
+///
+/// ## Examples
+///
+///    > let Ok(re) = from_string("[0-9]")
+///    > match(re, "abc123")
+///    True
+///
+///    > match(re, "abcxyz")
+///    False
+///
+///    > from_string("[0-9")
+///    Error(
+///      FromStringError(
+///        error: "missing terminating ] for character class",
+///        index: 4
+///      )
+///    )
+///
+pub external fn from_string(String) -> Result(Regex, FromStringError) =
+  "gleam_stdlib" "regex_from_string"
+
+pub type Options {
+  Options(case_insensitive: Bool, multi_line: Bool)
+}
+
+/// Create a Regex with some additional options.
+///
+/// ## Examples
+///
+///    > let options = Options(case_insensitive: False, multi_line: True)
+///    > let Ok(re) = from_string_with(options, "^[0-9]")
+///    > match(re, "abc\n123")
+///    True
+///
+///    > let options = Options(case_insensitive: True, multi_line: False)
+///    > let Ok(re) = from_string_with(options, "[A-Z]")
+///    > match(re, "abc123")
+///    True
+///
+pub external fn from_string_with(
+  Options,
+  String,
+) -> Result(Regex, FromStringError) =
+  "gleam_stdlib" "regex_from_string_with"
+
+/// Returns a boolean indicating whether there was a match or not.
+///
+/// ## Examples
+///
+///    > let Ok(re) = from_string("^f.o.?")
+///    > match(re, "foo")
+///    True
+///
+///    > match(re, "boo")
+///    False
+///
+pub external fn match(Regex, String) -> Bool =
+  "gleam_stdlib" "regex_match"
+
+/// Split a string
+///
+/// ## Examples
+///
+///    > let Ok(re) = from_string(" *, *")
+///    > match(re, "foo,32, 4, 9  ,0")
+///    ["foo", "32", "4", "9", "0"]
+///
+pub external fn split(Regex, String) -> List(String) =
+  "gleam_stdlib" "regex_split"
+
+/// Collects all matches of the regular expression.
+///
+/// ## Examples
+///
+///    > let Ok(re) = regex.from_string("[oi]n a (\\w+)")
+///    > regex.scan(re, "I am on a boat in a lake.")
+///    [
+///      Match(
+///        match: "on a boat",
+///        index: 5,
+///        number: 1,
+///        submatches: [Some("boat")]
+///      ),
+///      Match(
+///        match: "in a lake",
+///        index: 15,
+///        number: 2,
+///        submatches: [Some("lake")]
+///      )
+///    ]
+///
+pub external fn scan(Regex, String) -> List(Match) =
+  "gleam_stdlib" "regex_scan"

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -11,7 +11,7 @@
          string_pad/4, decode_tuple2/1, decode_map/1, binary_int_to_u32/1,
          binary_int_from_u32/1, binary_append/2, binary_part_/3,
          regex_from_string/1, regex_from_string_with/2, regex_match/2,
-         regex_split/2, regex_scan/2]).
+         regex_split/2, regex_scan/2, regex_replace/3]).
 
 should_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 should_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -210,3 +210,6 @@ regex_scan(Regex, String) ->
         {match, Captured} -> regex_captured(String, Captured, 1);
         _ -> []
     end.
+
+regex_replace(Regex, Subject, Replacement) ->
+    re:replace(Subject, Regex, Replacement, [global, {return, binary}]).

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -1,0 +1,77 @@
+import gleam/option.{Some, None}
+import gleam/regex.{Match, FromStringError, Options}
+import gleam/result
+import gleam/should
+
+pub fn from_string_test() {
+  let Ok(re) = regex.from_string("[0-9]")
+
+  regex.match(re, "abc123")
+  |> should.equal(True)
+
+  regex.match(re, "abcxyz")
+  |> should.equal(False)
+
+  let Error(from_string_err) = regex.from_string("[0-9")
+
+  from_string_err
+  |> should.equal(
+    FromStringError(
+      error: "missing terminating ] for character class",
+      index: 4,
+    ),
+  )
+}
+
+pub fn from_string_with_test() {
+  let options = Options(case_insensitive: True, multi_line: False)
+  let Ok(re) = regex.from_string_with(options, "[A-B]")
+
+  regex.match(re, "abc123")
+  |> should.equal(True)
+
+  let options = Options(case_insensitive: False, multi_line: True)
+  let Ok(re) = regex.from_string_with(options, "^[0-9]")
+
+  regex.match(re, "abc\n123")
+  |> should.equal(True)
+}
+
+pub fn match_test() {
+  let Ok(re) = regex.from_string("^f.o.?")
+
+  regex.match(re, "foo")
+  |> should.equal(True)
+
+  regex.match(re, "boo")
+  |> should.equal(False)
+}
+
+pub fn split_test() {
+  let Ok(re) = regex.from_string(" *, *")
+
+  regex.split(re, "foo,32, 4, 9  ,0")
+  |> should.equal(["foo", "32", "4", "9", "0"])
+}
+
+pub fn find_test() {
+  let Ok(re) = regex.from_string("[oi]n a(.?) (\\w+)")
+
+  regex.scan(re, "I am on a boat in a lake.")
+  |> should.equal(
+    [
+      Match(
+        match: "on a boat",
+        index: 5,
+        number: 1,
+        submatches: [None, Some("boat")],
+      ),
+      Match(
+        match: "in a lake",
+        index: 15,
+        number: 2,
+        submatches: [None, Some("lake")],
+      ),
+    ],
+  )
+}

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -75,3 +75,20 @@ pub fn find_test() {
     ],
   )
 }
+
+pub fn replace_test() {
+  let Ok(re) = regex.from_string("e+")
+
+  regex.replace(re, "Gleeeeam", "e")
+  |> should.equal("Gleam")
+
+  let Ok(re) = regex.from_string("([aeiou])")
+
+  regex.replace(re, "hello", "<\\1>")
+  |> should.equal("h<e>ll<o>")
+
+  let Ok(re) = regex.from_string("\\.(\\d)$")
+
+  regex.replace(re, "500.5", ".\\g{1}0")
+  |> should.equal("500.50")
+}


### PR DESCRIPTION
Added `Regex` module.
It's mostly modeled after: https://package.elm-lang.org/packages/elm/regex/latest/Regex

This resolves https://github.com/gleam-lang/suggestions/issues/40

## TODO

- [x] Add split function
- [x] Add find function
- [x] Support submatches
- [ ] Labelled arguments
- [x] Add `replace` function
- [x] Add `from_string_with` function ([re](https://erlang.org/doc/man/re.html#compile-2))
- [x] Documentation
- [ ] Check how to deal with anchors
- [x] Check how to deal with options
- [x] Error handling
- [ ] Add `replace_first`? Add `substitute` & `substitute_first`?
