### PR TITLE
Add "over" named arg for fold_right

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -477,7 +477,11 @@ pub fn fold(over list: List(a), from initial: b, with fun: fn(a, b) -> b) -> b {
 /// Unlike `fold` this function is not tail recursive. Where possible use
 /// `fold` instead as it will use less memory.
 ///
-pub fn fold_right(list: List(a), from initial: b, with fun: fn(a, b) -> b) -> b {
+pub fn fold_right(
+  over list: List(a),
+  from initial: b,
+  with fun: fn(a, b) -> b,
+) -> b {
   case list {
     [] -> initial
     [x, ..rest] -> fun(x, fold_right(rest, initial, fun))


### PR DESCRIPTION
Every fold in list has a named argument `over`. Except `fold_right`.
Add this named argument for consistency.