### PR TITLE
Ignore local asdf config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _build
 *.iml
 rebar3.crashdump
 doc
+.tool-versions


### PR DESCRIPTION
Useful when testing with gleam compiled from the main branch