### PR TITLE
add string.crop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
   `take_while`, `drop_while`, `chunk`, `sized_chunk`, `intersperse`, `any` and `all` functions.
 - Breaking change in `iterator.take`. Now it returns an iterator instead of a list.
+- The `string` module gains the `drop_before` function.
 
 ## v0.14.0 - 2021-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
   `take_while`, `drop_while`, `chunk`, `sized_chunk`, `intersperse`, `any` and `all` functions.
 - Breaking change in `iterator.take`. Now it returns an iterator instead of a list.
-- The `string` module gains the `drop_before` function.
+- The `string` module gains the `crop` function.
 
 ## v0.14.0 - 2021-02-18
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -167,6 +167,20 @@ pub fn slice(from string: String, at_index idx: Int, length len: Int) -> String 
   }
 }
 
+/// Drops contents of the first string that occur before the second string.
+/// If the first string does not contain the second string, the first string is returned.
+///
+/// ## Examples
+///    > drop_before(from: "The Lone Gunmen", before: "Lone")
+///    "Lone Gunmen"
+///
+pub fn drop_before(from string: String, before substring: String) -> String {
+  case split_once(string, substring) {
+    Ok(tuple(_, rest)) -> concat([substring, rest])
+    Error(Nil) -> string
+  }
+}
+
 /// Drops *n* Graphemes from the left side of a string.
 ///
 /// ## Examples

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -171,14 +171,14 @@ pub fn slice(from string: String, at_index idx: Int, length len: Int) -> String 
 /// If the first string does not contain the second string, the first string is returned.
 ///
 /// ## Examples
-///    > drop_before(from: "The Lone Gunmen", before: "Lone")
+///    > crop(from: "The Lone Gunmen", before: "Lone")
 ///    "Lone Gunmen"
 ///
-pub fn drop_before(from string: String, before substring: String) -> String {
-  case split_once(string, substring) {
-    Ok(tuple(_, rest)) -> concat([substring, rest])
-    Error(Nil) -> string
-  }
+pub fn crop(from string: String, before substring: String) -> String {
+  string
+  |> erl_contains(substring)
+  |> dynamic.string()
+  |> result.unwrap(string)
 }
 
 /// Drops *n* Graphemes from the left side of a string.

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -204,6 +204,27 @@ pub fn slice_test() {
   |> should.equal("")
 }
 
+pub fn drop_before_test() {
+  "gleam"
+  |> string.drop_before("gl")
+  |> should.equal("gleam")
+
+  "gleam"
+  |> string.drop_before("le")
+  |> should.equal("leam")
+
+  string.drop_before(from: "gleam", before: "ea")
+  |> should.equal("eam")
+
+  "gleam"
+  |> string.drop_before("")
+  |> should.equal("gleam")
+
+  "gleam"
+  |> string.drop_before("!")
+  |> should.equal("gleam")
+}
+
 pub fn drop_left_test() {
   "gleam"
   |> string.drop_left(up_to: 2)

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -204,24 +204,24 @@ pub fn slice_test() {
   |> should.equal("")
 }
 
-pub fn drop_before_test() {
+pub fn crop_test() {
   "gleam"
-  |> string.drop_before("gl")
+  |> string.crop("gl")
   |> should.equal("gleam")
 
   "gleam"
-  |> string.drop_before("le")
+  |> string.crop("le")
   |> should.equal("leam")
 
-  string.drop_before(from: "gleam", before: "ea")
+  string.crop(from: "gleam", before: "ea")
   |> should.equal("eam")
 
   "gleam"
-  |> string.drop_before("")
+  |> string.crop("")
   |> should.equal("gleam")
 
   "gleam"
-  |> string.drop_before("!")
+  |> string.crop("!")
   |> should.equal("gleam")
 }
 


### PR DESCRIPTION
Wasn't completely sure about the labels for this function (not against modifying them if there are better suggestions), settled on: 
```rust
fn drop_before(from string: String, before substring: String) -> String
```