### PR TITLE
Add percent_encode and percent_decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The `int` and `float` modules gain the `negate` function.
 - The `result` module gains the `all` function.
 - The `dynamic` module gains the `option` function.
+- The `uri` module gains the `percent_encode` and `percent_decode` functions.
 
 ## v0.11.0 - 2020-08-22
 

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -14,6 +14,7 @@ import gleam/string
 import gleam/dynamic.{Dynamic}
 import gleam/map.{Map}
 import gleam/function
+import gleam/pair
 
 /// Type representing holding the parsed components of an URI.
 /// All components of a URI are optional, except the path.
@@ -117,6 +118,33 @@ pub fn query_to_string(query: List(tuple(String, String))) -> String {
   |> erl_query_to_string([Encoding(Utf8)])
   |> dynamic.string
   |> result.unwrap("")
+}
+
+/// Encode a string into a percent encoded representation.
+/// Note that this encodes space as +.
+///
+/// ## Example
+///
+/// percent_encode("100% great")
+/// > "100%25+great"
+///
+pub fn percent_encode(value: String) -> String {
+  query_to_string([tuple("k", value)])
+  |> string.replace(each: "k=", with: "")
+}
+
+/// Decode a percent encoded string.
+///
+/// ## Example
+///
+/// percent_decode("100%25+great")
+/// > Ok("100% great")
+///
+pub fn percent_decode(value: String) -> Result(String, Nil) {
+  string.concat(["k=", value])
+  |> parse_query
+  |> result.then(list.head)
+  |> result.map(pair.second)
 }
 
 fn do_remove_dot_segments(


### PR DESCRIPTION
https://github.com/gleam-lang/stdlib/issues/118

Add functions to encode and decode a url component.

### Function naming

Unsure about the naming, this goes by many names in different languages. `percent_encode` seems to tell very clearly what this is about.

### Erlang implementation

I tried to find a function in erlang that would this but couldn't.

There is `http_uri.encode`. But this module is deprecated apparently. And is not consitent with `query_to_string` that is already in the std lib.

There is `uri_string.transcode`. But I couldn't figure out how to get the results. Tried a bunch of in and out encoding, but nothing.

I ended up using the functions `query_to_string` and `parse_query` already in the module. This ensures consistency.

### Encoding

This behaves a bit different than the JS implementation. e.g. in JS (encodeURIComponent spaces becomes `%20`. In this one it becomes `+`. However other implemetations encode space as +. e.g. ruby `URI.encode_www_form_component`
Not super clear to me when space should become `+`. 
But at least this is internally consistent.

### Decoding errors

In JS and ruby implementations I tested, giving an invalid string to decode returns an error. e.g. `"%2"` should be an Error.
But the erlang implementation is happy to return Ok("%2") back, which isn't great.
