### PR TITLE
add module for serializing/deserializing terms

### DIFF
--- a/src/gleam/bert.gleam
+++ b/src/gleam/bert.gleam
@@ -1,0 +1,26 @@
+import gleam/dynamic.{Dynamic}
+import gleam/function.{rescue}
+
+pub external fn term_to_binary(a) -> BitString =
+  "erlang" "term_to_binary"
+
+type Safe {
+  Safe
+}
+
+external fn erl_binary_to_term(BitString, List(Safe)) -> Dynamic =
+  "erlang" "binary_to_term"
+
+pub fn binary_to_term(binary) {
+  case rescue(fn() { erl_binary_to_term(binary, [Safe]) }) {
+    Ok(term) -> Ok(term)
+    Error(_) -> Error(Nil)
+  }
+}
+
+pub fn unsafe_binary_to_term(binary) {
+  case rescue(fn() { erl_binary_to_term(binary, []) }) {
+    Ok(term) -> Ok(term)
+    Error(_) -> Error(Nil)
+  }
+}

--- a/test/gleam/bert_test.gleam
+++ b/test/gleam/bert_test.gleam
@@ -1,0 +1,20 @@
+import gleam/bert
+import gleam/dynamic
+import gleam/should
+
+pub fn term_to_binary_test() {
+  let term = tuple("binary", [1, 2, 3])
+  term
+  |> bert.term_to_binary()
+  |> bert.binary_to_term()
+  |> should.equal(Ok(dynamic.from(term)))
+
+  term
+  |> bert.term_to_binary()
+  |> bert.unsafe_binary_to_term()
+  |> should.equal(Ok(dynamic.from(term)))
+
+  <<>>
+  |> bert.binary_to_term()
+  |> should.equal(Error(Nil))
+}


### PR DESCRIPTION
I've called this module bert because

- I didn't want to call it `erlang` that seemed weird at this point
- I've seen Erlang Term Format (ETF) External Erlang Term Format (EETF) and BERT (Binary ERlang Term)

Bert seemed to be the one used most in this thread
- https://elixirforum.com/t/anyone-using-erlang-external-term-format-etf-instead-of-e-g-json/17854

and the choice of the external javascript implementation.

https://github.com/rustyio/BERT-JS