### PR TITLE
Add {iterator, list}.reduce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - The `dynamic` module gains the `tuple3`, `tuple4`, `tuple5`, `tuple6`
   functions and their typed equivalents `typed_tuple3`, `typed_tuple4`,
   `typed_tuple5`, `typed_tuple6`.
-- The `list` module gains the `drop_while`, `map_reduce`, `take_while`,
+- The `list` module gains the `drop_while`, `map_fold`, `take_while`,
   `chunk` and `sized_chunk` functions.
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
   `take_while`, `drop_while`, `chunk`, `sized_chunk`, `intersperse`, `any` and `all` functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 - The `dynamic` module gains the `tuple3`, `tuple4`, `tuple5`, `tuple6`
   functions and their typed equivalents `typed_tuple3`, `typed_tuple4`,
   `typed_tuple5`, `typed_tuple6`.
-- The `list` module gains the `drop_while`, `map_fold`, `take_while`,
+- The `list` module gains the `drop_while`, `map_fold`, `take_while`, `reduce`,
   `chunk` and `sized_chunk` functions.
 - The `iterator` module gains the `index`, `iterate`, `zip`, `scan`,
-  `take_while`, `drop_while`, `chunk`, `sized_chunk`, `intersperse`, `any` and `all` functions.
+  `take_while`, `drop_while`, `chunk`, `sized_chunk`, `intersperse`, `reduce`, `any` and `all` functions.
 - Breaking change in `iterator.take`. Now it returns an iterator instead of a list.
 - The `string` module gains the `crop` function.
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -251,7 +251,7 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
 /// ## Examples
 ///
 /// ```
-/// > map_reduce(
+/// > map_fold(
 ///     over: [1, 2, 3],
 ///     from: 100,
 ///     with: fn(i, memo) { tuple(i * 2, memo + i) }
@@ -259,7 +259,7 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
 ///  tuple([2, 4, 6], 106)
 /// ```
 ///
-pub fn map_reduce(
+pub fn map_fold(
   over list: List(a),
   from memo: memo,
   with fun: fn(a, memo) -> tuple(b, memo),

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1377,3 +1377,27 @@ fn do_sized_chunk(
 pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
   do_sized_chunk(list, count, count, [], [])
 }
+
+/// This function acts similar to fold, but does not take an initial state.
+/// Instead, it starts from the first element in the list
+/// and combines it with each subsequent element in turn using the given function.
+/// The function is called as fun(current_element, accumulator).
+///
+/// Returns `Ok` to indicate a successful run, and `Error` if called on an empty list.
+///
+/// ## Examples
+///
+///    > [] |> reduce(fn(x, y) { x + y })
+///    Error(Nil)
+///
+///    > [1, 2, 3, 4, 5] |> reduce(fn(x, y) { x + y })
+///    Ok(15)
+///
+pub fn reduce(over list: List(a), with fun: fn(a, a) -> a) -> Result(a, Nil) {
+  case list {
+    [] -> Error(Nil)
+    [head, ..tail] ->
+      fold(tail, head, fun)
+      |> Ok
+  }
+}

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -373,3 +373,13 @@ pub fn group_test() {
     tuple(2, [2, 5]),
   ]))
 }
+
+pub fn reduce_test() {
+  iterator.from_list([])
+  |> iterator.reduce(with: fn(x, y) { x + y })
+  |> should.equal(Error(Nil))
+
+  iterator.from_list([1, 2, 3, 4, 5])
+  |> iterator.reduce(with: fn(x, y) { x + y })
+  |> should.equal(Ok(15))
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -612,3 +612,13 @@ pub fn sized_chunk_test() {
   |> list.sized_chunk(into: 3)
   |> should.equal([[1, 2, 3], [4, 5, 6], [7, 8]])
 }
+
+pub fn reduce_test() {
+  []
+  |> list.reduce(with: fn(x, y) { x + y })
+  |> should.equal(Error(Nil))
+
+  [1, 2, 3, 4, 5]
+  |> list.reduce(with: fn(x, y) { x + y })
+  |> should.equal(Ok(15))
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -99,9 +99,9 @@ pub fn map_test() {
   |> should.equal([0, 8, 10, 14, 6])
 }
 
-pub fn map_reduce_test() {
+pub fn map_fold_test() {
   [1, 2, 3, 4]
-  |> list.map_reduce(from: 0, with: fn(i, acc) { tuple(i * 2, acc + i) })
+  |> list.map_fold(from: 0, with: fn(i, acc) { tuple(i * 2, acc + i) })
   |> should.equal(tuple([2, 4, 6, 8], 10))
 }
 


### PR DESCRIPTION
Add a convenience function for cases when you want to fold a list/iterator on its first element.

The name is taken from Rust, might be mistaken with the recently added `map_reduce`, but I can't think of a good alternative...