### PR TITLE
Add int.absolute_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- The `int` module gains the `sum` and `product` functions.
+- The `int` module gains the `absolute_value`, `sum` and `product` functions.
 - The `float` module gains the `sum` and `product` functions.
 - The `result` module gains the `lazy_or` and `lazy_unwrap` functions.
 - The `bool` module gains the `nand`, `nor`, `exclusive_nor`, and `exclusive_or` functions.

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -3,6 +3,23 @@ import gleam/order.{Order}
 pub type Int =
   Int
 
+/// Returns the absolute value of the input.
+///
+/// ## Examples
+///
+///    > absolute_value(-12)
+///    12
+///
+///    > absolute_value(10)
+///    10
+///
+pub fn absolute_value(num: Int) -> Int {
+  case num >= 0 {
+    True -> num
+    False -> num * -1
+  }
+}
+
 /// Parse a given string as an int if possible.
 ///
 /// ## Examples

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -2,6 +2,16 @@ import gleam/should
 import gleam/int
 import gleam/order
 
+pub fn absolute_value_test() {
+  123
+  |> int.absolute_value
+  |> should.equal(123)
+
+  -123
+  |> int.absolute_value
+  |> should.equal(123)
+}
+
 pub fn to_string_test() {
   123
   |> int.to_string


### PR DESCRIPTION
`float` has `absolute_value` but `int` doesn't.
Add `int.absolute_value`.
Unsure if the erlang implementation is better somehow, but this seems pretty straighforward in plain Gleam.