### PR TITLE
Ensure atom exists before atom from_string_test

### DIFF
--- a/test/gleam/atom_test.gleam
+++ b/test/gleam/atom_test.gleam
@@ -2,11 +2,9 @@ import gleam/atom
 import gleam/should
 
 pub fn from_string_test() {
-  "ok"
-  |> atom.from_string
-  |> should.be_ok
+  atom.create_from_string("this is an existing atom")
 
-  "expect"
+  "this is an existing atom"
   |> atom.from_string
   |> should.be_ok
 


### PR DESCRIPTION
`atom_test.from_string_test/0` uses `ok` to test `atom.from_string/0`. However,
the availability of the `ok` atom seems to be a side effect of running the test
trough eunit.

This patch explicitly creates an atom to make sure it exists before using it to
test `atom.from_string/1`. It removes the assertion on `expect`, which had the
same issue and doesn't seem to test another case.