### PR TITLE
Support unicode in env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - The `list` module gains the `interleave`, `flat_map` and `transpose` functions.
 - The `option` module gains the `all` and `values` functions.
+- The `os` module now uses unicode to encode/decode environment variables.
+  This fixes an issue when non-latin characters are present in environment.
 - The `result` module gains the `values` function.
 - All modules now use the new `#(a, b, ...)` tuple syntax.
 

--- a/src/gleam/os.gleam
+++ b/src/gleam/os.gleam
@@ -17,10 +17,10 @@ external fn os_unsetenv(key: CharList) -> Bool =
   "os" "unsetenv"
 
 external fn char_list_to_string(CharList) -> String =
-  "erlang" "list_to_binary"
+  "unicode" "characters_to_binary"
 
 external fn string_to_char_list(String) -> CharList =
-  "erlang" "binary_to_list"
+  "unicode" "characters_to_list"
 
 /// Returns all environment variables set on the system.
 pub fn get_env() -> Map(String, String) {

--- a/test/gleam/os_test.gleam
+++ b/test/gleam/os_test.gleam
@@ -15,6 +15,13 @@ pub fn env_test() {
   |> should.equal(Error(Nil))
 }
 
+pub fn unicode_test() {
+  os.insert_env("GLEAM_UNICODE_TEST", "Iñtërnâtiônà£ißætiøn☃💩")
+  os.get_env()
+  |> map.get("GLEAM_UNICODE_TEST")
+  |> should.equal(Ok("Iñtërnâtiônà£ißætiøn☃💩"))
+}
+
 pub fn system_time_test() {
   let june_12_2020 = 1591966971
   { os.system_time(os.Second) > june_12_2020 }


### PR DESCRIPTION
Closes #206 (hopefully)

Replaces string ↔️ char list functions with their unicode counterparts.

Adds a unit test (source: https://marekj.github.io/2013/07/09/unicode-for-testers)