### PR TITLE
Add Base module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - The `result` module gains the the `or` function.
 - Created the `regex` module with the `from_string`, `from_string_with`, and
   `match` functions.
-  - The `list` module gains the the `pop`, `pop_map` and `key_pop` functions.
+- The `list` module gains the the `pop`, `pop_map` and `key_pop` functions.
 
 ## 0.9.0 - 2020-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Created the `regex` module with the `from_string`, `from_string_with`, and
   `match` functions.
 - The `list` module gains the the `pop`, `pop_map` and `key_pop` functions.
+- `base` module created with `encode64`, `decode64`, `url_encode64` and
+  `url_decode64`.
 
 ## 0.9.0 - 2020-05-26
 

--- a/src/gleam/base.gleam
+++ b/src/gleam/base.gleam
@@ -22,3 +22,16 @@ pub fn decode64(encoded: String) -> Result(BitString, Nil) {
   }
   erl_decode64(padded)
 }
+
+pub fn url_encode64(input: BitString, padding: Bool) -> String {
+  encode64(input, padding)
+  |> string.replace("+", "-")
+  |> string.replace("/", "_")
+}
+
+pub fn url_decode64(encoded: String) -> Result(BitString, Nil) {
+  encoded
+  |> string.replace("-", "+")
+  |> string.replace("_", "/")
+  |> decode64()
+}

--- a/src/gleam/base.gleam
+++ b/src/gleam/base.gleam
@@ -7,6 +7,7 @@ external fn erl_encode64(BitString) -> String =
 external fn erl_decode64(String) -> Result(BitString, Nil) =
   "gleam_stdlib" "base_decoded4"
 
+/// Encodes a BitString into a base 64 encoded string.
 pub fn encode64(input: BitString, padding: Bool) -> String {
   let encoded = erl_encode64(input)
   case padding {
@@ -15,6 +16,7 @@ pub fn encode64(input: BitString, padding: Bool) -> String {
   }
 }
 
+/// Decodes a base 64 encoded string into a BitString.
 pub fn decode64(encoded: String) -> Result(BitString, Nil) {
   let padded = case bit_string.byte_size(bit_string.from_string(encoded)) % 4 {
     0 -> encoded
@@ -23,12 +25,14 @@ pub fn decode64(encoded: String) -> Result(BitString, Nil) {
   erl_decode64(padded)
 }
 
+/// Encodes a BitString into a base 64 encoded string with URL and filename safe alphabet.
 pub fn url_encode64(input: BitString, padding: Bool) -> String {
   encode64(input, padding)
   |> string.replace("+", "-")
   |> string.replace("/", "_")
 }
 
+/// Decodes a base 64 encoded string with URL and filename safe alphabet into a BitString.
 pub fn url_decode64(encoded: String) -> Result(BitString, Nil) {
   encoded
   |> string.replace("-", "+")

--- a/src/gleam/base.gleam
+++ b/src/gleam/base.gleam
@@ -1,0 +1,24 @@
+import gleam/bit_string.{BitString}
+import gleam/string
+
+external fn erl_encode64(BitString) -> String =
+  "base64" "encode"
+
+external fn erl_decode64(String) -> Result(BitString, Nil) =
+  "gleam_stdlib" "base_decoded4"
+
+pub fn encode64(input: BitString, padding: Bool) -> String {
+  let encoded = erl_encode64(input)
+  case padding {
+    True -> encoded
+    False -> string.replace(encoded, "=", "")
+  }
+}
+
+pub fn decode64(encoded: String) -> Result(BitString, Nil) {
+  let padded = case bit_string.byte_size(bit_string.from_string(encoded)) % 4 {
+    0 -> encoded
+    n -> string.append(encoded, string.repeat("=", 4 - n))
+  }
+  erl_decode64(padded)
+}

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -11,7 +11,7 @@
          string_pad/4, decode_tuple2/1, decode_map/1, bit_string_int_to_u32/1,
          bit_string_int_from_u32/1, bit_string_append/2, bit_string_part_/3,
          decode_bit_string/1, regex_from_string/1, regex_from_string_with/2,
-         regex_match/2]).
+         regex_match/2, base_decoded4/1]).
 
 should_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 should_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -189,3 +189,8 @@ regex_match(Regex, String) ->
         {match, _} -> true;
         _ -> false
     end.
