### PR TITLE
Make list.take_while tail recursive

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1247,11 +1247,11 @@ fn do_take_while(
   acc: List(a),
 ) -> List(a) {
   case list {
-    [] -> acc
+    [] -> reverse(acc)
     [head, ..tail] ->
       case predicate(head) {
         True -> do_take_while(tail, predicate, [head, ..acc])
-        False -> acc
+        False -> reverse(acc)
       }
   }
 }
@@ -1268,5 +1268,4 @@ pub fn take_while(
   satisfying predicate: fn(a) -> Bool,
 ) -> List(a) {
   do_take_while(list, predicate, [])
-  |> reverse
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1260,7 +1260,7 @@ fn do_take_while(
 ///
 /// ## Examples
 ///
-///    > take_while([1, 2, 3, 4], fun (x) { x < 3 })
+///    > take_while([1, 2, 3, 2, 4], fun (x) { x < 3 })
 ///    [1, 2]
 ///
 pub fn take_while(

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1241,6 +1241,21 @@ pub fn drop_while(
   }
 }
 
+fn do_take_while(
+  list: List(a),
+  predicate: fn(a) -> Bool,
+  acc: List(a),
+) -> List(a) {
+  case list {
+    [] -> acc
+    [head, ..tail] ->
+      case predicate(head) {
+        True -> do_take_while(tail, predicate, [head, ..acc])
+        False -> acc
+      }
+  }
+}
+
 /// Takes the first elements in a given list for which the predicate funtion returns `True`.
 ///
 /// ## Examples
@@ -1252,12 +1267,6 @@ pub fn take_while(
   in list: List(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> List(a) {
-  case list {
-    [] -> []
-    [x, ..xs] ->
-      case predicate(x) {
-        True -> [x, ..take_while(xs, predicate)]
-        False -> []
-      }
-  }
+  do_take_while(list, predicate, [])
+  |> reverse
 }

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -586,7 +586,7 @@ pub fn drop_while_test() {
 }
 
 pub fn take_while_test() {
-  [1, 2, 3, 4]
+  [1, 2, 3, 2, 4]
   |> list.take_while(fn(x) { x < 3 })
   |> should.equal([1, 2])
 }


### PR DESCRIPTION
Changed the implementation to accumulate tail recursively and then reverse the result, not sure if there's a better solution...

I also modified the test case to show that any elements that fulfill the predicate after the first failed one are skipped as well.

Closes #167