### PR TITLE
start with a structured logger

### DIFF
--- a/src/gleam/logger.gleam
+++ b/src/gleam/logger.gleam
@@ -1,0 +1,41 @@
+import gleam/atom.{Atom}
+import gleam/dynamic.{Dynamic}
+import gleam/map.{Map}
+
+pub type Level {
+  Emergency
+  Alert
+  Critical
+  Error
+  Warning
+  Notice
+  Info
+  Debug
+}
+
+type Ok {
+  Ok
+}
+
+external fn erl_log(Level, List(tuple(Atom, Dynamic))) -> Ok =
+  "logger" "log"
+
+external fn erl_update_process_metadata(Map(Atom, Dynamic)) -> Ok =
+  "logger" "update_process_metadata"
+
+// Better name? entry/item/statement
+pub fn field(key: String, value: a) -> tuple(Atom, Dynamic) {
+  tuple(atom.create_from_string(key), dynamic.from(value))
+}
+
+pub fn log(level, report) -> Nil {
+  erl_log(level, report)
+  Nil
+}
+
+pub fn add_metadata(key, value) -> Nil {
+  [tuple(atom.create_from_string(key), dynamic.from(value))]
+  |> map.from_list()
+  |> erl_update_process_metadata()
+  Nil
+}

--- a/test/gleam/logger_test.gleam
+++ b/test/gleam/logger_test.gleam
@@ -1,0 +1,16 @@
+import gleam/logger.{log, field, Error, Warning}
+
+pub fn logger_test() {
+  log(
+    Warning,
+    [
+      field("event", "test_warning"),
+      field("number", 5),
+      field(
+        "really_long_field",
+        "00000000000000000000000000000000000000000000000000000",
+      ),
+    ],
+  )
+  todo
+}


### PR DESCRIPTION
This was the smallest useful interface I could come up with.

Also it looks like the standard logger is designed to never fail. 

```erl
logger:log(error, [{self(), self(), 5}, {a, a}]).
```
That log call works as a report so I think a keyword list of dynamic values is fine, no need for separate string/pid/ref/int/float/tuple1/tuple2 functions in the logger module