+
+base_decoded4(S) ->
+  try {ok, base64:decode(S)} catch
+    error:badarith -> {error, nil}
+  end.

--- a/test/gleam/base_test.gleam
+++ b/test/gleam/base_test.gleam
@@ -50,3 +50,47 @@ pub fn decode64_test() {
   |> base.decode64()
   |> should.equal(Error(Nil))
 }
+
+pub fn url_encode64_test() {
+  [255, 127, 254, 252]
+  |> list_to_binary()
+  |> base.url_encode64(True)
+  |> should.equal("_3_-_A==")
+
+  [255, 127, 254, 252]
+  |> list_to_binary()
+  |> base.url_encode64(False)
+  |> should.equal("_3_-_A")
+
+  [0, 0, 0]
+  |> list_to_binary()
+  |> base.url_encode64(True)
+  |> should.equal("AAAA")
+
+  []
+  |> list_to_binary()
+  |> base.url_encode64(True)
+  |> should.equal("")
+}
+
+pub fn url_decode64_test() {
+  "_3_-_A=="
+  |> base.url_decode64()
+  |> should.equal(Ok(list_to_binary([255, 127, 254, 252])))
+
+  "_3_-_A"
+  |> base.url_decode64()
+  |> should.equal(Ok(list_to_binary([255, 127, 254, 252])))
+
+  "AAAA"
+  |> base.url_decode64()
+  |> should.equal(Ok(list_to_binary([0, 0, 0])))
+
+  ""
+  |> base.url_decode64()
+  |> should.equal(Ok(list_to_binary([])))
+
+  ")!"
+  |> base.url_decode64()
+  |> should.equal(Error(Nil))
+}

--- a/test/gleam/base_test.gleam
+++ b/test/gleam/base_test.gleam
@@ -1,0 +1,52 @@
+import gleam/base
+import gleam/bit_string.{BitString}
+import gleam/io
+import gleam/list
+import gleam/should
+
+external fn list_to_binary(List(Int)) -> BitString =
+  "erlang" "list_to_binary"
+
+pub fn encode64_test() {
+  [255, 127, 254, 252]
+  |> list_to_binary()
+  |> base.encode64(True)
+  |> should.equal("/3/+/A==")
+
+  [255, 127, 254, 252]
+  |> list_to_binary()
+  |> base.encode64(False)
+  |> should.equal("/3/+/A")
+
+  [0, 0, 0]
+  |> list_to_binary()
+  |> base.encode64(True)
+  |> should.equal("AAAA")
+
+  []
+  |> list_to_binary()
+  |> base.encode64(True)
+  |> should.equal("")
+}
+
+pub fn decode64_test() {
+  "/3/+/A=="
+  |> base.decode64()
+  |> should.equal(Ok(list_to_binary([255, 127, 254, 252])))
+
+  "/3/+/A"
+  |> base.decode64()
+  |> should.equal(Ok(list_to_binary([255, 127, 254, 252])))
+
+  "AAAA"
+  |> base.decode64()
+  |> should.equal(Ok(list_to_binary([0, 0, 0])))
+
+  ""
+  |> base.decode64()
+  |> should.equal(Ok(list_to_binary([])))
+
+  ")!"
+  |> base.decode64()
+  |> should.equal(Error(Nil))
+}


### PR DESCRIPTION
This PR just adds base64 and url version of encoding. This is because:
-  erlang stdlibrary has support for it https://erlang.org/doc/man/base64.html
- it is useful on it's own, i.e. in basic authentication headers