### PR TITLE
Make iterator.take return an iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - The `list` modules gains the `drop_while` and `take_while` functions.
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
   `take_while` and `drop_while` functions.
+- Breaking change in `iterator.take`. Now it returns an iterator instead of a list.
 
 ## v0.14.0 - 2021-02-18
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -322,6 +322,7 @@ pub fn concat(strings: List(String)) -> String {
 pub fn repeat(string: String, times times: Int) -> String {
   iterator.repeat(string)
   |> iterator.take(times)
+  |> iterator.to_list
   |> concat
 }
 

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -47,6 +47,7 @@ pub fn take_test() {
     subject
     |> iterator.from_list
     |> iterator.take(n)
+    |> iterator.to_list
     |> should.equal(list.take(subject, n))
   }
 
@@ -173,6 +174,7 @@ pub fn repeat_test() {
   1
   |> iterator.repeat
   |> iterator.take(5)
+  |> iterator.to_list
   |> should.equal([1, 1, 1, 1, 1])
 }
 
@@ -181,16 +183,19 @@ pub fn cycle_test() {
   |> iterator.from_list
   |> iterator.cycle
   |> iterator.take(9)
+  |> iterator.to_list
   |> should.equal([1, 2, 3, 1, 2, 3, 1, 2, 3])
 }
 
 pub fn unfold_test() {
   iterator.unfold(2, fn(acc) { iterator.Next(acc, acc * 2) })
   |> iterator.take(5)
+  |> iterator.to_list
   |> should.equal([2, 4, 8, 16, 32])
 
   iterator.unfold(2, fn(_) { iterator.Done })
   |> iterator.take(5)
+  |> iterator.to_list
   |> should.equal([])
 
   fn(n) {
@@ -262,6 +267,7 @@ pub fn iterate_test() {
   fn(x) { x * 3 }
   |> iterator.iterate(from: 1)
   |> iterator.take(5)
+  |> iterator.to_list
   |> should.equal([1, 3, 9, 27, 81])
 }
 


### PR DESCRIPTION
Changes the behaviour of `iterator.take` to return an iterator that bounds another iterator up to a given number of elements.

Closes #179