### PR TITLE
`any`, `all` for lists and iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - The `list` module gains the `drop_while`, `take_while`,
   `chunk` and `sized_chunk` functions.
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
-  `take_while`, `drop_while`, `chunk`, `sized_chunk` and `intersperse` functions.
+  `take_while`, `drop_while`, `chunk`, `sized_chunk`, `intersperse`, `any` and `all` functions.
 - Breaking change in `iterator.take`. Now it returns an iterator instead of a list.
 
 ## v0.14.0 - 2021-02-18

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -807,3 +807,75 @@ pub fn intersperse(
   }
   |> Iterator
 }
+
+fn do_any(
+  continuation: fn() -> Action(element),
+  predicate: fn(element) -> Bool,
+) -> Bool {
+  case continuation() {
+    Stop -> False
+    Continue(e, next) -> predicate(e) || do_any(next, predicate)
+  }
+}
+
+/// Returns `True` if any element emitted by the iterator satisfies the given predicate,
+/// `False` otherwise.
+///
+/// This function short-circuits once it finds a satisfying element.
+///
+/// An empty iterator results in `False`.
+///
+/// ## Examples
+///
+///    > from_list([]) |> any(fn(n) { n % 2 == 0 })
+///    False
+///
+///    > from_list([1, 2, 5, 7, 9]) |> any(fn(n) { n % 2 == 0 })
+///    True
+///
+///    > from_list([1, 3, 5, 7, 9]) |> any(fn(n) { n % 2 == 0 })
+///    False
+///
+pub fn any(
+  in iterator: Iterator(element),
+  satisfying predicate: fn(element) -> Bool,
+) -> Bool {
+  iterator.continuation
+  |> do_any(predicate)
+}
+
+fn do_all(
+  continuation: fn() -> Action(element),
+  predicate: fn(element) -> Bool,
+) -> Bool {
+  case continuation() {
+    Stop -> True
+    Continue(e, next) -> predicate(e) && do_all(next, predicate)
+  }
+}
+
+/// Returns `True` if all elements emitted by the iterator satisfy the given predicate,
+/// `False` otherwise.
+///
+/// This function short-circuits once it finds a non-satisfying element.
+///
+/// An empty iterator results in `True`.
+///
+/// ## Examples
+///
+///    > from_list([]) |> all(fn(n) { n % 2 == 0 })
+///    True
+///
+///    > from_list([2, 4, 6, 8]) |> all(fn(n) { n % 2 == 0 })
+///    True
+///
+///    > from_list([2, 4, 5, 8]) |> all(fn(n) { n % 2 == 0 })
+///    False
+///
+pub fn all(
+  in iterator: Iterator(element),
+  satisfying predicate: fn(element) -> Bool,
+) -> Bool {
+  iterator.continuation
+  |> do_all(predicate)
+}

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -635,11 +635,7 @@ pub fn find_map(
 pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
   case list {
     [] -> True
-    [x, ..rest] ->
-      case predicate(x) {
-        True -> all(rest, predicate)
-        _ -> False
-      }
+    [x, ..rest] -> predicate(x) && all(rest, predicate)
   }
 }
 
@@ -664,11 +660,7 @@ pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
 pub fn any(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
   case list {
     [] -> False
-    [x, ..rest] ->
-      case predicate(x) {
-        False -> any(rest, predicate)
-        _ -> True
-      }
+    [x, ..rest] -> predicate(x) || any(rest, predicate)
   }
 }
 

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -334,3 +334,31 @@ pub fn intersperse_test() {
   |> iterator.to_list
   |> should.equal([1, 0, 2, 0, 3, 0, 4, 0, 5])
 }
+
+pub fn any_test() {
+  iterator.from_list([])
+  |> iterator.any(satisfying: fn(n) { n % 2 == 0 })
+  |> should.be_false
+
+  iterator.from_list([1, 2, 5, 7, 9])
+  |> iterator.any(satisfying: fn(n) { n % 2 == 0 })
+  |> should.be_true
+
+  iterator.from_list([1, 3, 5, 7, 9])
+  |> iterator.any(satisfying: fn(n) { n % 2 == 0 })
+  |> should.be_false
+}
+
+pub fn all_test() {
+  iterator.from_list([])
+  |> iterator.all(satisfying: fn(n) { n % 2 == 0 })
+  |> should.be_true
+
+  iterator.from_list([2, 4, 6, 8])
+  |> iterator.all(satisfying: fn(n) { n % 2 == 0 })
+  |> should.be_true
+
+  iterator.from_list([2, 4, 5, 8])
+  |> iterator.all(satisfying: fn(n) { n % 2 == 0 })
+  |> should.be_false
+}


### PR DESCRIPTION
- Add iterator.{any, all}
- Simplify list.{any, all}