### PR TITLE
Add list.flat_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `list` module gains the `flat_map` function.
+
 ## v0.15.0 - 2021-05-05
 
 - The `list.split_while` function's second argument now has the label

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -452,6 +452,20 @@ pub fn flatten(lists: List(List(a))) -> List(a) {
   do_flatten(lists, [])
 }
 
+/// Map and flatten the result
+///
+/// ## Examples
+///
+/// ```
+/// > flat_map([2, 4, 6], fn(x) { [x, x + 1] })
+/// [2, 3, 4, 5, 6, 7]
+/// ```
+///
+pub fn flat_map(over list: List(a), with fun: fn(a) -> List(b)) -> List(b) {
+  map(list, fun)
+  |> flatten
+}
+
 /// Reduces a list of elements into a single value by calling a given function
 /// on each element, going from left to right.
 ///

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -165,6 +165,11 @@ pub fn flatten_test() {
   |> should.equal([1, 2, 3, 4])
 }
 
+pub fn flat_map_test() {
+  list.flat_map([1, 10, 20], fn(x) { [x, x + 1] })
+  |> should.equal([1, 2, 10, 11, 20, 21])
+}
+
 pub fn fold_test() {
   [1, 2, 3]
   |> list.fold([], fn(x, acc) { [x, ..acc] })


### PR DESCRIPTION
`iterator` has `flat_map`. But with list you need to do `map` and then `flatten`.
It would be great to have `list.flat_map` as well.