### PR TITLE
Add result.replace_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - The `int` module gains the `absolute_value`, `sum` and `product` functions.
 - The `float` module gains the `sum` and `product` functions.
-- The `result` module gains the `lazy_or` and `lazy_unwrap` functions.
+- The `result` module gains the `lazy_or`, `lazy_unwrap`, and `replace_error` functions.
 - The `bool` module gains the `nand`, `nor`, `exclusive_nor`, and `exclusive_or` functions.
 - The `bit_builder` module gains the `from_string_builder` function.
 - The `list` modules gains the `permutations` function.

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -259,3 +259,8 @@ pub fn lazy_or(
 pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
   list.try_map(results, fn(x) { x })
 }
+
+pub fn replace_error(result: Result(a, e1), error: e2) -> Result(a, e2) {
+  result
+  |> map_error(fn(_) { error })
+}

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -156,3 +156,9 @@ pub fn all_test() {
   |> result.all
   |> should.equal(Error("a"))
 }
+
+pub fn replace_error_test() {
+  Error(Nil)
+  |> result.replace_error("Invalid")
+  |> should.equal(Error("Invalid"))
+}


### PR DESCRIPTION
As discussed in https://github.com/gleam-lang/stdlib/issues/153
This adds `result.replace_error`