### PR TITLE
Add io.get_line function

### DIFF
--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -55,3 +55,21 @@ pub fn debug(term: anything) -> anything {
   erl_print("~tp\n", [term])
   term
 }
+
+/// Error value returned by `get_line` function
+///
+pub type GetLineError {
+  Eof
+  NoData
+}
+
+/// Reads a line from standard input with the given prompt.
+///
+/// # Example
+///
+///    > io.get_line("Language: ")
+///    // -> Language: <- gleam 
+///    Ok("gleam\n")
+///
+pub external fn get_line(prompt: String) -> Result(String, GetLineError) =
+  "gleam_stdlib" "get_line"

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -11,7 +11,7 @@
          string_pad/4, decode_tuple2/1, decode_map/1, bit_string_int_to_u32/1,
          bit_string_int_from_u32/1, bit_string_append/2, bit_string_part_/3,
          decode_bit_string/1, compile_regex/2, regex_match/2, regex_split/2,
-         regex_scan/2, base_decode64/1, wrap_list/1, rescue/1]).
+         regex_scan/2, base_decode64/1, wrap_list/1, rescue/1, get_line/1]).
 
 should_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 should_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -209,4 +209,11 @@ rescue(F) ->
         throw:X -> {error, {thrown, X}};
         error:X -> {error, {errored, X}};
         exit:X -> {error, {exited, X}}
+    end.
+
+get_line(Prompt) ->
+    case io:get_line(Prompt) of
+        eof -> {error, eof};
+        {error, _} -> {error, no_data};
+        Data -> {ok, Data}
     end.


### PR DESCRIPTION
Adds a `get_line` function to the io module.

I couldn't figure out a way to represent the payload of the "rare" NoData error conditions returned by `io:get_line` so I've simply ignored it.