### PR TITLE
Add list.window and list.window_by_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `list` modules gains the `window`, and `window_by_2` functions.
+
 ## v0.13.0 - 2021-01-13
 
 - The `int` module gains the `absolute_value`, `sum` and `product` functions.

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1139,3 +1139,45 @@ pub fn permutations(l: List(a)) -> List(List(a)) {
       |> flatten
   }
 }
+
+fn do_window(acc: List(List(a)), l: List(a), n: Int) -> List(List(a)) {
+  let window = take(l, n)
+
+  case length(window) == n {
+    True -> do_window([window, ..acc], drop(l, 1), n)
+    False -> acc
+  }
+}
+
+/// Return a list of sliding window
+///
+/// ## Examples
+///
+/// ```
+/// > window([1,2,3,4,5], 3)
+/// [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+///
+/// > window([1, 2], 4)
+/// []
+/// ```
+///
+pub fn window(l: List(a), by n: Int) -> List(List(a)) {
+  do_window([], l, n)
+  |> reverse
+}
+
+/// Return a list of tuples containing two contiguous elements
+///
+/// ## Examples
+///
+/// ```
+/// > window_by_2([1,2,3,4])
+/// [tuple(1, 2), tuple(2, 3), tuple(3, 4)]
+///
+/// > window_by_2([1])
+/// []
+/// ```
+///
+pub fn window_by_2(l: List(a)) -> List(tuple(a, a)) {
+  zip(l, drop(l, 1))
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -536,3 +536,31 @@ pub fn permutations_test() {
   |> list.permutations
   |> should.equal([["a", "b"], ["b", "a"]])
 }
+
+pub fn window_test() {
+  [1, 2, 3]
+  |> list.window(by: 2)
+  |> should.equal([[1, 2], [2, 3]])
+
+  [1, 2, 3]
+  |> list.window(3)
+  |> should.equal([[1, 2, 3]])
+
+  [1, 2, 3]
+  |> list.window(4)
+  |> should.equal([])
+
+  [1, 2, 3, 4, 5]
+  |> list.window(3)
+  |> should.equal([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+}
+
+pub fn window_by_2_test() {
+  [1, 2, 3, 4]
+  |> list.window_by_2
+  |> should.equal([tuple(1, 2), tuple(2, 3), tuple(3, 4)])
+
+  [1]
+  |> list.window_by_2
+  |> should.equal([])
+}


### PR DESCRIPTION
As discussed in https://github.com/gleam-lang/stdlib/issues/153

This adds two functions to list.

`windows` is a generic sliding windows, where you can pass the number of items desired.

`window2` is a special version that returns a `List(tuple(a,a))`. This has the advantage that the elements in the list are of a known size, so is more convenient for when you only need two. Maybe this could be named `windows_of_2`.
