### PR TITLE
Add result.all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `list` module gains the `each`, and `partition` functions.
 - The `int` and `float` modules gain the `negate` function.
+- The `result` module gains the `all` function.
 
 ## v0.11.0 - 2020-08-22
 

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -1,3 +1,5 @@
+import gleam/list
+
 /// Result represents the result of something that may succeed or not.
 /// `Ok` means it was successful, `Error` means it was not successful.
 ///
@@ -198,4 +200,18 @@ pub fn or(first: Result(a, e), second: Result(a, e)) -> Result(a, e) {
     Ok(_) -> first
     Error(_) -> second
   }
+}
+
+/// Combine a list of results into a single result.
+/// If all elements in the list are Ok then returns an Ok holding the list of values.
+/// If any element is Error then returns the first error.
+///
+/// ## Examples
+///    > all([Ok(1), Ok(2)])
+///    Ok([1, 2])
+///
+///    > all([Ok(1), Error("e")])
+///    Error("e")
+pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
+  list.try_map(results, fn(x) { x })
 }

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -118,3 +118,13 @@ pub fn or_test() {
   |> result.or(Error("Error 2"))
   |> should.equal(Error("Error 2"))
 }
+
+pub fn all_test() {
+  [Ok(1), Ok(2), Ok(3)]
+  |> result.all
+  |> should.equal(Ok([1, 2, 3]))
+
+  [Ok(1), Error("a"), Error("b"), Ok(3)]
+  |> result.all
+  |> should.equal(Error("a"))
+}


### PR DESCRIPTION
Add a function to combine a list of results into a single result.
Doesn't seem to have a common name: `sequence` in haskell. `Result.Extra.combine` in Elm. `Result.all` in OCaml Base
This is a function I use from time to time. I think it could be a good addition. 

