### PR TITLE
Remove redefinitions of types from the prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   of target specific versions in Erlang and JavaScript specific libraries.
 - The `map.update` function now uses `Option` rather than `Result`.
 - The `iterator` module gains the `fold_until` function.
+- Prelude types like `Result`, `List` etc. are no longer redefined in their stdlib modules.
 - All modules have been updated to work when running on both Erlang and
   JavaScript.
 

--- a/src/gleam/base.gleam
+++ b/src/gleam/base.gleam
@@ -1,5 +1,5 @@
 if erlang {
-  import gleam/bit_string.{BitString}
+  import gleam/bit_string
   import gleam/string
 
   external fn erl_encode64(BitString) -> String =

--- a/src/gleam/bit_builder.gleam
+++ b/src/gleam/bit_builder.gleam
@@ -1,5 +1,4 @@
 if erlang {
-  import gleam/bit_string.{BitString}
   import gleam/string_builder.{StringBuilder}
 
   /// BitBuilder is a type used for efficiently concatenating bits to create bit

--- a/src/gleam/bit_string.gleam
+++ b/src/gleam/bit_string.gleam
@@ -3,9 +3,6 @@
 //// encoded.
 
 if erlang {
-  pub type BitString =
-    BitString
-
   /// Converts a UTF-8 String type into a raw BitString type.
   ///
   pub external fn from_string(String) -> BitString =

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -1,16 +1,5 @@
 import gleam/order.{Order}
 
-/// A type with two possible values, True and False. Used to indicate whether
-/// things are... true or false!
-///
-/// Often is it clearer and offers more type safety to define a custom type
-/// than to use Bool. For example, rather than having a `is_teacher: Bool`
-/// field consider having a `role: SchoolRole` field where SchoolRole is a custom
-/// type that can be either Student or Teacher.
-///
-pub type Bool =
-  Bool
-
 /// Returns the opposite bool value.
 ///
 /// This is the same as the `!` or `not` operators in some other languages.

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -1,3 +1,11 @@
+//// A type with two possible values, True and False. Used to indicate whether
+//// things are... true or false!
+////
+//// Often is it clearer and offers more type safety to define a custom type
+//// than to use Bool. For example, rather than having a `is_teacher: Bool`
+//// field consider having a `role: SchoolRole` field where SchoolRole is a custom
+//// type that can be either Student or Teacher.
+
 import gleam/order.{Order}
 
 /// Returns the opposite bool value.

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -1,6 +1,6 @@
 if erlang {
   import gleam/atom
-  import gleam/bit_string.{BitString}
+  import gleam/bit_string
   import gleam/list
   import gleam/map.{Map}
   import gleam/option.{None, Option, Some}

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -3,9 +3,6 @@ import gleam/order.{Order}
 if erlang {
   import gleam/string_builder
 
-  pub type Float =
-    Float
-
   /// Attempts to parse a string as a float, returning `Error(Nil)` if it was not
   /// possible.
   ///

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -1,8 +1,5 @@
 import gleam/order.{Order}
 
-pub type Int =
-  Int
-
 /// Returns the absolute value of the input.
 ///
 /// ## Examples

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -22,9 +22,6 @@ import gleam/int
 import gleam/pair
 import gleam/order.{Order}
 
-pub type List(elements) =
-  List(elements)
-
 /// An error value returned by the `strict_zip` function.
 ///
 pub type LengthMismatch {

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -1,19 +1,5 @@
 import gleam/list
 
-/// Result represents the result of something that may succeed or not.
-/// `Ok` means it was successful, `Error` means it was not successful.
-///
-pub type Result(success, error) =
-  Result(success, error)
-
-/// Nil is a type used to represent the absence of something, similar to null
-/// or undefined in other languages.
-///
-/// Unlike some other languages values cannot be implicitly nil.
-///
-pub type Nil =
-  Nil
-
 /// Checks whether the result is an Ok value.
 ///
 /// ## Examples

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -1,3 +1,6 @@
+//// Result represents the result of something that may succeed or not.
+//// `Ok` means it was successful, `Error` means it was not successful.
+
 import gleam/list
 
 /// Checks whether the result is an Ok value.

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -11,13 +11,6 @@ if erlang {
   import gleam/dynamic.{Dynamic}
 }
 
-pub type String =
-  String
-
-/// A UtfCodepoint is the integer representation of a valid UTF codepoint
-pub type UtfCodepoint =
-  UtfCodepoint
-
 /// Determines if a string is empty.
 ///
 /// ## Examples

--- a/test/gleam/base_test.gleam
+++ b/test/gleam/base_test.gleam
@@ -1,6 +1,5 @@
 if erlang {
   import gleam/base
-  import gleam/bit_string.{BitString}
   import gleam/io
   import gleam/list
   import gleam/should


### PR DESCRIPTION
Cleans up stdlib since we now have importable prelude