### PR TITLE
Add product function to int and float modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- The `int` module gains the `sum` function.
-- The `float` module gains the `sum` function.
+- The `int` module gains the `sum` and `product` functions.
+- The `float` module gains the `sum` and `product` functions.
 
 ## v0.12.0 - 2020-11-04
 

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -190,3 +190,24 @@ fn do_sum(numbers: List(Float), initial: Float) -> Float {
     [x, ..rest] -> do_sum(rest, x +. initial)
   }
 }
+
+/// Multiplies a list of Floats and returns the product.
+///
+/// ## Example
+///
+///    > product([2.5, 3.2, 4.2])
+///    33.6
+///
+pub fn product(numbers: List(Float)) -> Float {
+  case numbers {
+    [] -> 0.
+    _ -> do_product(numbers, 1.)
+  }
+}
+
+fn do_product(numbers: List(Float), initial: Float) -> Float {
+  case numbers {
+    [] -> initial
+    [x, ..rest] -> do_product(rest, x *. initial)
+  }
+}

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -167,3 +167,24 @@ fn do_sum(numbers: List(Int), initial: Int) -> Int {
     [x, ..rest] -> do_sum(rest, x + initial)
   }
 }
+
+/// Multiplies a list of Ints and returns the product.
+///
+/// ## Example
+///
+///    > product([2, 3, 4])
+///    24
+///
+pub fn product(numbers: List(Int)) -> Int {
+  case numbers {
+    [] -> 0
+    _ -> do_product(numbers, 1)
+  }
+}
+
+fn do_product(numbers: List(Int), initial: Int) -> Int {
+  case numbers {
+    [] -> initial
+    [x, ..rest] -> do_product(rest, x * initial)
+  }
+}

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -250,3 +250,14 @@ pub fn sum_test() {
   float.sum([1.0, 2.2, 3.3])
   |> should.equal(6.5)
 }
+
+pub fn product_test() {
+  float.product([])
+  |> should.equal(0.)
+
+  float.product([4.])
+  |> should.equal(4.)
+
+  float.product([2.5, 3.2, 4.2])
+  |> should.equal(33.6)
+}

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -190,3 +190,14 @@ pub fn sum_test() {
   int.sum([1, 2, 3])
   |> should.equal(6)
 }
+
+pub fn product_test() {
+  int.product([])
+  |> should.equal(0)
+
+  int.product([4])
+  |> should.equal(4)
+
+  int.product([1, 2, 3])
+  |> should.equal(6)
+}


### PR DESCRIPTION
Piggybacking off of @lrosa007's work with the sum function and discussion in the discord to add a respective product function for the `Int` and `Float` modules.