### PR TITLE
Reformat to new tuple syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           otp-version: 23.2
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.13.0-rc2
+          gleam-version: 0.15.0
       - run: rebar3 install_deps
       - run: rebar3 eunit
       - run: gleam format --check src test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- All modules now use the new `#(a, b, ...)` tuple syntax.
+
 ## v0.15.0 - 2021-05-05
 
 - The `list.split_while` function's second argument now has the label

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -169,12 +169,11 @@ pub external fn list(from: Dynamic) -> Result(List(Dynamic), String) =
 ///    Error("Expected a 2 element tuple, got an int")
 ///
 pub fn result(from: Dynamic) -> Result(Result(Dynamic, Dynamic), String) {
-  try tuple(key, val) = tuple2(from)
-  try tag = atom(key)
+  try #(key, val) = tuple2(from)
 
+  try tag = atom(key)
   let ok_atom = atom.create_from_string("ok")
   let error_atom = atom.create_from_string("error")
-
   case tag {
     tag if tag == ok_atom -> Ok(Ok(val))
     tag if tag == error_atom -> Ok(Error(val))
@@ -334,7 +333,7 @@ pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, String)
 ///    > tuple2(from(""))
 ///    Error("Expected a tuple, got a binary")
 ///
-pub external fn tuple2(from: Dynamic) -> Result(tuple(Dynamic, Dynamic), String) =
+pub external fn tuple2(from: Dynamic) -> Result(#(Dynamic, Dynamic), String) =
   "gleam_stdlib" "decode_tuple2"
 
 /// Checks to see if the Dynamic value is a 2 element tuple containing two
@@ -361,11 +360,11 @@ pub fn typed_tuple2(
   from tup: Dynamic,
   first decode_first: Decoder(a),
   second decode_second: Decoder(b),
-) -> Result(tuple(a, b), String) {
-  try tuple(first, second) = tuple2(tup)
+) -> Result(#(a, b), String) {
+  try #(first, second) = tuple2(tup)
   try a = decode_first(first)
   try b = decode_second(second)
-  Ok(tuple(a, b))
+  Ok(#(a, b))
 }
 
 /// Checks to see if the Dynamic value is a 3 element tuple.
@@ -386,7 +385,7 @@ pub fn typed_tuple2(
 ///
 pub external fn tuple3(
   from: Dynamic,
-) -> Result(tuple(Dynamic, Dynamic, Dynamic), String) =
+) -> Result(#(Dynamic, Dynamic, Dynamic), String) =
   "gleam_stdlib" "decode_tuple3"
 
 /// Checks to see if the Dynamic value is a 3 element tuple containing two
@@ -414,12 +413,12 @@ pub fn typed_tuple3(
   first decode_first: Decoder(a),
   second decode_second: Decoder(b),
   third decode_third: Decoder(c),
-) -> Result(tuple(a, b, c), String) {
-  try tuple(first, second, third) = tuple3(tup)
+) -> Result(#(a, b, c), String) {
+  try #(first, second, third) = tuple3(tup)
   try a = decode_first(first)
   try b = decode_second(second)
   try c = decode_third(third)
-  Ok(tuple(a, b, c))
+  Ok(#(a, b, c))
 }
 
 /// Checks to see if the Dynamic value is a 4 element tuple.
@@ -440,7 +439,7 @@ pub fn typed_tuple3(
 ///
 pub external fn tuple4(
   from: Dynamic,
-) -> Result(tuple(Dynamic, Dynamic, Dynamic, Dynamic), String) =
+) -> Result(#(Dynamic, Dynamic, Dynamic, Dynamic), String) =
   "gleam_stdlib" "decode_tuple4"
 
 /// Checks to see if the Dynamic value is a 4 element tuple containing two
@@ -469,13 +468,13 @@ pub fn typed_tuple4(
   second decode_second: Decoder(b),
   third decode_third: Decoder(c),
   fourth decode_fourth: Decoder(d),
-) -> Result(tuple(a, b, c, d), String) {
-  try tuple(first, second, third, fourth) = tuple4(tup)
+) -> Result(#(a, b, c, d), String) {
+  try #(first, second, third, fourth) = tuple4(tup)
   try a = decode_first(first)
   try b = decode_second(second)
   try c = decode_third(third)
   try d = decode_fourth(fourth)
-  Ok(tuple(a, b, c, d))
+  Ok(#(a, b, c, d))
 }
 
 /// Checks to see if the Dynamic value is a 5 element tuple.
@@ -496,7 +495,7 @@ pub fn typed_tuple4(
 ///
 pub external fn tuple5(
   from: Dynamic,
-) -> Result(tuple(Dynamic, Dynamic, Dynamic, Dynamic, Dynamic), String) =
+) -> Result(#(Dynamic, Dynamic, Dynamic, Dynamic, Dynamic), String) =
   "gleam_stdlib" "decode_tuple5"
 
 /// Checks to see if the Dynamic value is a 5 element tuple containing two
@@ -526,14 +525,14 @@ pub fn typed_tuple5(
   third decode_third: Decoder(c),
   fourth decode_fourth: Decoder(d),
   fifth decode_fifth: Decoder(e),
-) -> Result(tuple(a, b, c, d, e), String) {
-  try tuple(first, second, third, fourth, fifth) = tuple5(tup)
+) -> Result(#(a, b, c, d, e), String) {
+  try #(first, second, third, fourth, fifth) = tuple5(tup)
   try a = decode_first(first)
   try b = decode_second(second)
   try c = decode_third(third)
   try d = decode_fourth(fourth)
   try e = decode_fifth(fifth)
-  Ok(tuple(a, b, c, d, e))
+  Ok(#(a, b, c, d, e))
 }
 
 /// Checks to see if the Dynamic value is a 6 element tuple.
@@ -554,7 +553,7 @@ pub fn typed_tuple5(
 ///
 pub external fn tuple6(
   from: Dynamic,
-) -> Result(tuple(Dynamic, Dynamic, Dynamic, Dynamic, Dynamic, Dynamic), String) =
+) -> Result(#(Dynamic, Dynamic, Dynamic, Dynamic, Dynamic, Dynamic), String) =
   "gleam_stdlib" "decode_tuple6"
 
 /// Checks to see if the Dynamic value is a 6 element tuple containing two
@@ -585,15 +584,15 @@ pub fn typed_tuple6(
   fourth decode_fourth: Decoder(d),
   fifth decode_fifth: Decoder(e),
   sixth decode_sixth: Decoder(f),
-) -> Result(tuple(a, b, c, d, e, f), String) {
-  try tuple(first, second, third, fourth, fifth, sixth) = tuple6(tup)
+) -> Result(#(a, b, c, d, e, f), String) {
+  try #(first, second, third, fourth, fifth, sixth) = tuple6(tup)
   try a = decode_first(first)
   try b = decode_second(second)
   try c = decode_third(third)
   try d = decode_fourth(fourth)
   try e = decode_fifth(fifth)
   try f = decode_sixth(sixth)
-  Ok(tuple(a, b, c, d, e, f))
+  Ok(#(a, b, c, d, e, f))
 }
 
 /// Checks to see if the Dynamic value is map.

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -305,10 +305,10 @@ pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, String) =
 ///
 /// ## Examples
 ///
-///    > element(from(tuple(1, 2)), 0)
+///    > element(from(#(1, 2)), 0)
 ///    Ok(from(1))
 ///
-///    > element(from(tuple(1, 2)), 2)
+///    > element(from(#(1, 2)), 2)
 ///    Error("Expected a tuple of at least 3 size, got a tuple of 2 size")
 ///
 ///    > element(from(""), 2)
@@ -324,10 +324,10 @@ pub external fn element(from: Dynamic, position: Int) -> Result(Dynamic, String)
 ///
 /// ## Examples
 ///
-///    > tuple2(from(tuple(1, 2)))
-///    Ok(tuple(from(1), from(2)))
+///    > tuple2(from(#(1, 2)))
+///    Ok(#(from(1), from(2)))
 ///
-///    > tuple2(from(tuple(1, 2, 3)))
+///    > tuple2(from(#(1, 2, 3)))
 ///    Error("Expected a 2 element tuple")
 ///
 ///    > tuple2(from(""))
@@ -344,13 +344,13 @@ pub external fn tuple2(from: Dynamic) -> Result(#(Dynamic, Dynamic), String) =
 ///
 /// ## Examples
 ///
-///    > typed_tuple2(from(tuple(1, 2)), int, int)
-///    Ok(tuple(1, 2))
+///    > typed_tuple2(from(#(1, 2)), int, int)
+///    Ok(#(1, 2))
 ///
-///    > typed_tuple2(from(tuple(1, 2.0)), int, float)
-///    Ok(tuple(1, 2.0))
+///    > typed_tuple2(from(#(1, 2.0)), int, float)
+///    Ok(#(1, 2.0))
 ///
-///    > typed_tuple2(from(tuple(1, 2, 3)), int, float)
+///    > typed_tuple2(from(#(1, 2, 3)), int, float)
 ///    Error("Expected a 2 element tuple, got a 3 element tuple")
 ///
 ///    > typed_tuple2(from(""), int, float)
@@ -374,10 +374,10 @@ pub fn typed_tuple2(
 ///
 /// ## Examples
 ///
-///    > tuple3(from(tuple(1, 2, 3)))
-///    Ok(tuple(from(1), from(2), from(3)))
+///    > tuple3(from(#(1, 2, 3)))
+///    Ok(#(from(1), from(2), from(3)))
 ///
-///    > tuple3(from(tuple(1, 2)))
+///    > tuple3(from(#(1, 2)))
 ///    Error("Expected a 3 element tuple")
 ///
 ///    > tuple3(from(""))
@@ -396,13 +396,13 @@ pub external fn tuple3(
 ///
 /// ## Examples
 ///
-///    > typed_tuple3(from(tuple(1, 2, 3)), int, int, int)
-///    Ok(tuple(1, 2, 3))
+///    > typed_tuple3(from(#(1, 2, 3)), int, int, int)
+///    Ok(#(1, 2, 3))
 ///
-///    > typed_tuple3(from(tuple(1, 2.0, "3")), int, float, string)
-///    Ok(tuple(1, 2.0, "3"))
+///    > typed_tuple3(from(#(1, 2.0, "3")), int, float, string)
+///    Ok(#(1, 2.0, "3"))
 ///
-///    > typed_tuple3(from(tuple(1, 2)), int, float, string)
+///    > typed_tuple3(from(#(1, 2)), int, float, string)
 ///    Error("Expected a 3 element tuple, got a 2 element tuple")
 ///
 ///    > typed_tuple3(from(""), int, float, string)
@@ -428,10 +428,10 @@ pub fn typed_tuple3(
 ///
 /// ## Examples
 ///
-///    > tuple4(from(tuple(1, 2, 3, 4)))
-///    Ok(tuple(from(1), from(2), from(3), from(4)))
+///    > tuple4(from(#(1, 2, 3, 4)))
+///    Ok(#(from(1), from(2), from(3), from(4)))
 ///
-///    > tuple4(from(tuple(1, 2)))
+///    > tuple4(from(#(1, 2)))
 ///    Error("Expected a 4 element tuple")
 ///
 ///    > tuple4(from(""))
@@ -450,13 +450,13 @@ pub external fn tuple4(
 ///
 /// ## Examples
 ///
-///    > typed_tuple4(from(tuple(1, 2, 3, 4)), int, int, int, int)
-///    Ok(tuple(1, 2, 3, 4))
+///    > typed_tuple4(from(#(1, 2, 3, 4)), int, int, int, int)
+///    Ok(#(1, 2, 3, 4))
 ///
-///    > typed_tuple4(from(tuple(1, 2.0, "3", 4)), int, float, string, int)
-///    Ok(tuple(1, 2.0, "3", 4))
+///    > typed_tuple4(from(#(1, 2.0, "3", 4)), int, float, string, int)
+///    Ok(#(1, 2.0, "3", 4))
 ///
-///    > typed_tuple4(from(tuple(1, 2)), int, float, string, int)
+///    > typed_tuple4(from(#(1, 2)), int, float, string, int)
 ///    Error("Expected a 4 element tuple, got a 2 element tuple")
 ///
 ///    > typed_tuple4(from(""), int, float, string, int)
@@ -484,10 +484,10 @@ pub fn typed_tuple4(
 ///
 /// ## Examples
 ///
-///    > tuple5(from(tuple(1, 2, 3, 4, 5)))
-///    Ok(tuple(from(1), from(2), from(3), from(4), from(5)))
+///    > tuple5(from(#(1, 2, 3, 4, 5)))
+///    Ok(#(from(1), from(2), from(3), from(4), from(5)))
 ///
-///    > tuple5(from(tuple(1, 2)))
+///    > tuple5(from(#(1, 2)))
 ///    Error("Expected a 5 element tuple")
 ///
 ///    > tuple5(from(""))
@@ -506,13 +506,13 @@ pub external fn tuple5(
 ///
 /// ## Examples
 ///
-///    > typed_tuple5(from(tuple(1, 2, 3, 4, 5)), int, int, int, int, int)
-///    Ok(tuple(1, 2, 3, 4, 5))
+///    > typed_tuple5(from(#(1, 2, 3, 4, 5)), int, int, int, int, int)
+///    Ok(#(1, 2, 3, 4, 5))
 ///
-///    > typed_tuple5(from(tuple(1, 2.0, "3", 4, 5)), int, float, string, int, int)
-///    Ok(tuple(1, 2.0, "3", 4, 5))
+///    > typed_tuple5(from(#(1, 2.0, "3", 4, 5)), int, float, string, int, int)
+///    Ok(#(1, 2.0, "3", 4, 5))
 ///
-///    > typed_tuple5(from(tuple(1, 2)), int, float, string, int, int)
+///    > typed_tuple5(from(#(1, 2)), int, float, string, int, int)
 ///    Error("Expected a 5 element tuple, got a 2 element tuple")
 ///
 ///    > typed_tuple5(from(""), int, float, string, int, int)
@@ -542,10 +542,10 @@ pub fn typed_tuple5(
 ///
 /// ## Examples
 ///
-///    > tuple6(from(tuple(1, 2, 3, 4, 5, 6)))
-///    Ok(tuple(from(1), from(2), from(3), from(4), from(5), from(6)))
+///    > tuple6(from(#(1, 2, 3, 4, 5, 6)))
+///    Ok(#(from(1), from(2), from(3), from(4), from(5), from(6)))
 ///
-///    > tuple6(from(tuple(1, 2)))
+///    > tuple6(from(#(1, 2)))
 ///    Error("Expected a 6 element tuple")
 ///
 ///    > tuple6(from(""))
@@ -564,13 +564,13 @@ pub external fn tuple6(
 ///
 /// ## Examples
 ///
-///    > typed_tuple6(from(tuple(1, 2, 3, 4, 5, 6)), int, int, int, int, int, int)
-///    Ok(tuple(1, 2, 3, 4, 5, 6))
+///    > typed_tuple6(from(#(1, 2, 3, 4, 5, 6)), int, int, int, int, int, int)
+///    Ok(#(1, 2, 3, 4, 5, 6))
 ///
-///    > typed_tuple6(from(tuple(1, 2.0, "3", 4, 5, 6)), int, float, string, int, int)
-///    Ok(tuple(1, 2.0, "3", 4, 5, 6))
+///    > typed_tuple6(from(#(1, 2.0, "3", 4, 5, 6)), int, float, string, int, int)
+///    Ok(#(1, 2.0, "3", 4, 5, 6))
 ///
-///    > typed_tuple6(from(tuple(1, 2)), int, float, string, int, int, int)
+///    > typed_tuple6(from(#(1, 2)), int, float, string, int, int, int)
 ///    Error("Expected a 6 element tuple, got a 2 element tuple")
 ///
 ///    > typed_tuple6(from(""), int, float, string, int, int, int)

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -493,7 +493,7 @@ fn do_index(
 /// ## Examples
 ///
 ///    > from_list(["a", "b", "c"]) |> index |> to_list
-///    [tuple(0, "a"), tuple(1, "b"), tuple(2, "c")]
+///    [#(0, "a"), #(1, "b"), #(2, "c")]
 ///
 pub fn index(over iterator: Iterator(element)) -> Iterator(#(Int, element)) {
   iterator.continuation
@@ -636,7 +636,7 @@ fn do_zip(
 /// ## Examples
 ///
 ///    > from_list(["a", "b", "c"]) |> zip(range(20, 30)) |> to_list
-///    [tuple("a", 20), tuple("b", 21), tuple("c", 22)]
+///    [#("a", 20), #("b", 21), #("c", 22)]
 ///
 pub fn zip(left: Iterator(a), right: Iterator(b)) -> Iterator(#(a, b)) {
   do_zip(left.continuation, right.continuation)
@@ -907,7 +907,7 @@ fn group_updater(
 /// ## Examples
 ///
 ///    > from_list([1, 2, 3, 4, 5, 6]) |> group(by: fn(n) { n % 3 })
-///    map.from_list([tuple(0, [3, 6]), tuple(1, [1, 4]), tuple(2, [2, 5])])
+///    map.from_list([#(0, [3, 6]), #(1, [1, 4]), #(2, [2, 5])])
 ///
 pub fn group(
   in iterator: Iterator(element),

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -478,12 +478,12 @@ pub fn find(
 fn do_index(
   continuation: fn() -> Action(element),
   next: Int,
-) -> fn() -> Action(tuple(Int, element)) {
+) -> fn() -> Action(#(Int, element)) {
   fn() {
     case continuation() {
       Stop -> Stop
       Continue(e, continuation) ->
-        Continue(tuple(next, e), do_index(continuation, next + 1))
+        Continue(#(next, e), do_index(continuation, next + 1))
     }
   }
 }
@@ -495,7 +495,7 @@ fn do_index(
 ///    > from_list(["a", "b", "c"]) |> index |> to_list
 ///    [tuple(0, "a"), tuple(1, "b"), tuple(2, "c")]
 ///
-pub fn index(over iterator: Iterator(element)) -> Iterator(tuple(Int, element)) {
+pub fn index(over iterator: Iterator(element)) -> Iterator(#(Int, element)) {
   iterator.continuation
   |> do_index(0)
   |> Iterator
@@ -616,7 +616,7 @@ pub fn scan(
 fn do_zip(
   left: fn() -> Action(a),
   right: fn() -> Action(b),
-) -> fn() -> Action(tuple(a, b)) {
+) -> fn() -> Action(#(a, b)) {
   fn() {
     case left() {
       Stop -> Stop
@@ -624,7 +624,7 @@ fn do_zip(
         case right() {
           Stop -> Stop
           Continue(el_right, next_right) ->
-            Continue(tuple(el_left, el_right), do_zip(next_left, next_right))
+            Continue(#(el_left, el_right), do_zip(next_left, next_right))
         }
     }
   }
@@ -638,7 +638,7 @@ fn do_zip(
 ///    > from_list(["a", "b", "c"]) |> zip(range(20, 30)) |> to_list
 ///    [tuple("a", 20), tuple("b", 21), tuple("c", 22)]
 ///
-pub fn zip(left: Iterator(a), right: Iterator(b)) -> Iterator(tuple(a, b)) {
+pub fn zip(left: Iterator(a), right: Iterator(b)) -> Iterator(#(a, b)) {
   do_zip(left.continuation, right.continuation)
   |> Iterator
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -254,9 +254,9 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
 /// > map_fold(
 ///     over: [1, 2, 3],
 ///     from: 100,
-///     with: fn(i, memo) { tuple(i * 2, memo + i) }
+///     with: fn(i, memo) { #(i * 2, memo + i) }
 ///  )
-///  tuple([2, 4, 6], 106)
+///  #([2, 4, 6], 106)
 /// ```
 ///
 pub fn map_fold(
@@ -296,8 +296,8 @@ fn do_index_map(
 ///
 /// ## Examples
 ///
-///    > index_map(["a", "b"], fn(i, x) { tuple(i, x) })
-///    [tuple(0, "a"), tuple(1, "b")]
+///    > index_map(["a", "b"], fn(i, x) { #(i, x) })
+///    [#(0, "a"), #(1, "b")]
 ///
 pub fn index_map(list: List(a), with fun: fn(Int, a) -> b) -> List(b) {
   do_index_map(list, fun, 0, [])
@@ -712,13 +712,13 @@ fn do_zip(xs: List(a), ys: List(b), acc: List(#(a, b))) -> List(#(a, b)) {
 ///    []
 ///
 ///    > zip([1, 2], [3])
-///    [tuple(1, 3)]
+///    [#(1, 3)]
 ///
 ///    > zip([1], [3, 4])
-///    [tuple(1, 3)]
+///    [#(1, 3)]
 ///
 ///    > zip([1, 2], [3, 4])
-///    [tuple(1, 3), tuple(2, 4)]
+///    [#(1, 3), #(2, 4)]
 ///
 pub fn zip(xs: List(a), ys: List(b)) -> List(#(a, b)) {
   do_zip(xs, ys, [])
@@ -740,7 +740,7 @@ pub fn zip(xs: List(a), ys: List(b)) -> List(#(a, b)) {
 ///    Error(LengthMismatch)
 ///
 ///    > strict_zip([1, 2], [3, 4])
-///    Ok([tuple(1, 3), tuple(2, 4)])
+///    Ok([#(1, 3), #(2, 4)])
 ///
 pub fn strict_zip(
   l1: List(a),
@@ -763,11 +763,11 @@ fn do_unzip(input, xs, ys) {
 ///
 /// ## Examples
 ///
-///    > unzip([tuple(1, 2), tuple(3, 4)])
-///    tuple([1, 3], [2, 4])
+///    > unzip([#(1, 2), #(3, 4)])
+///    #([1, 3], [2, 4])
 ///
 ///    > unzip([])
-///    tuple([], [])
+///    #([], [])
 ///
 pub fn unzip(input: List(#(a, b))) -> #(List(a), List(b)) {
   do_unzip(input, [], [])
@@ -949,13 +949,13 @@ fn do_split(list: List(a), n: Int, taken: List(a)) -> #(List(a), List(a)) {
 /// ## Examples
 ///
 ///    > split([6, 7, 8, 9], 0)
-///    tuple([], [6, 7, 8, 9])
+///    #([], [6, 7, 8, 9])
 ///
 ///    > split([6, 7, 8, 9], 2)
-///    tuple([6, 7], [8, 9])
+///    #([6, 7], [8, 9])
 ///
 ///    > split([6, 7, 8, 9], 4)
-///    tuple([6, 7, 8, 9], [])
+///    #([6, 7, 8, 9], [])
 ///
 pub fn split(list list: List(a), at index: Int) -> #(List(a), List(a)) {
   do_split(list, index, [])
@@ -985,10 +985,10 @@ fn do_split_while(
 /// ## Examples
 ///
 ///    > split_while([1, 2, 3, 4, 5], fn(x) { x <= 3 })
-///    tuple([1, 2, 3], [4, 5])
+///    #([1, 2, 3], [4, 5])
 ///
 ///    > split_while([1, 2, 3, 4, 5], fn(x) { x <= 5 })
-///    tuple([1, 2, 3, 4, 5], [])
+///    #([1, 2, 3, 4, 5], [])
 ///
 pub fn split_while(
   list list: List(a),
@@ -1007,13 +1007,13 @@ pub fn split_while(
 ///
 /// ## Examples
 ///
-///    > key_find([tuple("a", 0), tuple("b", 1)], "a")
+///    > key_find([#("a", 0), #("b", 1)], "a")
 ///    Ok(0)
 ///
-///    > key_find([tuple("a", 0), tuple("b", 1)], "b")
+///    > key_find([#("a", 0), #("b", 1)], "b")
 ///    Ok(1)
 ///
-///    > key_find([tuple("a", 0), tuple("b", 1)], "c")
+///    > key_find([#("a", 0), #("b", 1)], "c")
 ///    Error(Nil)
 ///
 pub fn key_find(
@@ -1051,7 +1051,7 @@ fn do_pop(haystack, predicate, checked) {
 /// ## Examples
 ///
 ///    > pop([1, 2, 3], fn(x) { x > 2 })
-///    Ok(tuple(3, [1, 2]))
+///    Ok(#(3, [1, 2]))
 ///
 ///    > pop([1, 2, 3], fn(x) { x > 4 })
 ///    Error(Nil)
@@ -1086,7 +1086,7 @@ fn do_pop_map(haystack, mapper, checked) {
 /// ## Examples
 ///
 ///    > pop_map([[], [2], [3]], head)
-///    Ok(tuple(2, [[], [3]]))
+///    Ok(#(2, [[], [3]]))
 ///
 ///    > pop_map([[], []], head)
 ///    Error(Nil)
@@ -1109,13 +1109,13 @@ pub fn pop_map(
 ///
 /// ## Examples
 ///
-///    > key_pop([tuple("a", 0), tuple("b", 1)], "a")
-///    Ok(tuple(0, [tuple("b", 1)])
+///    > key_pop([#("a", 0), #("b", 1)], "a")
+///    Ok(#(0, [#("b", 1)])
 ///
-///    > key_pop([tuple("a", 0), tuple("b", 1)], "b")
-///    Ok(tuple(1, [tuple("a", 0)])
+///    > key_pop([#("a", 0), #("b", 1)], "b")
+///    Ok(#(1, [#("a", 0)])
 ///
-///    > key_pop([tuple("a", 0), tuple("b", 1)], "c")
+///    > key_pop([#("a", 0), #("b", 1)], "c")
 ///    Error(Nil)
 ///
 pub fn key_pop(
@@ -1142,11 +1142,11 @@ pub fn key_pop(
 ///
 /// ## Examples
 ///
-///    > key_set([tuple(5, 0), tuple(4, 1)], 4, 100)
-///    [tuple(5, 0), tuple(4, 100)]
+///    > key_set([#(5, 0), #(4, 1)], 4, 100)
+///    [#(5, 0), #(4, 100)]
 ///
-///    > key_set([tuple(5, 0), tuple(4, 1)], 1, 100)
-///    [tuple(5, 0), tuple(4, 1), tuple(1, 100)]
+///    > key_set([#(5, 0), #(4, 1)], 1, 100)
+///    [#(5, 0), #(4, 1), #(1, 100)]
 ///
 pub fn key_set(list: List(#(a, b)), key: a, value: b) -> List(#(a, b)) {
   case list {
@@ -1242,7 +1242,7 @@ pub fn window(l: List(a), by n: Int) -> List(List(a)) {
 ///
 /// ```
 /// > window_by_2([1,2,3,4])
-/// [tuple(1, 2), tuple(2, 3), tuple(3, 4)]
+/// [#(1, 2), #(2, 3), #(3, 4)]
 ///
 /// > window_by_2([1])
 /// []
@@ -1501,7 +1501,7 @@ fn do_combination_pairs(items: List(a)) -> List(List(#(a, a))) {
 ///
 /// ```
 /// > combination_pairs([1, 2, 3])
-/// [tuple(1, 2), tuple(1, 3), tuple(2, 3)]
+/// [#(1, 2), #(1, 3), #(2, 3)]
 /// ```
 ///
 pub fn combination_pairs(items: List(a)) -> List(#(a, a)) {

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -45,7 +45,7 @@ pub external fn size(Map(k, v)) -> Int =
 ///    > new() |> insert("key", 0) |> to_list()
 ///    [tuple("key", 0)]
 ///
-pub external fn to_list(Map(key, value)) -> List(tuple(key, value)) =
+pub external fn to_list(Map(key, value)) -> List(#(key, value)) =
   "maps" "to_list"
 
 /// Converts a list of 2-element tuples `tuple(key, value)` to a map.
@@ -53,7 +53,7 @@ pub external fn to_list(Map(key, value)) -> List(tuple(key, value)) =
 /// If two tuples have the same key the last one in the list will be the one
 /// that is present in the map.
 ///
-pub external fn from_list(List(tuple(key, value))) -> Map(key, value) =
+pub external fn from_list(List(#(key, value))) -> Map(key, value) =
   "maps" "from_list"
 
 external fn is_key(key, Map(key, v)) -> Bool =
@@ -286,14 +286,10 @@ pub fn update(
   |> insert(map, key, _)
 }
 
-fn do_fold(
-  list: List(tuple(k, v)),
-  initial: acc,
-  fun: fn(k, v, acc) -> acc,
-) -> acc {
+fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(k, v, acc) -> acc) -> acc {
   case list {
     [] -> initial
-    [tuple(k, v), ..tail] -> do_fold(tail, fun(k, v, initial), fun)
+    [#(k, v), ..tail] -> do_fold(tail, fun(k, v, initial), fun)
   }
 }
 

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -32,7 +32,7 @@ pub external type Map(key, value)
 pub external fn size(Map(k, v)) -> Int =
   "maps" "size"
 
-/// Converts the map to a list of 2-element tuples `tuple(key, value)`, one for
+/// Converts the map to a list of 2-element tuples `#(key, value)`, one for
 /// each key-value pair in the map.
 ///
 /// The tuples in the list have no specific order.
@@ -43,12 +43,12 @@ pub external fn size(Map(k, v)) -> Int =
 ///    []
 ///
 ///    > new() |> insert("key", 0) |> to_list()
-///    [tuple("key", 0)]
+///    [#("key", 0)]
 ///
 pub external fn to_list(Map(key, value)) -> List(#(key, value)) =
   "maps" "to_list"
 
-/// Converts a list of 2-element tuples `tuple(key, value)` to a map.
+/// Converts a list of 2-element tuples `#(key, value)` to a map.
 ///
 /// If two tuples have the same key the last one in the list will be the one
 /// that is present in the map.
@@ -105,10 +105,10 @@ external fn erl_insert(key, value, Map(key, value)) -> Map(key, value) =
 /// ## Examples
 ///
 ///    > new() |> insert("a", 0) |> to_list
-///    [tuple("a", 0)]
+///    [#("a", 0)]
 ///
 ///    > new() |> insert("a", 0) |> insert("a", 5) |> to_list
-///    [tuple("a", 5)]
+///    [#("a", 5)]
 ///
 pub fn insert(into map: Map(k, v), for key: k, insert value: v) -> Map(k, v) {
   erl_insert(key, value, map)
@@ -122,10 +122,10 @@ external fn erl_map_values(fn(key, a) -> b, Map(key, value)) -> Map(key, b) =
 ///
 /// ## Examples
 ///
-///    > [tuple(3, 3), tuple(2, 4)]
+///    > [#(3, 3), #(2, 4)]
 ///    > |> from_list
 ///    > |> map_values(fn(key, value) { key * value })
-///    [tuple(3, 9), tuple(2, 8)]
+///    [#(3, 9), #(2, 8)]
 ///
 ///
 pub fn map_values(in map: Map(k, v), with fun: fn(k, v) -> w) -> Map(k, w) {
@@ -140,7 +140,7 @@ pub fn map_values(in map: Map(k, v), with fun: fn(k, v) -> w) -> Map(k, w) {
 ///
 /// ## Examples
 ///
-///    > keys([tuple("a", 0), tuple("b", 1)])
+///    > keys([#("a", 0), #("b", 1)])
 ///    ["a", "b"]
 ///
 pub external fn keys(Map(keys, v)) -> List(keys) =
@@ -154,7 +154,7 @@ pub external fn keys(Map(keys, v)) -> List(keys) =
 ///
 /// ## Examples
 ///
-///    > keys(from_list([tuple("a", 0), tuple("b", 1)]))
+///    > keys(from_list([#("a", 0), #("b", 1)]))
 ///    [0, 1]
 ///
 pub external fn values(Map(k, values)) -> List(values) =
@@ -171,13 +171,13 @@ external fn erl_filter(
 ///
 /// ## Examples
 ///
-///    > from_list([tuple("a", 0), tuple("b", 1)])
+///    > from_list([#("a", 0), #("b", 1)])
 ///    > |> filter(fn(key, value) { value != 0 })
-///    from_list([tuple("b", 1)])
+///    from_list([#("b", 1)])
 ///
-///    > from_list([tuple("a", 0), tuple("b", 1)])
+///    > from_list([#("a", 0), #("b", 1)])
 ///    > |> filter(fn(key, value) { True })
-///    from_list([tuple("a", 0), tuple("b", 1)])
+///    from_list([#("a", 0), #("b", 1)])
 ///
 pub fn filter(in map: Map(k, v), for property: fn(k, v) -> Bool) -> Map(k, v) {
   erl_filter(property, map)
@@ -191,13 +191,13 @@ external fn erl_take(List(k), Map(k, v)) -> Map(k, v) =
 ///
 /// ## Examples
 ///
-///    > from_list([tuple("a", 0), tuple("b", 1)])
+///    > from_list([#("a", 0), #("b", 1)])
 ///    > |> take(["b"])
-///    from_list([tuple("b", 1)])
+///    from_list([#("b", 1)])
 ///
-///    > from_list([tuple("a", 0), tuple("b", 1)])
+///    > from_list([#("a", 0), #("b", 1)])
 ///    > |> take(["a", "b", "c"])
-///    from_list([tuple("a", 0), tuple("b", 1)])
+///    from_list([#("a", 0), #("b", 1)])
 ///
 pub fn take(from map: Map(k, v), keeping desired_keys: List(k)) -> Map(k, v) {
   erl_take(desired_keys, map)
@@ -210,10 +210,10 @@ pub fn take(from map: Map(k, v), keeping desired_keys: List(k)) -> Map(k, v) {
 ///
 /// ## Examples
 ///
-///    > let a = from_list([tuple("a", 0), tuple("b", 1)])
-///    > let b = from_list([tuple("b", 2), tuple("c", 3)])
+///    > let a = from_list([#("a", 0), #("b", 1)])
+///    > let b = from_list([#("b", 2), #("c", 3)])
 ///    > merge(a, b)
-///    from_list([tuple("a", 0), tuple("b", 2), tuple("c", 3)])
+///    from_list([#("a", 0), #("b", 2), #("c", 3)])
 ///
 pub external fn merge(into: Map(k, v), merge: Map(k, v)) -> Map(k, v) =
   "maps" "merge"
@@ -226,11 +226,11 @@ external fn erl_delete(k, Map(k, v)) -> Map(k, v) =
 ///
 /// ## Examples
 ///
-///    > delete([tuple("a", 0), tuple("b", 1)], "a")
-///    from_list([tuple("b", 1)])
+///    > delete([#("a", 0), #("b", 1)], "a")
+///    from_list([#("b", 1)])
 ///
-///    > delete([tuple("a", 0), tuple("b", 1)], "c")
-///    from_list([tuple("a", 0), tuple("b", 1)])
+///    > delete([#("a", 0), #("b", 1)], "c")
+///    from_list([#("a", 0), #("b", 1)])
 ///
 pub fn delete(from map: Map(k, v), delete key: k) -> Map(k, v) {
   erl_delete(key, map)
@@ -241,13 +241,13 @@ pub fn delete(from map: Map(k, v), delete key: k) -> Map(k, v) {
 ///
 /// ## Examples
 ///
-///    > drop([tuple("a", 0), tuple("b", 1)], ["a"])
-///    from_list([tuple("b", 2)])
+///    > drop([#("a", 0), #("b", 1)], ["a"])
+///    from_list([#("b", 2)])
 ///
-///    > delete([tuple("a", 0), tuple("b", 1)], ["c"])
-///    from_list([tuple("a", 0), tuple("b", 1)])
+///    > delete([#("a", 0), #("b", 1)], ["c"])
+///    from_list([#("a", 0), #("b", 1)])
 ///
-///    > drop([tuple("a", 0), tuple("b", 1)], ["a", "b", "c"])
+///    > drop([#("a", 0), #("b", 1)], ["a", "b", "c"])
 ///    from_list([])
 ///
 pub fn drop(from map: Map(k, v), drop disallowed_keys: List(k)) -> Map(k, v) {
@@ -267,13 +267,13 @@ pub fn drop(from map: Map(k, v), drop disallowed_keys: List(k)) -> Map(k, v) {
 ///    >     Error(Nil) -> 0
 ///    >   }
 ///    > }
-///    > let map = from_list([tuple("a", 0)])
+///    > let map = from_list([#("a", 0)])
 ///    >
 ///    > update(map, "a" increment)
-///    from_list([tuple("a", 1)])
+///    from_list([#("a", 1)])
 ///
 ///    > update(map, "b" increment)
-///    from_list([tuple("a", 0), tuple("b", 0)])
+///    from_list([#("a", 0), #("b", 0)])
 ///
 pub fn update(
   in map: Map(k, v),
@@ -302,7 +302,7 @@ fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(k, v, acc) -> acc) -> acc 
 ///
 /// # Examples
 ///
-///    > let map = from_list([tuple("a", 1), tuple("b", 3), tuple("c", 9)])
+///    > let map = from_list([#("a", 1), #("b", 3), #("c", 9)])
 ///    > fold(map, 0, fn(key, value, accumulator) { accumulator + value })
 ///    13
 ///

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -142,8 +142,8 @@ pub fn flatten(option: Option(Option(a))) -> Option(a) {
 ///    > then(Some(1), fn(x) { Some(x + 1) })
 ///    Some(2)
 ///
-///    > then(Some(1), fn(x) { Some(tuple("a", x)) })
-///    Some(tuple("a", 1))
+///    > then(Some(1), fn(x) { Some(#("a", x)) })
+///    Some(#("a", 1))
 ///
 ///    > then(Some(1), fn(x) { None })
 ///    None

--- a/src/gleam/os.gleam
+++ b/src/gleam/os.gleam
@@ -62,5 +62,5 @@ pub external fn system_time(TimeUnit) -> Int =
 /// Returns the current OS system time as a tuple of Ints
 ///
 /// http://erlang.org/doc/man/os.html#timestamp-0
-pub external fn erlang_timestamp() -> tuple(Int, Int, Int) =
+pub external fn erlang_timestamp() -> #(Int, Int, Int) =
   "os" "timestamp"

--- a/src/gleam/pair.gleam
+++ b/src/gleam/pair.gleam
@@ -2,7 +2,7 @@
 ///
 /// ## Examples
 ///
-///    > first(tuple(1, 2))
+///    > first(#(1, 2))
 ///    1
 ///
 pub fn first(pair: #(a, b)) -> a {
@@ -14,7 +14,7 @@ pub fn first(pair: #(a, b)) -> a {
 ///
 /// ## Examples
 ///
-///    > second(tuple(1, 2))
+///    > second(#(1, 2))
 ///    2
 ///
 pub fn second(pair: #(a, b)) -> b {
@@ -26,8 +26,8 @@ pub fn second(pair: #(a, b)) -> b {
 ///
 /// ## Examples
 ///
-///    > swap(tuple(1, 2))
-///    tuple(2, 1)
+///    > swap(#(1, 2))
+///    #(2, 1)
 ///
 pub fn swap(pair: #(a, b)) -> #(b, a) {
   let #(a, b) = pair
@@ -39,7 +39,7 @@ pub fn swap(pair: #(a, b)) -> #(b, a) {
 ///
 /// ## Examples
 ///
-///    > tuple(1, 2) |> map_first(fn(n) { n * 2 })
+///    > #(1, 2) |> map_first(fn(n) { n * 2 })
 ///    2
 ///
 pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
@@ -52,7 +52,7 @@ pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
 ///
 /// ## Examples
 ///
-///    > tuple(1, 2) |> map_second(fn(n) { n * 2 })
+///    > #(1, 2) |> map_second(fn(n) { n * 2 })
 ///    4
 ///
 pub fn map_second(of pair: #(a, b), with fun: fn(b) -> c) -> #(a, c) {

--- a/src/gleam/pair.gleam
+++ b/src/gleam/pair.gleam
@@ -5,8 +5,8 @@
 ///    > first(tuple(1, 2))
 ///    1
 ///
-pub fn first(pair: tuple(a, b)) -> a {
-  let tuple(a, _) = pair
+pub fn first(pair: #(a, b)) -> a {
+  let #(a, _) = pair
   a
 }
 
@@ -17,8 +17,8 @@ pub fn first(pair: tuple(a, b)) -> a {
 ///    > second(tuple(1, 2))
 ///    2
 ///
-pub fn second(pair: tuple(a, b)) -> b {
-  let tuple(_, a) = pair
+pub fn second(pair: #(a, b)) -> b {
+  let #(_, a) = pair
   a
 }
 
@@ -29,9 +29,9 @@ pub fn second(pair: tuple(a, b)) -> b {
 ///    > swap(tuple(1, 2))
 ///    tuple(2, 1)
 ///
-pub fn swap(pair: tuple(a, b)) -> tuple(b, a) {
-  let tuple(a, b) = pair
-  tuple(b, a)
+pub fn swap(pair: #(a, b)) -> #(b, a) {
+  let #(a, b) = pair
+  #(b, a)
 }
 
 /// Returns a new pair with the first element having had `with` applied to
@@ -42,9 +42,9 @@ pub fn swap(pair: tuple(a, b)) -> tuple(b, a) {
 ///    > tuple(1, 2) |> map_first(fn(n) { n * 2 })
 ///    2
 ///
-pub fn map_first(of pair: tuple(a, b), with fun: fn(a) -> c) -> tuple(c, b) {
-  let tuple(a, b) = pair
-  tuple(fun(a), b)
+pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
+  let #(a, b) = pair
+  #(fun(a), b)
 }
 
 /// Returns a new pair with the second element having had `with` applied to
@@ -55,7 +55,7 @@ pub fn map_first(of pair: tuple(a, b), with fun: fn(a) -> c) -> tuple(c, b) {
 ///    > tuple(1, 2) |> map_second(fn(n) { n * 2 })
 ///    4
 ///
-pub fn map_second(of pair: tuple(a, b), with fun: fn(b) -> c) -> tuple(a, c) {
-  let tuple(a, b) = pair
-  tuple(a, fun(b))
+pub fn map_second(of pair: #(a, b), with fun: fn(b) -> c) -> #(a, c) {
+  let #(a, b) = pair
+  #(a, fun(b))
 }

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -136,13 +136,13 @@ pub fn push_front(onto queue: Queue(a), this item: a) -> Queue(a) {
 ///    > |> queue.pop_back()
 ///    Error(Nil)
 ///
-pub fn pop_back(from queue: Queue(a)) -> Result(tuple(a, Queue(a)), Nil) {
+pub fn pop_back(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
   case queue {
     Queue(in: [], out: []) -> Error(Nil)
     Queue(in: [], out: out) -> pop_back(Queue(in: list.reverse(out), out: []))
     Queue(in: [first, ..rest], out: out) -> {
       let queue = Queue(in: rest, out: out)
-      Ok(tuple(first, queue))
+      Ok(#(first, queue))
     }
   }
 }
@@ -170,13 +170,13 @@ pub fn pop_back(from queue: Queue(a)) -> Result(tuple(a, Queue(a)), Nil) {
 ///    > |> queue.pop_back()
 ///    Error(Nil)
 ///
-pub fn pop_front(from queue: Queue(a)) -> Result(tuple(a, Queue(a)), Nil) {
+pub fn pop_front(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
   case queue {
     Queue(in: [], out: []) -> Error(Nil)
     Queue(in: in, out: []) -> pop_front(Queue(in: [], out: list.reverse(in)))
     Queue(in: in, out: [first, ..rest]) -> {
       let queue = Queue(in: in, out: rest)
-      Ok(tuple(first, queue))
+      Ok(#(first, queue))
     }
   }
 }

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -125,12 +125,12 @@ pub fn push_front(onto queue: Queue(a), this item: a) -> Queue(a) {
 ///    > |> queue.push_back(0)
 ///    > |> queue.push_back(1)
 ///    > |> queue.pop_back()
-///    Ok(tuple(1, queue.push_front(queue.new(), 0)))
+///    Ok(#(1, queue.push_front(queue.new(), 0)))
 ///
 ///    > queue.new()
 ///    > |> queue.push_front(0)
 ///    > |> queue.pop_back()
-///    Ok(tuple(0, queue.new()))
+///    Ok(#(0, queue.new()))
 ///
 ///    > queue.new()
 ///    > |> queue.pop_back()
@@ -159,12 +159,12 @@ pub fn pop_back(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
 ///    > |> queue.push_front(1)
 ///    > |> queue.push_front(0)
 ///    > |> queue.pop_front()
-///    Ok(tuple(0, queue.push_back(queue.new(), 1)))
+///    Ok(#(0, queue.push_back(queue.new(), 1)))
 ///
 ///    > queue.new()
 ///    > |> queue.push_back(0)
 ///    > |> queue.pop_front()
-///    Ok(tuple(0, queue.new()))
+///    Ok(#(0, queue.new()))
 ///
 ///    > queue.new()
 ///    > |> queue.pop_back()

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -128,8 +128,8 @@ pub fn flatten(result: Result(Result(a, e), e)) -> Result(a, e) {
 ///    > then(Ok(1), fn(x) { Ok(x + 1) })
 ///    Ok(2)
 ///
-///    > then(Ok(1), fn(x) { Ok(tuple("a", x)) })
-///    Ok(tuple("a", 1))
+///    > then(Ok(1), fn(x) { Ok(#("a", x)) })
+///    Ok(#("a", 1))
 ///
 ///    > then(Ok(1), fn(x) { Error("Oh no") })
 ///    Error("Oh no")

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -168,13 +168,10 @@ pub fn take(from set: Set(member), keeping desired: List(member)) -> Set(member)
   Set(map.take(from: set.map, keeping: desired))
 }
 
-fn order(
-  first: Set(member),
-  second: Set(member),
-) -> tuple(Set(member), Set(member)) {
+fn order(first: Set(member), second: Set(member)) -> #(Set(member), Set(member)) {
   case map.size(first.map) > map.size(second.map) {
-    True -> tuple(first, second)
-    False -> tuple(second, first)
+    True -> #(first, second)
+    False -> #(second, first)
   }
 }
 
@@ -188,7 +185,7 @@ fn order(
 ///     [1, 2, 3]
 ///
 pub fn union(of first: Set(member), and second: Set(member)) -> Set(member) {
-  let tuple(larger, smaller) = order(first, second)
+  let #(larger, smaller) = order(first, second)
   fold(over: smaller, from: larger, with: fn(m, a) { insert(a, m) })
 }
 
@@ -205,6 +202,6 @@ pub fn intersection(
   of first: Set(member),
   and second: Set(member),
 ) -> Set(member) {
-  let tuple(larger, smaller) = order(first, second)
+  let #(larger, smaller) = order(first, second)
   take(from: larger, keeping: to_list(smaller))
 }

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -274,7 +274,7 @@ external fn erl_split(String, String) -> List(String) =
 /// ## Examples
 ///
 ///    > split_once("home/gleam/desktop/", on: "/")
-///    Ok(tuple("home", "gleam/desktop/"))
+///    Ok(#("home", "gleam/desktop/"))
 ///
 ///    > split_once("home/gleam/desktop/", on: "?")
 ///    Error(Nil)
@@ -439,7 +439,7 @@ pub fn trim_right(string: String) -> String {
 ///
 /// ## Examples
 ///    > pop_grapheme("gleam")
-///    Ok(tuple("g", "leam"))
+///    Ok(#("g", "leam"))
 ///
 ///    > pop_grapheme("")
 ///    Error(Nil)

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -282,9 +282,9 @@ external fn erl_split(String, String) -> List(String) =
 pub fn split_once(
   x: String,
   on substring: String,
-) -> Result(tuple(String, String), Nil) {
+) -> Result(#(String, String), Nil) {
   case erl_split(x, substring) {
-    [first, rest] -> Ok(tuple(first, rest))
+    [first, rest] -> Ok(#(first, rest))
     _ -> Error(Nil)
   }
 }
@@ -444,9 +444,7 @@ pub fn trim_right(string: String) -> String {
 ///    > pop_grapheme("")
 ///    Error(Nil)
 ///
-pub external fn pop_grapheme(
-  string: String,
-) -> Result(tuple(String, String), Nil) =
+pub external fn pop_grapheme(string: String) -> Result(#(String, String), Nil) =
   "gleam_stdlib" "string_pop_grapheme"
 
 /// Converts a string to a list of Graphemes.
@@ -456,7 +454,7 @@ pub external fn pop_grapheme(
 ///
 pub fn to_graphemes(string: String) -> List(String) {
   case pop_grapheme(string) {
-    Ok(tuple(grapheme, rest)) -> [grapheme, ..to_graphemes(rest)]
+    Ok(#(grapheme, rest)) -> [grapheme, ..to_graphemes(rest)]
     _ -> []
   }
 }

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -97,7 +97,7 @@ external fn erl_parse_query(String) -> Dynamic =
 /// Ok([tuple("a", "1"), tuple("b", "2")])
 /// ```
 ///
-pub fn parse_query(query: String) -> Result(List(tuple(String, String)), Nil) {
+pub fn parse_query(query: String) -> Result(List(#(String, String)), Nil) {
   let bool_value = fn(x) { result.map(dynamic.bool(x), fn(_) { "" }) }
   let query_param = dynamic.typed_tuple2(
     _,
@@ -120,7 +120,7 @@ type ErlQueryToStringOption {
 }
 
 external fn erl_query_to_string(
-  List(tuple(String, String)),
+  List(#(String, String)),
   List(ErlQueryToStringOption),
 ) -> Dynamic =
   "uri_string" "compose_query"
@@ -137,7 +137,7 @@ external fn erl_query_to_string(
 /// "a=1&b=2"
 /// ```
 ///
-pub fn query_to_string(query: List(tuple(String, String))) -> String {
+pub fn query_to_string(query: List(#(String, String))) -> String {
   query
   |> erl_query_to_string([Encoding(Utf8)])
   |> dynamic.string
@@ -156,7 +156,7 @@ pub fn query_to_string(query: List(tuple(String, String))) -> String {
 /// ```
 ///
 pub fn percent_encode(value: String) -> String {
-  query_to_string([tuple("k", value)])
+  query_to_string([#("k", value)])
   |> string.replace(each: "k=", with: "")
 }
 
@@ -235,11 +235,11 @@ external fn erl_to_string(Map(UriKey, Dynamic)) -> Dynamic =
 ///
 pub fn to_string(uri: Uri) -> String {
   let field = fn(key: UriKey, value: Option(anything)) -> Result(
-    tuple(UriKey, Dynamic),
+    #(UriKey, Dynamic),
     Nil,
   ) {
     case value {
-      Some(v) -> Ok(tuple(key, dynamic.from(v)))
+      Some(v) -> Ok(#(key, dynamic.from(v)))
       None -> Error(Nil)
     }
   }
@@ -322,8 +322,8 @@ pub fn merge(base: Uri, relative: Uri) -> Result(Uri, Nil) {
           Ok(resolved)
         }
         Uri(scheme: None, host: None, ..) -> {
-          let tuple(new_path, new_query) = case relative.path {
-            "" -> tuple(base.path, option.or(relative.query, base.query))
+          let #(new_path, new_query) = case relative.path {
+            "" -> #(base.path, option.or(relative.query, base.query))
             _ -> {
               let path_segments = case string.starts_with(relative.path, "/") {
                 True -> string.split(relative.path, "/")
@@ -336,7 +336,7 @@ pub fn merge(base: Uri, relative: Uri) -> Result(Uri, Nil) {
                 path_segments
                 |> remove_dot_segments()
                 |> join_segments()
-              tuple(path, relative.query)
+              #(path, relative.query)
             }
           }
           let resolved =

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -94,7 +94,7 @@ external fn erl_parse_query(String) -> Dynamic =
 /// ```
 /// > parse_query("a=1&b=2")
 ///
-/// Ok([tuple("a", "1"), tuple("b", "2")])
+/// Ok([#("a", "1"), #("b", "2")])
 /// ```
 ///
 pub fn parse_query(query: String) -> Result(List(#(String, String)), Nil) {
@@ -132,7 +132,7 @@ external fn erl_query_to_string(
 /// ## Examples
 ///
 /// ```
-/// > query_to_string([tuple("a", "1"), tuple("b", "2")])
+/// > query_to_string([#("a", "1"), #("b", "2")])
 ///
 /// "a=1&b=2"
 /// ```

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -273,7 +273,7 @@ pub fn field_test() {
 
 pub fn element_test() {
   let Ok(ok_atom) = atom.from_string("ok")
-  let ok_one_tuple = tuple(ok_atom, 1)
+  let ok_one_tuple = #(ok_atom, 1)
 
   ok_one_tuple
   |> dynamic.from
@@ -308,17 +308,17 @@ pub fn element_test() {
 }
 
 pub fn tuple2_test() {
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.tuple2
-  |> should.equal(Ok(tuple(dynamic.from(1), dynamic.from(2))))
+  |> should.equal(Ok(#(dynamic.from(1), dynamic.from(2))))
 
-  tuple(1, "")
+  #(1, "")
   |> dynamic.from
   |> dynamic.tuple2
-  |> should.equal(Ok(tuple(dynamic.from(1), dynamic.from(""))))
+  |> should.equal(Ok(#(dynamic.from(1), dynamic.from(""))))
 
-  tuple(1, 2, 3)
+  #(1, 2, 3)
   |> dynamic.from
   |> dynamic.tuple2
   |> should.equal(Error("Expected a 2 element tuple, got a 3 element tuple"))
@@ -330,22 +330,22 @@ pub fn tuple2_test() {
 }
 
 pub fn typed_tuple2_test() {
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-  |> should.equal(Ok(tuple(1, 2)))
+  |> should.equal(Ok(#(1, 2)))
 
-  tuple(1, "")
+  #(1, "")
   |> dynamic.from
   |> dynamic.typed_tuple2(dynamic.int, dynamic.string)
-  |> should.equal(Ok(tuple(1, "")))
+  |> should.equal(Ok(#(1, "")))
 
-  tuple(1, "")
+  #(1, "")
   |> dynamic.from
   |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
   |> should.equal(Error("Expected an int, got a binary"))
 
-  tuple(1, 2, 3)
+  #(1, 2, 3)
   |> dynamic.from
   |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
   |> should.equal(Error("Expected a 2 element tuple, got a 3 element tuple"))
@@ -357,17 +357,17 @@ pub fn typed_tuple2_test() {
 }
 
 pub fn tuple3_test() {
-  tuple(1, 2, 3)
+  #(1, 2, 3)
   |> dynamic.from
   |> dynamic.tuple3
-  |> should.equal(Ok(tuple(dynamic.from(1), dynamic.from(2), dynamic.from(3))))
+  |> should.equal(Ok(#(dynamic.from(1), dynamic.from(2), dynamic.from(3))))
 
-  tuple(1, "", 3.0)
+  #(1, "", 3.0)
   |> dynamic.from
   |> dynamic.tuple3
-  |> should.equal(Ok(tuple(dynamic.from(1), dynamic.from(""), dynamic.from(3.0))))
+  |> should.equal(Ok(#(dynamic.from(1), dynamic.from(""), dynamic.from(3.0))))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.tuple3
   |> should.equal(Error("Expected a 3 element tuple, got a 2 element tuple"))
@@ -379,22 +379,22 @@ pub fn tuple3_test() {
 }
 
 pub fn typed_tuple3_test() {
-  tuple(1, 2, 3)
+  #(1, 2, 3)
   |> dynamic.from
   |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-  |> should.equal(Ok(tuple(1, 2, 3)))
+  |> should.equal(Ok(#(1, 2, 3)))
 
-  tuple(1, "", 3.0)
+  #(1, "", 3.0)
   |> dynamic.from
   |> dynamic.typed_tuple3(dynamic.int, dynamic.string, dynamic.float)
-  |> should.equal(Ok(tuple(1, "", 3.0)))
+  |> should.equal(Ok(#(1, "", 3.0)))
 
-  tuple(1, 2, "")
+  #(1, 2, "")
   |> dynamic.from
   |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error("Expected an int, got a binary"))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error("Expected a 3 element tuple, got a 2 element tuple"))
@@ -406,27 +406,27 @@ pub fn typed_tuple3_test() {
 }
 
 pub fn tuple4_test() {
-  tuple(1, 2, 3, 4)
+  #(1, 2, 3, 4)
   |> dynamic.from
   |> dynamic.tuple4
-  |> should.equal(Ok(tuple(
+  |> should.equal(Ok(#(
     dynamic.from(1),
     dynamic.from(2),
     dynamic.from(3),
     dynamic.from(4),
   )))
 
-  tuple(1, "", 3.0, 4)
+  #(1, "", 3.0, 4)
   |> dynamic.from
   |> dynamic.tuple4
-  |> should.equal(Ok(tuple(
+  |> should.equal(Ok(#(
     dynamic.from(1),
     dynamic.from(""),
     dynamic.from(3.0),
     dynamic.from(4),
   )))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.tuple4
   |> should.equal(Error("Expected a 4 element tuple, got a 2 element tuple"))
@@ -438,12 +438,12 @@ pub fn tuple4_test() {
 }
 
 pub fn typed_tuple4_test() {
-  tuple(1, 2, 3, 4)
+  #(1, 2, 3, 4)
   |> dynamic.from
   |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-  |> should.equal(Ok(tuple(1, 2, 3, 4)))
+  |> should.equal(Ok(#(1, 2, 3, 4)))
 
-  tuple(1, "", 3.0, 4)
+  #(1, "", 3.0, 4)
   |> dynamic.from
   |> dynamic.typed_tuple4(
     dynamic.int,
@@ -451,14 +451,14 @@ pub fn typed_tuple4_test() {
     dynamic.float,
     dynamic.int,
   )
-  |> should.equal(Ok(tuple(1, "", 3.0, 4)))
+  |> should.equal(Ok(#(1, "", 3.0, 4)))
 
-  tuple(1, 2, 3, "")
+  #(1, 2, 3, "")
   |> dynamic.from
   |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error("Expected an int, got a binary"))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error("Expected a 4 element tuple, got a 2 element tuple"))
@@ -470,10 +470,10 @@ pub fn typed_tuple4_test() {
 }
 
 pub fn tuple5_test() {
-  tuple(1, 2, 3, 4, 5)
+  #(1, 2, 3, 4, 5)
   |> dynamic.from
   |> dynamic.tuple5
-  |> should.equal(Ok(tuple(
+  |> should.equal(Ok(#(
     dynamic.from(1),
     dynamic.from(2),
     dynamic.from(3),
@@ -481,10 +481,10 @@ pub fn tuple5_test() {
     dynamic.from(5),
   )))
 
-  tuple(1, "", 3.0, 4, 5)
+  #(1, "", 3.0, 4, 5)
   |> dynamic.from
   |> dynamic.tuple5
-  |> should.equal(Ok(tuple(
+  |> should.equal(Ok(#(
     dynamic.from(1),
     dynamic.from(""),
     dynamic.from(3.0),
@@ -492,7 +492,7 @@ pub fn tuple5_test() {
     dynamic.from(5),
   )))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.tuple5
   |> should.equal(Error("Expected a 5 element tuple, got a 2 element tuple"))
@@ -504,7 +504,7 @@ pub fn tuple5_test() {
 }
 
 pub fn typed_tuple5_test() {
-  tuple(1, 2, 3, 4, 5)
+  #(1, 2, 3, 4, 5)
   |> dynamic.from
   |> dynamic.typed_tuple5(
     dynamic.int,
@@ -513,9 +513,9 @@ pub fn typed_tuple5_test() {
     dynamic.int,
     dynamic.int,
   )
-  |> should.equal(Ok(tuple(1, 2, 3, 4, 5)))
+  |> should.equal(Ok(#(1, 2, 3, 4, 5)))
 
-  tuple(1, "", 3.0, 4, 5)
+  #(1, "", 3.0, 4, 5)
   |> dynamic.from
   |> dynamic.typed_tuple5(
     dynamic.int,
@@ -524,9 +524,9 @@ pub fn typed_tuple5_test() {
     dynamic.int,
     dynamic.int,
   )
-  |> should.equal(Ok(tuple(1, "", 3.0, 4, 5)))
+  |> should.equal(Ok(#(1, "", 3.0, 4, 5)))
 
-  tuple(1, 2, 3, 4, "")
+  #(1, 2, 3, 4, "")
   |> dynamic.from
   |> dynamic.typed_tuple5(
     dynamic.int,
@@ -537,7 +537,7 @@ pub fn typed_tuple5_test() {
   )
   |> should.equal(Error("Expected an int, got a binary"))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.typed_tuple5(
     dynamic.int,
@@ -561,10 +561,10 @@ pub fn typed_tuple5_test() {
 }
 
 pub fn tuple6_test() {
-  tuple(1, 2, 3, 4, 5, 6)
+  #(1, 2, 3, 4, 5, 6)
   |> dynamic.from
   |> dynamic.tuple6
-  |> should.equal(Ok(tuple(
+  |> should.equal(Ok(#(
     dynamic.from(1),
     dynamic.from(2),
     dynamic.from(3),
@@ -573,10 +573,10 @@ pub fn tuple6_test() {
     dynamic.from(6),
   )))
 
-  tuple(1, "", 3.0, 4, 5, 6)
+  #(1, "", 3.0, 4, 5, 6)
   |> dynamic.from
   |> dynamic.tuple6
-  |> should.equal(Ok(tuple(
+  |> should.equal(Ok(#(
     dynamic.from(1),
     dynamic.from(""),
     dynamic.from(3.0),
@@ -585,7 +585,7 @@ pub fn tuple6_test() {
     dynamic.from(6),
   )))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.tuple6
   |> should.equal(Error("Expected a 6 element tuple, got a 2 element tuple"))
@@ -597,7 +597,7 @@ pub fn tuple6_test() {
 }
 
 pub fn typed_tuple6_test() {
-  tuple(1, 2, 3, 4, 5, 6)
+  #(1, 2, 3, 4, 5, 6)
   |> dynamic.from
   |> dynamic.typed_tuple6(
     dynamic.int,
@@ -607,9 +607,9 @@ pub fn typed_tuple6_test() {
     dynamic.int,
     dynamic.int,
   )
-  |> should.equal(Ok(tuple(1, 2, 3, 4, 5, 6)))
+  |> should.equal(Ok(#(1, 2, 3, 4, 5, 6)))
 
-  tuple(1, "", 3.0, 4, 5, 6)
+  #(1, "", 3.0, 4, 5, 6)
   |> dynamic.from
   |> dynamic.typed_tuple6(
     dynamic.int,
@@ -619,9 +619,9 @@ pub fn typed_tuple6_test() {
     dynamic.int,
     dynamic.int,
   )
-  |> should.equal(Ok(tuple(1, "", 3.0, 4, 5, 6)))
+  |> should.equal(Ok(#(1, "", 3.0, 4, 5, 6)))
 
-  tuple(1, 2, 3, 4, 5, "")
+  #(1, 2, 3, 4, 5, "")
   |> dynamic.from
   |> dynamic.typed_tuple6(
     dynamic.int,
@@ -633,7 +633,7 @@ pub fn typed_tuple6_test() {
   )
   |> should.equal(Error("Expected an int, got a binary"))
 
-  tuple(1, 2)
+  #(1, 2)
   |> dynamic.from
   |> dynamic.typed_tuple6(
     dynamic.int,
@@ -710,7 +710,7 @@ pub fn result_test() {
 
   let tag = atom.create_from_string("bad")
 
-  tuple(tag, "value")
+  #(tag, "value")
   |> dynamic.from
   |> dynamic.result
   |> should.equal(Error("Expected a tag of \"ok\" or \"error\", got \"bad\""))

--- a/test/gleam/function_test.gleam
+++ b/test/gleam/function_test.gleam
@@ -103,9 +103,9 @@ pub fn identity_test() {
   |> function.identity
   |> should.equal([])
 
-  tuple(1, 2.0)
+  #(1, 2.0)
   |> function.identity
-  |> should.equal(tuple(1, 2.0))
+  |> should.equal(#(1, 2.0))
 }
 
 external fn throw(a) -> Nil =

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -261,7 +261,7 @@ pub fn index_test() {
   iterator.from_list(["a", "b", "c"])
   |> iterator.index
   |> iterator.to_list
-  |> should.equal([tuple(0, "a"), tuple(1, "b"), tuple(2, "c")])
+  |> should.equal([#(0, "a"), #(1, "b"), #(2, "c")])
 }
 
 pub fn iterate_test() {
@@ -297,7 +297,7 @@ pub fn zip_test() {
   iterator.from_list(["a", "b", "c"])
   |> iterator.zip(iterator.range(20, 30))
   |> iterator.to_list
-  |> should.equal([tuple("a", 20), tuple("b", 21), tuple("c", 22)])
+  |> should.equal([#("a", 20), #("b", 21), #("c", 22)])
 }
 
 pub fn chunk_test() {
@@ -367,11 +367,7 @@ pub fn all_test() {
 pub fn group_test() {
   iterator.from_list([1, 2, 3, 4, 5, 6])
   |> iterator.group(by: fn(n) { n % 3 })
-  |> should.equal(map.from_list([
-    tuple(0, [3, 6]),
-    tuple(1, [1, 4]),
-    tuple(2, [2, 5]),
-  ]))
+  |> should.equal(map.from_list([#(0, [3, 6]), #(1, [1, 4]), #(2, [2, 5])]))
 }
 
 pub fn reduce_test() {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -101,8 +101,8 @@ pub fn map_test() {
 
 pub fn map_fold_test() {
   [1, 2, 3, 4]
-  |> list.map_fold(from: 0, with: fn(i, acc) { tuple(i * 2, acc + i) })
-  |> should.equal(tuple([2, 4, 6, 8], 10))
+  |> list.map_fold(from: 0, with: fn(i, acc) { #(i * 2, acc + i) })
+  |> should.equal(#([2, 4, 6, 8], 10))
 }
 
 pub fn try_map_test() {
@@ -179,8 +179,8 @@ pub fn fold_right_test() {
 
 pub fn index_fold_test() {
   ["a", "b", "c"]
-  |> list.index_fold([], fn(ix, i, acc) { [tuple(ix, i), ..acc] })
-  |> should.equal([tuple(2, "c"), tuple(1, "b"), tuple(0, "a")])
+  |> list.index_fold([], fn(ix, i, acc) { [#(ix, i), ..acc] })
+  |> should.equal([#(2, "c"), #(1, "b"), #(0, "a")])
 }
 
 pub fn fold_until_test() {
@@ -290,13 +290,13 @@ pub fn zip_test() {
   |> should.equal([])
 
   list.zip([1, 2, 3], [4, 5, 6])
-  |> should.equal([tuple(1, 4), tuple(2, 5), tuple(3, 6)])
+  |> should.equal([#(1, 4), #(2, 5), #(3, 6)])
 
   list.zip([5, 6], [1, 2, 3])
-  |> should.equal([tuple(5, 1), tuple(6, 2)])
+  |> should.equal([#(5, 1), #(6, 2)])
 
   list.zip([5, 6, 7], [1, 2])
-  |> should.equal([tuple(5, 1), tuple(6, 2)])
+  |> should.equal([#(5, 1), #(6, 2)])
 }
 
 pub fn strict_zip_test() {
@@ -307,7 +307,7 @@ pub fn strict_zip_test() {
   |> should.equal(Error(list.LengthMismatch))
 
   list.strict_zip([1, 2, 3], [4, 5, 6])
-  |> should.equal(Ok([tuple(1, 4), tuple(2, 5), tuple(3, 6)]))
+  |> should.equal(Ok([#(1, 4), #(2, 5), #(3, 6)]))
 
   list.strict_zip([5, 6], [1, 2, 3])
   |> should.equal(Error(list.LengthMismatch))
@@ -317,11 +317,11 @@ pub fn strict_zip_test() {
 }
 
 pub fn unzip_test() {
-  list.unzip([tuple(1, 2), tuple(3, 4)])
-  |> should.equal(tuple([1, 3], [2, 4]))
+  list.unzip([#(1, 2), #(3, 4)])
+  |> should.equal(#([1, 3], [2, 4]))
 
   list.unzip([])
-  |> should.equal(tuple([], []))
+  |> should.equal(#([], []))
 }
 
 pub fn intersperse_test() {
@@ -379,8 +379,8 @@ pub fn sort_test() {
 }
 
 pub fn index_map_test() {
-  list.index_map([3, 4, 5], fn(i, x) { tuple(i, x) })
-  |> should.equal([tuple(0, 3), tuple(1, 4), tuple(2, 5)])
+  list.index_map([3, 4, 5], fn(i, x) { #(i, x) })
+  |> should.equal([#(0, 3), #(1, 4), #(2, 5)])
 
   let f = fn(i, x) { string.append(x, int.to_string(i)) }
   list.index_map(["a", "b", "c"], f)
@@ -424,53 +424,53 @@ pub fn repeat_test() {
 pub fn split_test() {
   []
   |> list.split(0)
-  |> should.equal(tuple([], []))
+  |> should.equal(#([], []))
 
   [0, 1, 2, 3, 4]
   |> list.split(0)
-  |> should.equal(tuple([], [0, 1, 2, 3, 4]))
+  |> should.equal(#([], [0, 1, 2, 3, 4]))
 
   [0, 1, 2, 3, 4]
   |> list.split(-2)
-  |> should.equal(tuple([], [0, 1, 2, 3, 4]))
+  |> should.equal(#([], [0, 1, 2, 3, 4]))
 
   [0, 1, 2, 3, 4]
   |> list.split(1)
-  |> should.equal(tuple([0], [1, 2, 3, 4]))
+  |> should.equal(#([0], [1, 2, 3, 4]))
 
   [0, 1, 2, 3, 4]
   |> list.split(3)
-  |> should.equal(tuple([0, 1, 2], [3, 4]))
+  |> should.equal(#([0, 1, 2], [3, 4]))
 
   [0, 1, 2, 3, 4]
   |> list.split(9)
-  |> should.equal(tuple([0, 1, 2, 3, 4], []))
+  |> should.equal(#([0, 1, 2, 3, 4], []))
 }
 
 pub fn split_while_test() {
   []
   |> list.split_while(fn(x) { x <= 5 })
-  |> should.equal(tuple([], []))
+  |> should.equal(#([], []))
 
   [1, 2, 3, 4, 5]
   |> list.split_while(fn(x) { x <= 5 })
-  |> should.equal(tuple([1, 2, 3, 4, 5], []))
+  |> should.equal(#([1, 2, 3, 4, 5], []))
 
   [1, 2, 3, 4, 5]
   |> list.split_while(fn(x) { x == 2 })
-  |> should.equal(tuple([], [1, 2, 3, 4, 5]))
+  |> should.equal(#([], [1, 2, 3, 4, 5]))
 
   [1, 2, 3, 4, 5]
   |> list.split_while(fn(x) { x <= 3 })
-  |> should.equal(tuple([1, 2, 3], [4, 5]))
+  |> should.equal(#([1, 2, 3], [4, 5]))
 
   [1, 2, 3, 4, 5]
   |> list.split_while(fn(x) { x <= -3 })
-  |> should.equal(tuple([], [1, 2, 3, 4, 5]))
+  |> should.equal(#([], [1, 2, 3, 4, 5]))
 }
 
 pub fn key_find_test() {
-  let proplist = [tuple(0, "1"), tuple(1, "2")]
+  let proplist = [#(0, "1"), #(1, "2")]
 
   proplist
   |> list.key_find(0)
@@ -487,7 +487,7 @@ pub fn key_find_test() {
 
 pub fn pop_test() {
   list.pop([1, 2, 3], fn(x) { x > 2 })
-  |> should.equal(Ok(tuple(3, [1, 2])))
+  |> should.equal(Ok(#(3, [1, 2])))
 
   list.pop([1, 2, 3], fn(x) { x > 4 })
   |> should.equal(Error(Nil))
@@ -498,7 +498,7 @@ pub fn pop_test() {
 
 pub fn pop_map_test() {
   list.pop_map(["foo", "2", "3"], int.parse)
-  |> should.equal(Ok(tuple(2, ["foo", "3"])))
+  |> should.equal(Ok(#(2, ["foo", "3"])))
 
   list.pop_map(["foo", "bar"], int.parse)
   |> should.equal(Error(Nil))
@@ -508,30 +508,30 @@ pub fn pop_map_test() {
 }
 
 pub fn key_pop_test() {
-  list.key_pop([tuple("a", 0), tuple("b", 1)], "a")
-  |> should.equal(Ok(tuple(0, [tuple("b", 1)])))
+  list.key_pop([#("a", 0), #("b", 1)], "a")
+  |> should.equal(Ok(#(0, [#("b", 1)])))
 
-  list.key_pop([tuple("a", 0), tuple("b", 1)], "b")
-  |> should.equal(Ok(tuple(1, [tuple("a", 0)])))
+  list.key_pop([#("a", 0), #("b", 1)], "b")
+  |> should.equal(Ok(#(1, [#("a", 0)])))
 
-  list.key_pop([tuple("a", 0), tuple("b", 1)], "c")
+  list.key_pop([#("a", 0), #("b", 1)], "c")
   |> should.equal(Error(Nil))
 }
 
 pub fn key_set_test() {
-  [tuple(5, 0), tuple(4, 1)]
+  [#(5, 0), #(4, 1)]
   |> list.key_set(4, 100)
-  |> should.equal([tuple(5, 0), tuple(4, 100)])
+  |> should.equal([#(5, 0), #(4, 100)])
 
-  [tuple(5, 0), tuple(4, 1)]
+  [#(5, 0), #(4, 1)]
   |> list.key_set(1, 100)
-  |> should.equal([tuple(5, 0), tuple(4, 1), tuple(1, 100)])
+  |> should.equal([#(5, 0), #(4, 1), #(1, 100)])
 }
 
 pub fn partition_test() {
   [1, 2, 3, 4, 5, 6, 7]
   |> list.partition(int.is_odd)
-  |> should.equal(tuple([1, 3, 5, 7], [2, 4, 6]))
+  |> should.equal(#([1, 3, 5, 7], [2, 4, 6]))
 }
 
 pub fn permutations_test() {
@@ -578,7 +578,7 @@ pub fn window_test() {
 pub fn window_by_2_test() {
   [1, 2, 3, 4]
   |> list.window_by_2
-  |> should.equal([tuple(1, 2), tuple(2, 3), tuple(3, 4)])
+  |> should.equal([#(1, 2), #(2, 3), #(3, 4)])
 
   [1]
   |> list.window_by_2
@@ -679,18 +679,11 @@ pub fn combination_pairs_test() {
   |> should.equal([])
 
   list.combination_pairs([1, 2])
-  |> should.equal([tuple(1, 2)])
+  |> should.equal([#(1, 2)])
 
   list.combination_pairs([1, 2, 3])
-  |> should.equal([tuple(1, 2), tuple(1, 3), tuple(2, 3)])
+  |> should.equal([#(1, 2), #(1, 3), #(2, 3)])
 
   list.combination_pairs([1, 2, 3, 4])
-  |> should.equal([
-    tuple(1, 2),
-    tuple(1, 3),
-    tuple(1, 4),
-    tuple(2, 3),
-    tuple(2, 4),
-    tuple(3, 4),
-  ])
+  |> should.equal([#(1, 2), #(1, 3), #(1, 4), #(2, 3), #(2, 4), #(3, 4)])
 }

--- a/test/gleam/map_test.gleam
+++ b/test/gleam/map_test.gleam
@@ -3,14 +3,14 @@ import gleam/should
 import gleam/map
 
 pub fn from_list_test() {
-  [tuple(4, 0), tuple(1, 0)]
+  [#(4, 0), #(1, 0)]
   |> map.from_list
   |> map.size
   |> should.equal(2)
 
-  [tuple(1, 0), tuple(1, 1)]
+  [#(1, 0), #(1, 1)]
   |> map.from_list
-  |> should.equal(map.from_list([tuple(1, 1)]))
+  |> should.equal(map.from_list([#(1, 1)]))
 }
 
 pub fn has_key_test() {
@@ -19,17 +19,17 @@ pub fn has_key_test() {
   |> map.has_key(1)
   |> should.be_false
 
-  [tuple(1, 0)]
+  [#(1, 0)]
   |> map.from_list
   |> map.has_key(1)
   |> should.be_true
 
-  [tuple(4, 0), tuple(1, 0)]
+  [#(4, 0), #(1, 0)]
   |> map.from_list
   |> map.has_key(1)
   |> should.be_true
 
-  [tuple(4, 0), tuple(1, 0)]
+  [#(4, 0), #(1, 0)]
   |> map.from_list
   |> map.has_key(0)
   |> should.be_false
@@ -46,7 +46,7 @@ pub fn new_test() {
 }
 
 pub fn get_test() {
-  let proplist = [tuple(4, 0), tuple(1, 1)]
+  let proplist = [#(4, 0), #(1, 1)]
   let m = map.from_list(proplist)
 
   m
@@ -67,76 +67,66 @@ pub fn insert_test() {
   |> map.insert("a", 0)
   |> map.insert("b", 1)
   |> map.insert("c", 2)
-  |> should.equal(map.from_list([tuple("a", 0), tuple("b", 1), tuple("c", 2)]))
+  |> should.equal(map.from_list([#("a", 0), #("b", 1), #("c", 2)]))
 }
 
 pub fn map_values_test() {
-  [tuple(1, 0), tuple(2, 1), tuple(3, 2)]
+  [#(1, 0), #(2, 1), #(3, 2)]
   |> map.from_list
   |> map.map_values(fn(k, v) { k + v })
-  |> should.equal(map.from_list([tuple(1, 1), tuple(2, 3), tuple(3, 5)]))
+  |> should.equal(map.from_list([#(1, 1), #(2, 3), #(3, 5)]))
 }
 
 pub fn keys_test() {
-  [tuple("a", 0), tuple("b", 1), tuple("c", 2)]
+  [#("a", 0), #("b", 1), #("c", 2)]
   |> map.from_list
   |> map.keys
   |> should.equal(["a", "b", "c"])
 }
 
 pub fn values_test() {
-  [tuple("a", 0), tuple("b", 1), tuple("c", 2)]
+  [#("a", 0), #("b", 1), #("c", 2)]
   |> map.from_list
   |> map.values
   |> should.equal([0, 1, 2])
 }
 
 pub fn take_test() {
-  [tuple("a", 0), tuple("b", 1), tuple("c", 2)]
+  [#("a", 0), #("b", 1), #("c", 2)]
   |> map.from_list
   |> map.take(["a", "b", "d"])
-  |> should.equal(map.from_list([tuple("a", 0), tuple("b", 1)]))
+  |> should.equal(map.from_list([#("a", 0), #("b", 1)]))
 }
 
 pub fn drop_test() {
-  [tuple("a", 0), tuple("b", 1), tuple("c", 2)]
+  [#("a", 0), #("b", 1), #("c", 2)]
   |> map.from_list
   |> map.drop(["a", "b", "d"])
-  |> should.equal(map.from_list([tuple("c", 2)]))
+  |> should.equal(map.from_list([#("c", 2)]))
 }
 
 pub fn merge_test() {
-  let a = map.from_list([tuple("a", 2), tuple("c", 4), tuple("d", 3)])
+  let a = map.from_list([#("a", 2), #("c", 4), #("d", 3)])
 
-  let b = map.from_list([tuple("a", 0), tuple("b", 1), tuple("c", 2)])
+  let b = map.from_list([#("a", 0), #("b", 1), #("c", 2)])
 
   map.merge(a, b)
-  |> should.equal(map.from_list([
-    tuple("a", 0),
-    tuple("b", 1),
-    tuple("c", 2),
-    tuple("d", 3),
-  ]))
+  |> should.equal(map.from_list([#("a", 0), #("b", 1), #("c", 2), #("d", 3)]))
 
   map.merge(b, a)
-  |> should.equal(map.from_list([
-    tuple("a", 2),
-    tuple("b", 1),
-    tuple("c", 4),
-    tuple("d", 3),
-  ]))
+  |> should.equal(map.from_list([#("a", 2), #("b", 1), #("c", 4), #("d", 3)]))
 }
 
 pub fn delete_test() {
-  [tuple("a", 0), tuple("b", 1), tuple("c", 2)]
+  [#("a", 0), #("b", 1), #("c", 2)]
   |> map.from_list
   |> map.delete("a")
   |> map.delete("d")
-  |> should.equal(map.from_list([tuple("b", 1), tuple("c", 2)]))
+  |> should.equal(map.from_list([#("b", 1), #("c", 2)]))
 }
 
 pub fn update_test() {
-  let dict = map.from_list([tuple("a", 0), tuple("b", 1), tuple("c", 2)])
+  let dict = map.from_list([#("a", 0), #("b", 1), #("c", 2)])
 
   let inc_or_zero = fn(x) {
     case x {
@@ -147,25 +137,19 @@ pub fn update_test() {
 
   dict
   |> map.update("a", inc_or_zero)
-  |> should.equal(map.from_list([tuple("a", 1), tuple("b", 1), tuple("c", 2)]))
+  |> should.equal(map.from_list([#("a", 1), #("b", 1), #("c", 2)]))
 
   dict
   |> map.update("b", inc_or_zero)
-  |> should.equal(map.from_list([tuple("a", 0), tuple("b", 2), tuple("c", 2)]))
+  |> should.equal(map.from_list([#("a", 0), #("b", 2), #("c", 2)]))
 
   dict
   |> map.update("z", inc_or_zero)
-  |> should.equal(map.from_list([
-    tuple("a", 0),
-    tuple("b", 1),
-    tuple("c", 2),
-    tuple("z", 0),
-  ]))
+  |> should.equal(map.from_list([#("a", 0), #("b", 1), #("c", 2), #("z", 0)]))
 }
 
 pub fn fold_test() {
-  let dict =
-    map.from_list([tuple("a", 0), tuple("b", 1), tuple("c", 2), tuple("d", 3)])
+  let dict = map.from_list([#("a", 0), #("b", 1), #("c", 2), #("d", 3)])
 
   let add = fn(_, v, acc) { v + acc }
 

--- a/test/gleam/os_test.gleam
+++ b/test/gleam/os_test.gleam
@@ -30,7 +30,7 @@ pub fn system_time_test() {
 pub fn erlang_timestamp_test() {
   // in microseconds
   let june_12_2020 = 1591966971000000
-  let tuple(mega_seconds, seconds, micro_seconds) = os.erlang_timestamp()
+  let #(mega_seconds, seconds, micro_seconds) = os.erlang_timestamp()
 
   let stamp_as_micro =
     { mega_seconds * 1_000_000 + seconds } * 1_000_000 + micro_seconds

--- a/test/gleam/pair_test.gleam
+++ b/test/gleam/pair_test.gleam
@@ -2,57 +2,57 @@ import gleam/should
 import gleam/pair
 
 pub fn first_test() {
-  tuple(1, 2)
+  #(1, 2)
   |> pair.first
   |> should.equal(1)
 
-  tuple("abc", [])
+  #("abc", [])
   |> pair.first
   |> should.equal("abc")
 }
 
 pub fn second_test() {
-  tuple(1, 2)
+  #(1, 2)
   |> pair.second
   |> should.equal(2)
 
-  tuple("abc", [])
+  #("abc", [])
   |> pair.second
   |> should.equal([])
 }
 
 pub fn swap_test() {
-  tuple(1, "2")
+  #(1, "2")
   |> pair.swap
-  |> should.equal(tuple("2", 1))
+  |> should.equal(#("2", 1))
 }
 
 pub fn map_first_test() {
   let inc = fn(a) { a + 1 }
-  pair.map_first(tuple(1, 2), inc)
-  |> should.equal(tuple(2, 2))
+  pair.map_first(#(1, 2), inc)
+  |> should.equal(#(2, 2))
 
-  pair.map_first(tuple(8, 2), inc)
-  |> should.equal(tuple(9, 2))
+  pair.map_first(#(8, 2), inc)
+  |> should.equal(#(9, 2))
 
-  pair.map_first(tuple(0, -2), inc)
-  |> should.equal(tuple(1, -2))
+  pair.map_first(#(0, -2), inc)
+  |> should.equal(#(1, -2))
 
-  pair.map_first(tuple(-10, 20), inc)
-  |> should.equal(tuple(-9, 20))
+  pair.map_first(#(-10, 20), inc)
+  |> should.equal(#(-9, 20))
 }
 
 pub fn map_second_test() {
   let dec = fn(a) { a - 1 }
-  pair.map_second(tuple(1, 2), dec)
-  |> should.equal(tuple(1, 1))
+  pair.map_second(#(1, 2), dec)
+  |> should.equal(#(1, 1))
 
-  pair.map_second(tuple(8, 2), dec)
-  |> should.equal(tuple(8, 1))
+  pair.map_second(#(8, 2), dec)
+  |> should.equal(#(8, 1))
 
-  pair.map_second(tuple(0, -2), dec)
-  |> should.equal(tuple(0, -3))
+  pair.map_second(#(0, -2), dec)
+  |> should.equal(#(0, -3))
 
-  pair.map_second(tuple(-10, 20), dec)
-  |> should.equal(tuple(-10, 19))
+  pair.map_second(#(-10, 20), dec)
+  |> should.equal(#(-10, 19))
 }

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -37,8 +37,8 @@ pub fn map_error_test() {
   |> should.equal(Ok(1))
 
   Error(1)
-  |> result.map_error(fn(x) { tuple("ok", x + 1) })
-  |> should.equal(Error(tuple("ok", 2)))
+  |> result.map_error(fn(x) { #("ok", x + 1) })
+  |> should.equal(Error(#("ok", 2)))
 }
 
 pub fn flatten_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -41,7 +41,7 @@ pub fn split_test() {
 pub fn split_once_test() {
   "Gleam,Erlang,Elixir"
   |> string.split_once(",")
-  |> should.equal(Ok(tuple("Gleam", "Erlang,Elixir")))
+  |> should.equal(Ok(#("Gleam", "Erlang,Elixir")))
 
   "Gleam"
   |> string.split_once(",")
@@ -292,11 +292,11 @@ pub fn pad_right_test() {
 pub fn pop_grapheme_test() {
   "gleam"
   |> string.pop_grapheme()
-  |> should.equal(Ok(tuple("g", "leam")))
+  |> should.equal(Ok(#("g", "leam")))
 
   "g"
   |> string.pop_grapheme()
-  |> should.equal(Ok(tuple("g", "")))
+  |> should.equal(Ok(#("g", "")))
 
   ""
   |> string.pop_grapheme()

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -66,13 +66,13 @@ pub fn path_only_uri_to_string_test() {
 
 pub fn parse_query_string_test() {
   assert Ok(parsed) = uri.parse_query("foo+bar=1&city=%C3%B6rebro")
-  should.equal(parsed, [tuple("foo bar", "1"), tuple("city", "örebro")])
+  should.equal(parsed, [#("foo bar", "1"), #("city", "örebro")])
 
   // Duplicates keys not overridden
   assert Ok(parsed) = uri.parse_query("a[]=1&a[]=2")
 
   parsed
-  |> should.equal([tuple("a[]", "1"), tuple("a[]", "2")])
+  |> should.equal([#("a[]", "1"), #("a[]", "2")])
 }
 
 pub fn parse_empty_query_string_test() {
@@ -82,7 +82,7 @@ pub fn parse_empty_query_string_test() {
 
 pub fn parse_query_string_with_empty_test() {
   uri.parse_query("present")
-  |> should.equal(Ok([tuple("present", "")]))
+  |> should.equal(Ok([#("present", "")]))
 }
 
 pub fn error_parsing_query_test() {
@@ -91,7 +91,7 @@ pub fn error_parsing_query_test() {
 
 pub fn query_to_string_test() {
   let query_string =
-    uri.query_to_string([tuple("foo bar", "1"), tuple("city", "örebro")])
+    uri.query_to_string([#("foo bar", "1"), #("city", "örebro")])
   should.equal(query_string, "foo+bar=1&city=%C3%B6rebro")
 }
 
@@ -102,37 +102,37 @@ pub fn empty_query_to_string_test() {
 
 fn percent_codec_fixtures() {
   [
-    tuple(" ", "+"),
-    tuple(",", "%2C"),
-    tuple(";", "%3B"),
-    tuple(":", "%3A"),
-    tuple("!", "%21"),
-    tuple("?", "%3F"),
-    tuple("'", "%27"),
-    tuple("(", "%28"),
-    tuple(")", "%29"),
-    tuple("[", "%5B"),
-    tuple("@", "%40"),
-    tuple("/", "%2F"),
-    tuple("\\", "%5C"),
-    tuple("&", "%26"),
-    tuple("#", "%23"),
-    tuple("=", "%3D"),
-    tuple("~", "%7E"),
-    tuple("ñ", "%C3%B1"),
+    #(" ", "+"),
+    #(",", "%2C"),
+    #(";", "%3B"),
+    #(":", "%3A"),
+    #("!", "%21"),
+    #("?", "%3F"),
+    #("'", "%27"),
+    #("(", "%28"),
+    #(")", "%29"),
+    #("[", "%5B"),
+    #("@", "%40"),
+    #("/", "%2F"),
+    #("\\", "%5C"),
+    #("&", "%26"),
+    #("#", "%23"),
+    #("=", "%3D"),
+    #("~", "%7E"),
+    #("ñ", "%C3%B1"),
     // Allowed chars
-    tuple("-", "-"),
-    tuple("_", "_"),
-    tuple(".", "."),
-    tuple("*", "*"),
-    tuple("100% great", "100%25+great"),
+    #("-", "-"),
+    #("_", "_"),
+    #(".", "."),
+    #("*", "*"),
+    #("100% great", "100%25+great"),
   ]
 }
 
 pub fn percent_encode_test() {
   percent_codec_fixtures()
   |> list.map(fn(t) {
-    let tuple(a, b) = t
+    let #(a, b) = t
     uri.percent_encode(a)
     |> should.equal(b)
   })
@@ -142,7 +142,7 @@ pub fn percent_encode_consistency_test() {
   let k = "foo bar[]"
   let v = "ñaña (,:*~)"
 
-  let query_string = uri.query_to_string([tuple(k, v)])
+  let query_string = uri.query_to_string([#(k, v)])
 
   let encoded_key = uri.percent_encode(k)
   let encoded_value = uri.percent_encode(v)
@@ -154,7 +154,7 @@ pub fn percent_encode_consistency_test() {
 pub fn percent_decode_test() {
   percent_codec_fixtures()
   |> list.map(fn(t) {
-    let tuple(a, b) = t
+    let #(a, b) = t
     uri.percent_decode(b)
     |> should.equal(Ok(a))
   })
@@ -169,7 +169,7 @@ pub fn percent_decode_consistency_test() {
   assert Ok(decoded_key) = uri.percent_decode(k)
   assert Ok(decoded_value) = uri.percent_decode(v)
 
-  should.equal(parsed, [tuple(decoded_key, decoded_value)])
+  should.equal(parsed, [#(decoded_key, decoded_value)])
 }
 
 pub fn parse_segments_test() {


### PR DESCRIPTION
Makes stdlib use new tuples and switches CI so that it tests with Gleam 0.15.0