### PR TITLE
Add a few simple math functions to the float module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - The `bit_builder` module gains the `from_string` function.
 - The `list` module gains the `key_set` and `unzip` function.
 - The `function` module gains the `rescue` function.
+- The `float` module gains the `power`, `square_root`, and `absolute_value`
+  functions.
 
 ## v0.10.1 - 2020-07-01
 

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -115,3 +115,16 @@ pub external fn round(Float) -> Int =
 ///
 pub external fn truncate(Float) -> Int =
   "erlang" "trunc"
+
+/// Returns the absolute value of the input as a float.
+///
+/// ## Examples
+///
+///    > absolute_value(-12.5)
+///    12.5
+///
+///    > absolute_value(10.2)
+///    10.2
+///
+pub external fn absolute_value(Float) -> Float =
+  "erlang" "abs"

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -128,3 +128,17 @@ pub external fn truncate(Float) -> Int =
 ///
 pub external fn absolute_value(Float) -> Float =
   "erlang" "abs"
+
+/// Returns the results of the base being raised to the power of the
+/// exponent, as a float.
+///
+/// ## Examples
+///
+///    > power(2.0, 2.0)
+///    4.0
+///
+///    > power(8.0, 1.5)
+///    64.0
+///
+pub external fn power(base: Float, exponent: Float) -> Float =
+  "math" "pow"

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -142,3 +142,20 @@ pub external fn absolute_value(Float) -> Float =
 ///
 pub external fn power(base: Float, exponent: Float) -> Float =
   "math" "pow"
+
+/// Returns the square root of the input as a float.
+///
+/// ## Examples
+///
+///    > square_root(4.0)
+///    2.0
+///
+///    > square_root(-16.0)
+///    Error(Nil)
+///
+pub fn square_root(number: Float) -> Result(Float, Nil) {
+  case number <. 0.0 {
+    True -> Error(Nil)
+    False -> Ok(power(number, 0.5))
+  }
+}

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -217,3 +217,17 @@ pub fn power_test() {
   float.power(2.0, -1.0)
   |> should.equal(0.5)
 }
+
+pub fn square_root_test() {
+  float.square_root(4.0)
+  |> should.equal(Ok(2.0))
+
+  float.square_root(16.0)
+  |> should.equal(Ok(4.0))
+
+  float.square_root(0.0)
+  |> should.equal(Ok(0.0))
+
+  float.square_root(-4.0)
+  |> should.equal(Error(Nil))
+}

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -183,3 +183,20 @@ pub fn max_test() {
   float.max(-1.1, -1.)
   |> should.equal(-1.)
 }
+
+pub fn absolute_value_test() {
+  float.absolute_value(-1.0)
+  |> should.equal(1.0)
+
+  float.absolute_value(-20.6)
+  |> should.equal(20.6)
+
+  float.absolute_value(0.0)
+  |> should.equal(0.0)
+
+  float.absolute_value(1.0)
+  |> should.equal(1.0)
+
+  float.absolute_value(25.2)
+  |> should.equal(25.2)
+}

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -200,3 +200,20 @@ pub fn absolute_value_test() {
   float.absolute_value(25.2)
   |> should.equal(25.2)
 }
+
+pub fn power_test() {
+  float.power(2.0, 2.0)
+  |> should.equal(4.0)
+
+  float.power(-5.0, 3.0)
+  |> should.equal(-125.0)
+
+  float.power(10.5, 0.0)
+  |> should.equal(1.0)
+
+  float.power(16.0, 0.5)
+  |> should.equal(4.0)
+
+  float.power(2.0, -1.0)
+  |> should.equal(0.5)
+}


### PR DESCRIPTION
# Overview

This PR attempts to address some of what was discussed in #100 aimed at the float module.

## Implementation

This PR adds the following functions to the float module:
 - `absolute_value`
 - `square_root`
 - `power`

In terms of implementation, `abs` is available as a BIF in erlang, so I am just making an external call to that. The square root and power functions were also simple enough that I thought it would be fine to make these external calls to the erlang stdlib as well.

Please let me know any thoughts/criticisms/opinions regarding this.