### PR TITLE
Add chunk functions for lists and iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 - The `dynamic` module gains the `tuple3`, `tuple4`, `tuple5`, `tuple6`
   functions and their typed equivalents `typed_tuple3`, `typed_tuple4`,
   `typed_tuple5`, `typed_tuple6`.
-- The `list` modules gains the `drop_while` and `take_while` functions.
+- The `list` module gains the `drop_while`, `take_while`,
+  `chunk` and `sized_chunk` functions.
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
-  `take_while` and `drop_while` functions.
+  `take_while`, `drop_while`, `chunk`, and `sized_chunk` functions.
 - Breaking change in `iterator.take`. Now it returns an iterator instead of a list.
 
 ## v0.14.0 - 2021-02-18

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -664,7 +664,6 @@ pub fn zip(left: Iterator(a), right: Iterator(b)) -> Iterator(tuple(a, b)) {
 type ChunkBy(element, key) {
   AnotherBy(List(element), key, element, fn() -> Action(element))
   LastBy(List(element))
-  NoneBy
 }
 
 fn next_chunk_by(
@@ -674,11 +673,7 @@ fn next_chunk_by(
   current_chunk: List(element),
 ) -> ChunkBy(element, key) {
   case continuation() {
-    Stop ->
-      case current_chunk {
-        [] -> NoneBy
-        remaining -> LastBy(list.reverse(remaining))
-      }
+    Stop -> LastBy(list.reverse(current_chunk))
     Continue(e, next) -> {
       let key = f(e)
       case key == previous_key {
@@ -696,7 +691,6 @@ fn do_chunk_by(
   previous_element: element,
 ) -> Action(List(element)) {
   case next_chunk_by(continuation, f, previous_key, [previous_element]) {
-    NoneBy -> Stop
     LastBy(chunk) -> Continue(chunk, stop)
     AnotherBy(chunk, key, el, next) ->
       Continue(chunk, fn() { do_chunk_by(next, f, key, el) })

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1270,7 +1270,7 @@ pub fn take_while(
   do_take_while(list, predicate, [])
 }
 
-fn do_chunk_by(
+fn do_chunk(
   list: List(a),
   f: fn(a) -> key,
   previous_key: key,
@@ -1282,9 +1282,8 @@ fn do_chunk_by(
     [head, ..tail] -> {
       let key = f(head)
       case key == previous_key {
-        False ->
-          do_chunk_by(tail, f, key, [head], [reverse(current_chunk), ..acc])
-        True -> do_chunk_by(tail, f, key, [head, ..current_chunk], acc)
+        False -> do_chunk(tail, f, key, [head], [reverse(current_chunk), ..acc])
+        True -> do_chunk(tail, f, key, [head, ..current_chunk], acc)
       }
     }
   }
@@ -1295,12 +1294,12 @@ fn do_chunk_by(
 ///
 /// ## Examples
 ///
-///    > [1, 2, 2, 3, 4, 4, 6, 7, 7] |> chunk_by(fn(n) { n % 2 })
+///    > [1, 2, 2, 3, 4, 4, 6, 7, 7] |> chunk(by: fn(n) { n % 2 })
 ///    [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
 ///
-pub fn chunk_by(in list: List(a), with f: fn(a) -> key) -> List(List(a)) {
+pub fn chunk(in list: List(a), by f: fn(a) -> key) -> List(List(a)) {
   case list {
     [] -> []
-    [head, ..tail] -> do_chunk_by(tail, f, f(head), [head], [])
+    [head, ..tail] -> do_chunk(tail, f, f(head), [head], [])
   }
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1269,3 +1269,42 @@ pub fn take_while(
 ) -> List(a) {
   do_take_while(list, predicate, [])
 }
+
+fn do_chunk_by(
+  list: List(a),
+  f: fn(a) -> key,
+  previous_key: key,
+  current_chunk: List(a),
+  acc: List(List(a)),
+) -> List(List(a)) {
+  case list {
+    [] ->
+      case current_chunk {
+        [] -> reverse(acc)
+        remaining -> reverse([reverse(remaining), ..acc])
+      }
+    [head, ..tail] -> {
+      let key = f(head)
+      case key == previous_key {
+        False ->
+          do_chunk_by(tail, f, key, [head], [reverse(current_chunk), ..acc])
+        True -> do_chunk_by(tail, f, key, [head, ..current_chunk], acc)
+      }
+    }
+  }
+}
+
+/// Returns a list of chunks in which
+/// the result of calling `f` on each element is the same.
+///
+/// ## Examples
+///
+///    > [1, 2, 2, 3, 4, 4, 6, 7, 7] |> chunk_by(fn(n) { n % 2 })
+///    [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
+///
+pub fn chunk_by(in list: List(a), with f: fn(a) -> key) -> List(List(a)) {
+  case list {
+    [] -> []
+    [head, ..tail] -> do_chunk_by(tail, f, f(head), [head], [])
+  }
+}

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1278,11 +1278,7 @@ fn do_chunk_by(
   acc: List(List(a)),
 ) -> List(List(a)) {
   case list {
-    [] ->
-      case current_chunk {
-        [] -> reverse(acc)
-        remaining -> reverse([reverse(remaining), ..acc])
-      }
+    [] -> reverse([reverse(current_chunk), ..acc])
     [head, ..tail] -> {
       let key = f(head)
       case key == previous_key {

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1303,3 +1303,45 @@ pub fn chunk(in list: List(a), by f: fn(a) -> key) -> List(List(a)) {
     [head, ..tail] -> do_chunk(tail, f, f(head), [head], [])
   }
 }
+
+fn do_sized_chunk(
+  list: List(a),
+  count: Int,
+  left: Int,
+  current_chunk: List(a),
+  acc: List(List(a)),
+) -> List(List(a)) {
+  case list {
+    [] ->
+      case current_chunk {
+        [] -> reverse(acc)
+        remaining -> reverse([reverse(remaining), ..acc])
+      }
+    [head, ..tail] -> {
+      let chunk = [head, ..current_chunk]
+      case left > 1 {
+        False -> do_sized_chunk(tail, count, count, [], [reverse(chunk), ..acc])
+        True -> do_sized_chunk(tail, count, left - 1, chunk, acc)
+      }
+    }
+  }
+}
+
+/// Returns a list of chunks containing `count` elements each.
+///
+/// If the last chunk does not have `count` elements, it is instead
+/// a partial chunk, with less than `count` elements.
+///
+/// For any `count` less than 1 this function behaves as if it was set to 1.
+///
+/// ## Examples
+///
+///    > [1, 2, 3, 4, 5, 6] |> chunk(into: 2)
+///    [[1, 2], [3, 4], [5, 6]]
+///
+///    > [1, 2, 3, 4, 5, 6, 7, 8] |> chunk(into: 3)
+///    [[1, 2, 3], [4, 5, 6], [7, 8]]
+///
+pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
+  do_sized_chunk(list, count, count, [], [])
+}

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -299,9 +299,9 @@ pub fn zip_test() {
   |> should.equal([tuple("a", 20), tuple("b", 21), tuple("c", 22)])
 }
 
-pub fn chunk_by_test() {
+pub fn chunk_test() {
   iterator.from_list([1, 2, 2, 3, 4, 4, 6, 7, 7])
-  |> iterator.chunk_by(fn(n) { n % 2 })
+  |> iterator.chunk(by: fn(n) { n % 2 })
   |> iterator.to_list
   |> should.equal([[1], [2, 2], [3], [4, 4, 6], [7, 7]])
 }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -305,3 +305,15 @@ pub fn chunk_test() {
   |> iterator.to_list
   |> should.equal([[1], [2, 2], [3], [4, 4, 6], [7, 7]])
 }
+
+pub fn sized_chunk_test() {
+  iterator.from_list([1, 2, 3, 4, 5, 6])
+  |> iterator.sized_chunk(into: 2)
+  |> iterator.to_list
+  |> should.equal([[1, 2], [3, 4], [5, 6]])
+
+  iterator.from_list([1, 2, 3, 4, 5, 6, 7, 8])
+  |> iterator.sized_chunk(into: 3)
+  |> iterator.to_list
+  |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
+}

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -298,3 +298,10 @@ pub fn zip_test() {
   |> iterator.to_list
   |> should.equal([tuple("a", 20), tuple("b", 21), tuple("c", 22)])
 }
+
+pub fn chunk_by_test() {
+  iterator.from_list([1, 2, 2, 3, 4, 4, 6, 7, 7])
+  |> iterator.chunk_by(fn(n) { n % 2 })
+  |> iterator.to_list
+  |> should.equal([[1], [2, 2], [3], [4, 4, 6], [7, 7]])
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -590,3 +590,9 @@ pub fn take_while_test() {
   |> list.take_while(fn(x) { x < 3 })
   |> should.equal([1, 2])
 }
+
+pub fn chunk_by_test() {
+  [1, 2, 2, 3, 4, 4, 6, 7, 7]
+  |> list.chunk_by(fn(n) { n % 2 })
+  |> should.equal([[1], [2, 2], [3], [4, 4, 6], [7, 7]])
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -596,3 +596,13 @@ pub fn chunk_test() {
   |> list.chunk(by: fn(n) { n % 2 })
   |> should.equal([[1], [2, 2], [3], [4, 4, 6], [7, 7]])
 }
+
+pub fn sized_chunk_test() {
+  [1, 2, 3, 4, 5, 6]
+  |> list.sized_chunk(into: 2)
+  |> should.equal([[1, 2], [3, 4], [5, 6]])
+
+  [1, 2, 3, 4, 5, 6, 7, 8]
+  |> list.sized_chunk(into: 3)
+  |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -591,8 +591,8 @@ pub fn take_while_test() {
   |> should.equal([1, 2])
 }
 
-pub fn chunk_by_test() {
+pub fn chunk_test() {
   [1, 2, 2, 3, 4, 4, 6, 7, 7]
-  |> list.chunk_by(fn(n) { n % 2 })
+  |> list.chunk(by: fn(n) { n % 2 })
   |> should.equal([[1], [2, 2], [3], [4, 4, 6], [7, 7]])
 }


### PR DESCRIPTION
Adds a direct equivalent of Elixir's `Stream.chunk_by` and `Stream.chunk_every/2`