### PR TITLE
Add dedup for iterators and lists

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -768,7 +768,7 @@ pub fn sized_chunk(
   |> Iterator
 }
 
-fn do_dedup_by(
+fn do_dedup(
   continuation: fn() -> Action(element),
   f: fn(element) -> key,
   previous_key: key,
@@ -778,8 +778,8 @@ fn do_dedup_by(
     Continue(e, next) -> {
       let key = f(e)
       case key == previous_key {
-        False -> Continue(e, fn() { do_dedup_by(next, f, key) })
-        True -> do_dedup_by(next, f, key)
+        False -> Continue(e, fn() { do_dedup(next, f, key) })
+        True -> do_dedup(next, f, key)
       }
     }
   }
@@ -790,17 +790,17 @@ fn do_dedup_by(
 ///
 /// ## Examples
 ///
-///    > from_list([tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")]) |> dedup_by(pair.first) |> to_list
+///    > from_list([tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")]) |> dedup(by: pair.first) |> to_list
 ///    [tuple(1, "a"), tuple(2, "b"), tuple(1, "a")]
 ///
-pub fn dedup_by(
+pub fn dedup(
   over iterator: Iterator(element),
-  with f: fn(element) -> key,
+  by key: fn(element) -> key,
 ) -> Iterator(element) {
   fn() {
     case iterator.continuation() {
       Stop -> Stop
-      Continue(e, next) -> Continue(e, fn() { do_dedup_by(next, f, f(e)) })
+      Continue(e, next) -> Continue(e, fn() { do_dedup(next, key, key(e)) })
     }
   }
   |> Iterator
@@ -811,9 +811,9 @@ pub fn dedup_by(
 ///
 /// ## Examples
 ///
-///    > from_list([1, 2, 3, 3, 2, 1, 1, 2]) |> dedup |> to_list
+///    > from_list([1, 2, 3, 3, 2, 1, 1, 2]) |> dedup_identical |> to_list
 ///    [1, 2, 3, 2, 1, 2]
 ///
-pub fn dedup(over iterator: Iterator(element)) -> Iterator(element) {
-  dedup_by(iterator, fn(x) { x })
+pub fn dedup_identical(iterator: Iterator(element)) -> Iterator(element) {
+  dedup(iterator, fn(x) { x })
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1346,7 +1346,7 @@ pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
   do_sized_chunk(list, count, count, [], [])
 }
 
-fn do_dedup_by(
+fn do_dedup(
   list: List(a),
   f: fn(a) -> key,
   previous_key: key,
@@ -1357,8 +1357,8 @@ fn do_dedup_by(
     [head, ..tail] -> {
       let key = f(head)
       case key == previous_key {
-        False -> do_dedup_by(tail, f, key, [head, ..acc])
-        True -> do_dedup_by(tail, f, key, acc)
+        False -> do_dedup(tail, f, key, [head, ..acc])
+        True -> do_dedup(tail, f, key, acc)
       }
     }
   }
@@ -1369,13 +1369,13 @@ fn do_dedup_by(
 ///
 /// ## Examples
 ///
-///    > [tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")] |> dedup_by(pair.first)
+///    > [tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")] |> dedup(by: pair.first)
 ///    [tuple(1, "a"), tuple(2, "b"), tuple(1, "a")]
 ///
-pub fn dedup_by(list: List(a), f: fn(a) -> key) -> List(a) {
+pub fn dedup(in list: List(a), by key: fn(a) -> key) -> List(a) {
   case list {
     [] -> []
-    [head, ..tail] -> do_dedup_by(tail, f, f(head), [head])
+    [head, ..tail] -> do_dedup(tail, key, key(head), [head])
   }
 }
 
@@ -1384,9 +1384,9 @@ pub fn dedup_by(list: List(a), f: fn(a) -> key) -> List(a) {
 ///
 /// ## Examples
 ///
-///    > dedup([1, 2, 3, 3, 2, 1, 1, 2])
+///    > dedup_identical([1, 2, 3, 3, 2, 1, 1, 2])
 ///    [1, 2, 3, 2, 1, 2]
 ///
-pub fn dedup(list: List(a)) -> List(a) {
-  dedup_by(list, fn(x) { x })
+pub fn dedup_identical(list: List(a)) -> List(a) {
+  dedup(list, fn(x) { x })
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1345,3 +1345,48 @@ fn do_sized_chunk(
 pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
   do_sized_chunk(list, count, count, [], [])
 }
+
+fn do_dedup_by(
+  list: List(a),
+  f: fn(a) -> key,
+  previous_key: key,
+  acc: List(a),
+) -> List(a) {
+  case list {
+    [] -> reverse(acc)
+    [head, ..tail] -> {
+      let key = f(head)
+      case key == previous_key {
+        False -> do_dedup_by(tail, f, key, [head, ..acc])
+        True -> do_dedup_by(tail, f, key, acc)
+      }
+    }
+  }
+}
+
+/// Returns a new list where a given element is dropped
+/// if the result of calling `f` on it and the previous element is the same.
+///
+/// ## Examples
+///
+///    > [tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")] |> dedup_by(pair.first)
+///    [tuple(1, "a"), tuple(2, "b"), tuple(1, "a")]
+///
+pub fn dedup_by(list: List(a), f: fn(a) -> key) -> List(a) {
+  case list {
+    [] -> []
+    [head, ..tail] -> do_dedup_by(tail, f, f(head), [head])
+  }
+}
+
+/// Returns a new list where a given element is dropped
+/// if it is the same as the previous element.
+///
+/// ## Examples
+///
+///    > dedup([1, 2, 3, 3, 2, 1, 1, 2])
+///    [1, 2, 3, 2, 1, 2]
+///
+pub fn dedup(list: List(a)) -> List(a) {
+  dedup_by(list, fn(x) { x })
+}

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -319,21 +319,21 @@ pub fn sized_chunk_test() {
   |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
 }
 
-pub fn dedup_by_test() {
+pub fn dedup_test() {
   iterator.from_list([
     tuple(1, "a"),
     tuple(2, "b"),
     tuple(2, "c"),
     tuple(1, "a"),
   ])
-  |> iterator.dedup_by(pair.first)
+  |> iterator.dedup(by: pair.first)
   |> iterator.to_list
   |> should.equal([tuple(1, "a"), tuple(2, "b"), tuple(1, "a")])
 }
 
-pub fn dedup_test() {
+pub fn dedup_identical_test() {
   iterator.from_list([1, 2, 3, 3, 2, 1, 1, 2])
-  |> iterator.dedup
+  |> iterator.dedup_identical
   |> iterator.to_list
   |> should.equal([1, 2, 3, 2, 1, 2])
 }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -1,6 +1,7 @@
 import gleam/should
 import gleam/iterator.{Done, Next}
 import gleam/list
+import gleam/pair
 
 // a |> from_list |> to_list == a
 pub fn to_from_list_test() {
@@ -316,4 +317,23 @@ pub fn sized_chunk_test() {
   |> iterator.sized_chunk(into: 3)
   |> iterator.to_list
   |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
+}
+
+pub fn dedup_by_test() {
+  iterator.from_list([
+    tuple(1, "a"),
+    tuple(2, "b"),
+    tuple(2, "c"),
+    tuple(1, "a"),
+  ])
+  |> iterator.dedup_by(pair.first)
+  |> iterator.to_list
+  |> should.equal([tuple(1, "a"), tuple(2, "b"), tuple(1, "a")])
+}
+
+pub fn dedup_test() {
+  iterator.from_list([1, 2, 3, 3, 2, 1, 1, 2])
+  |> iterator.dedup
+  |> iterator.to_list
+  |> should.equal([1, 2, 3, 2, 1, 2])
 }

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -606,3 +606,14 @@ pub fn sized_chunk_test() {
   |> list.sized_chunk(into: 3)
   |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
 }
+
+pub fn dedup_by_test() {
+  [tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")]
+  |> list.dedup_by(pair.first)
+  |> should.equal([tuple(1, "a"), tuple(2, "b"), tuple(1, "a")])
+}
+
+pub fn dedup_test() {
+  list.dedup([1, 2, 3, 3, 2, 1, 1, 2])
+  |> should.equal([1, 2, 3, 2, 1, 2])
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -607,13 +607,13 @@ pub fn sized_chunk_test() {
   |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
 }
 
-pub fn dedup_by_test() {
+pub fn dedup_test() {
   [tuple(1, "a"), tuple(2, "b"), tuple(2, "c"), tuple(1, "a")]
-  |> list.dedup_by(pair.first)
+  |> list.dedup(by: pair.first)
   |> should.equal([tuple(1, "a"), tuple(2, "b"), tuple(1, "a")])
 }
 
-pub fn dedup_test() {
-  list.dedup([1, 2, 3, 3, 2, 1, 1, 2])
+pub fn dedup_identical_test() {
+  list.dedup_identical([1, 2, 3, 3, 2, 1, 1, 2])
   |> should.equal([1, 2, 3, 2, 1, 2])
 }


### PR DESCRIPTION
As in title, naming takes after the chunk PR.