### PR TITLE
Add iterator.index

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -494,3 +494,29 @@ pub fn find(
     Stop -> Error(Nil)
   }
 }
+
+fn do_index(
+  continuation: fn() -> Action(element),
+  next: Int,
+) -> fn() -> Action(tuple(Int, element)) {
+  fn() {
+    case continuation() {
+      Continue(e, continuation) ->
+        Continue(tuple(next, e), do_index(continuation, next + 1))
+      Stop -> Stop
+    }
+  }
+}
+
+/// Wraps values yielded from an iterator with indices, starting from 0.
+///
+/// ## Examples
+///
+///    > from_list(["a", "b", "c"]) |> index |> to_list
+///    [tuple(0, "a"), tuple(1, "b"), tuple(2, "c")]
+///
+pub fn index(over iterator: Iterator(element)) -> Iterator(tuple(Int, element)) {
+  iterator.continuation
+  |> do_index(0)
+  |> Iterator
+}

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -250,3 +250,10 @@ pub fn find_test() {
   |> iterator.find(fn(cat: Cat) { cat.id == 10 })
   |> should.equal(Ok(Cat(id: 10)))
 }
+
+pub fn index_test() {
+  iterator.from_list(["a", "b", "c"])
+  |> iterator.index
+  |> iterator.to_list
+  |> should.equal([tuple(0, "a"), tuple(1, "b"), tuple(2, "c")])
+}


### PR DESCRIPTION
Adds `iterator.index`, which is similar to `list.index_map`, or Rust's `Iterator::enumerate`