### PR TITLE
Improve dynamic decoding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   stdlib modules.
 - All modules have been updated to work when running on both Erlang and
   JavaScript.
+- The `dynamic` module functions now return structured error values instead of a
+  string error description.
 
 ## v0.16.0 - 2021-06-17
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -61,13 +61,7 @@ if erlang {
   ///
   pub fn string(from: Dynamic) -> Result(String, DecodeError) {
     bit_string(from)
-    |> result.map_error(fn(error) {
-      case error {
-        DecodeError(_expected, found) ->
-          // Convert error so it doesn't say expected 'BitString'
-          DecodeError(expected: "String", found: found)
-      }
-    })
+    |> result.map_error(fn(error) { DecodeError(..error, expected: "String") })
     |> result.then(fn(raw) {
       case bit_string.to_string(raw) {
         Ok(string) -> Ok(string)

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -42,7 +42,7 @@ if erlang {
   ///    True
   ///
   ///    > bit_string(from(123))
-  ///    Error(DecoderError(expected: "bit_string", found: "int"))
+  ///    Error(DecoderError(expected: "BitString", found: "Int"))
   ///
   pub external fn bit_string(from: Dynamic) -> Result(BitString, DecodeError) =
     "gleam_stdlib" "decode_bit_string"
@@ -56,15 +56,21 @@ if erlang {
   ///    Ok("Hello")
   ///
   ///    > string(from(123))
-  ///    Error(DecoderError(expected: "string", found: "int"))
+  ///    Error(DecoderError(expected: "String", found: "Int"))
   ///
   pub fn string(from: Dynamic) -> Result(String, DecodeError) {
     bit_string(from)
+    |> result.map_error(fn(error) {
+      case error {
+        DecodeError(_expected, found) ->
+          // Convert error so it doesn't say expected 'BitString'
+          DecodeError(expected: "String", found: found)
+      }
+    })
     |> result.then(fn(raw) {
       case bit_string.to_string(raw) {
         Ok(string) -> Ok(string)
-        Error(Nil) ->
-          Error(DecodeError(expected: "string", found: "bit_string"))
+        Error(Nil) -> Error(DecodeError(expected: "String", found: "BitString"))
       }
     })
   }
@@ -78,7 +84,7 @@ if erlang {
   ///    Ok(123)
   ///
   ///    > int(from("Hello"))
-  ///    Error(DecoderError(expected: "int", found: "string"))
+  ///    Error(DecoderError(expected: "Int", found: "String"))
   ///
   pub external fn int(from: Dynamic) -> Result(Int, DecodeError) =
     "gleam_stdlib" "decode_int"
@@ -92,7 +98,7 @@ if erlang {
   ///    Ok(2.0)
   ///
   ///    > float(from(123))
-  ///    Error(DecoderError(expected: "float", found: "int"))
+  ///    Error(DecoderError(expected: "Float", found: "Int"))
   ///
   pub external fn float(from: Dynamic) -> Result(Float, DecodeError) =
     "gleam_stdlib" "decode_float"
@@ -106,7 +112,7 @@ if erlang {
   ///    Ok(True)
   ///
   ///    > bool(from(123))
-  ///    Error(DecoderError(expected: "bool", found: "int"))
+  ///    Error(DecoderError(expected: "bool", found: "Int"))
   ///
   pub external fn bool(from: Dynamic) -> Result(Bool, DecodeError) =
     "gleam_stdlib" "decode_bool"
@@ -122,7 +128,7 @@ if erlang {
   ///    True
   ///
   ///    > thunk(from(123))
-  ///    Error(DecoderError(expected: "zero arity function", found: "int"))
+  ///    Error(DecoderError(expected: "zero arity function", found: "Int"))
   ///
   pub external fn thunk(from: Dynamic) -> Result(fn() -> Dynamic, DecodeError) =
     "gleam_stdlib" "decode_thunk"
@@ -139,7 +145,7 @@ if erlang {
   ///    Ok([from("a"), from("b"), from("c")])
   ///
   ///    > list(1)
-  ///    Error(DecoderError(expected: "int", found: "binary"))
+  ///    Error(DecoderError(expected: "Int", found: "Int"))
   ///
   pub external fn list(from: Dynamic) -> Result(List(Dynamic), DecodeError) =
     "gleam_stdlib" "decode_list"
@@ -156,7 +162,7 @@ if erlang {
   ///    Ok(Error(from("boom")))
   ///
   ///    > result(from(123))
-  ///    Error(DecoderError(expected: "2 element tuple", found: "int"))
+  ///    Error(DecoderError(expected: "2 element tuple", found: "Int"))
   ///
   pub external fn result(
     Dynamic,
@@ -178,7 +184,7 @@ if erlang {
   ///    Ok(Error("boom"))
   ///
   ///    > typed_result(of: from(123), ok: int, error: string)
-  ///    Error(DecoderError(expected: "2 element tuple", found: "int"))
+  ///    Error(DecoderError(expected: "2 element tuple", found: "Int"))
   ///
   pub fn typed_result(
     of dynamic: Dynamic,
@@ -215,10 +221,10 @@ if erlang {
   ///    Ok(["a", "b", "c"])
   ///
   ///    > typed_list(from([1, 2, 3]), of: string)
-  ///    Error(DecoderError(expected: "int", found: "binary"))
+  ///    Error(DecoderError(expected: "String", found: "Int"))
   ///
   ///    > typed_list(from("ok"), of: string)
-  ///    Error(DecoderError(expected: "list", found: "binary"))
+  ///    Error(DecoderError(expected: "List", found: "String"))
   ///
   pub fn typed_list(
     from dynamic: Dynamic,
@@ -250,7 +256,7 @@ if erlang {
   ///    Ok(None)
   ///
   ///    > option(from(123), string)
-  ///    Error(DecoderError(expected: "bit_string", found: "int"))
+  ///    Error(DecoderError(expected: "BitString", found: "Int"))
   ///
   pub external fn optional(
     from: Dynamic,
@@ -270,7 +276,7 @@ if erlang {
   ///    Ok(Dynamic)
   ///
   ///    > field(from(123), "Hello")
-  ///    Error(DecoderError(expected: "map", found: "int"))
+  ///    Error(DecoderError(expected: "Map", found: "Int"))
   ///
   pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, DecodeError) =
     "gleam_stdlib" "decode_field"
@@ -287,7 +293,7 @@ if erlang {
   ///    Error(DecoderError(expected: "3 element tuple", found: "2 element tuple"))
   ///
   ///    > element(from(""), 2)
-  ///    Error(DecoderError(expected: "tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "Tuple", found: "String"))
   ///
   pub external fn element(
     from: Dynamic,
@@ -309,7 +315,7 @@ if erlang {
   ///    Error(DecoderError(expected: "2 element tuple", found: "3 element tuple"))
   ///
   ///    > tuple2(from(""))
-  ///    Error(DecoderError(expected: "2 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "2 element tuple", found: "String"))
   ///
   pub external fn tuple2(
     from: Dynamic,
@@ -334,7 +340,7 @@ if erlang {
   ///    Error(DecoderError(expected: "2 element tuple", found: "3 element tuple"))
   ///
   ///    > typed_tuple2(from(""), int, float)
-  ///    Error(DecoderError(expected: "2 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "2 element tuple", found: "String"))
   ///
   pub fn typed_tuple2(
     from tup: Dynamic,
@@ -361,7 +367,7 @@ if erlang {
   ///    Error(DecoderError(expected: "3 element tuple", found: "3 element tuple"))
   ///
   ///    > tuple3(from(""))
-  ///    Error(DecoderError(expected: "3 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "3 element tuple", found: "String"))
   ///
   pub external fn tuple3(
     from: Dynamic,
@@ -386,7 +392,7 @@ if erlang {
   ///    Error(DecoderError(expected: "3 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple3(from(""), int, float, string)
-  ///    Error(DecoderError(expected: "3 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "3 element tuple", found: "String"))
   ///
   pub fn typed_tuple3(
     from tup: Dynamic,
@@ -415,7 +421,7 @@ if erlang {
   ///    Error(DecoderError(expected: "4 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple4(from(""))
-  ///    Error(DecoderError(expected: "4 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "4 element tuple", found: "String"))
   ///
   pub external fn tuple4(
     from: Dynamic,
@@ -441,7 +447,7 @@ if erlang {
   ///    Error(DecoderError(expected: "4 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple4(from(""), int, float, string, int)
-  ///    Error(DecoderError(expected: "4 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "4 element tuple", found: "String"))
   ///
   pub fn typed_tuple4(
     from tup: Dynamic,
@@ -472,7 +478,7 @@ if erlang {
   ///    Error(DecoderError(expected: "5 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple5(from(""))
-  ///    Error(DecoderError(expected: "5 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "5 element tuple", found: "String"))
   ///
   pub external fn tuple5(
     from: Dynamic,
@@ -497,7 +503,7 @@ if erlang {
   ///    Error(DecoderError(expected: "5 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple5(from(""), int, float, string, int, int)
-  ///    Error(DecoderError(expected: "5 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "5 element tuple", found: "String"))
   ///
   pub fn typed_tuple5(
     from tup: Dynamic,
@@ -530,7 +536,7 @@ if erlang {
   ///    Error(DecoderError(expected: "6 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple6(from(""))
-  ///    Error(DecoderError(expected: "6 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "6 element tuple", found: "String"))
   ///
   pub external fn tuple6(
     from: Dynamic,
@@ -558,7 +564,7 @@ if erlang {
   ///    Error(DecoderError(expected: "6 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple6(from(""), int, float, string, int, int, int)
-  ///    Error(DecoderError(expected: "6 element tuple", found: "binary"))
+  ///    Error(DecoderError(expected: "6 element tuple", found: "String"))
   ///
   pub fn typed_tuple6(
     from tup: Dynamic,
@@ -588,10 +594,10 @@ if erlang {
   ///    Ok(map.new())
   ///
   ///    > map(from(1))
-  ///    Error(DecoderError(expected: "map", found: "int"))
+  ///    Error(DecoderError(expected: "Map", found: "Int"))
   ///
   ///    > map(from(""))
-  ///    Error(DecoderError(expected: "map", found: "binary"))
+  ///    Error(DecoderError(expected: "Map", found: "String"))
   ///
   pub external fn map(
     from: Dynamic,

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -12,7 +12,7 @@ if erlang {
   pub external type Dynamic
 
   pub type DecodeError {
-    DecodeError(expected: String, got: String)
+    DecodeError(expected: String, found: String)
   }
 
   pub type Decoder(t) =
@@ -42,7 +42,7 @@ if erlang {
   ///    True
   ///
   ///    > bit_string(from(123))
-  ///    Error("Expected a BitString, got `123`")
+  ///    Error("Expected a BitString, found `123`")
   ///
   pub external fn bit_string(from: Dynamic) -> Result(BitString, DecodeError) =
     "gleam_stdlib" "decode_bit_string"
@@ -56,14 +56,15 @@ if erlang {
   ///    Ok("Hello")
   ///
   ///    > string(from(123))
-  ///    Error("Expected a String, got `123`")
+  ///    Error("Expected a String, found `123`")
   ///
   pub fn string(from: Dynamic) -> Result(String, DecodeError) {
     bit_string(from)
     |> result.then(fn(raw) {
       case bit_string.to_string(raw) {
         Ok(string) -> Ok(string)
-        Error(Nil) -> Error(DecodeError(expected: "string", got: "bit_string"))
+        Error(Nil) ->
+          Error(DecodeError(expected: "string", found: "bit_string"))
       }
     })
   }
@@ -77,7 +78,7 @@ if erlang {
   ///    Ok(123)
   ///
   ///    > int(from("Hello"))
-  ///    Error("Expected an Int, got `\"Hello World\"`")
+  ///    Error("Expected an Int, found `\"Hello World\"`")
   ///
   pub external fn int(from: Dynamic) -> Result(Int, DecodeError) =
     "gleam_stdlib" "decode_int"
@@ -91,7 +92,7 @@ if erlang {
   ///    Ok(2.0)
   ///
   ///    > float(from(123))
-  ///    Error("Expected a Float, got `123`")
+  ///    Error("Expected a Float, found `123`")
   ///
   pub external fn float(from: Dynamic) -> Result(Float, DecodeError) =
     "gleam_stdlib" "decode_float"
@@ -105,7 +106,7 @@ if erlang {
   ///    Ok(True)
   ///
   ///    > bool(from(123))
-  ///    Error("Expected a Bool, got `123`")
+  ///    Error("Expected a Bool, found `123`")
   ///
   pub external fn bool(from: Dynamic) -> Result(Bool, DecodeError) =
     "gleam_stdlib" "decode_bool"
@@ -121,7 +122,7 @@ if erlang {
   ///    True
   ///
   ///    > thunk(from(123))
-  ///    Error("Expected a zero arity function, got `123`")
+  ///    Error("Expected a zero arity function, found `123`")
   ///
   pub external fn thunk(from: Dynamic) -> Result(fn() -> Dynamic, DecodeError) =
     "gleam_stdlib" "decode_thunk"
@@ -138,7 +139,7 @@ if erlang {
   ///    Ok([from("a"), from("b"), from("c")])
   ///
   ///    > list(1)
-  ///    Error("Expected an Int, got a binary")
+  ///    Error("Expected an Int, found a binary")
   ///
   pub external fn list(from: Dynamic) -> Result(List(Dynamic), DecodeError) =
     "gleam_stdlib" "decode_list"
@@ -155,7 +156,7 @@ if erlang {
   ///    Ok(Error(from("boom")))
   ///
   ///    > result(from(123))
-  ///    Error("Expected a 2 element tuple, got an int")
+  ///    Error("Expected a 2 element tuple, found an int")
   ///
   pub external fn result(
     Dynamic,
@@ -177,7 +178,7 @@ if erlang {
   ///    Ok(Error("boom"))
   ///
   ///    > typed_result(of: from(123), ok: int, error: string)
-  ///    Error("Expected a 2 element tuple, got an int")
+  ///    Error("Expected a 2 element tuple, found an int")
   ///
   pub fn typed_result(
     of dynamic: Dynamic,
@@ -214,10 +215,10 @@ if erlang {
   ///    Ok(["a", "b", "c"])
   ///
   ///    > typed_list(from([1, 2, 3]), of: string)
-  ///    Error("Expected an Int, got a binary")
+  ///    Error("Expected an Int, found a binary")
   ///
   ///    > typed_list(from("ok"), of: string)
-  ///    Error("Expected a List, got a binary")
+  ///    Error("Expected a List, found a binary")
   ///
   pub fn typed_list(
     from dynamic: Dynamic,
@@ -249,7 +250,7 @@ if erlang {
   ///    Ok(None)
   ///
   ///    > option(from(123), string)
-  ///    Error("Expected a bit_string, got an int")
+  ///    Error("Expected a bit_string, found an int")
   ///
   pub external fn optional(
     from: Dynamic,
@@ -269,7 +270,7 @@ if erlang {
   ///    Ok(Dynamic)
   ///
   ///    > field(from(123), "Hello")
-  ///    Error("Expected a map with key `\"Hello\"`, got an Int")
+  ///    Error("Expected a map with key `\"Hello\"`, found an Int")
   ///
   pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, DecodeError) =
     "gleam_stdlib" "decode_field"
@@ -283,10 +284,10 @@ if erlang {
   ///    Ok(from(1))
   ///
   ///    > element(from(#(1, 2)), 2)
-  ///    Error("Expected a tuple of at least 3 size, got a tuple of 2 size")
+  ///    Error("Expected a tuple of at least 3 size, found a tuple of 2 size")
   ///
   ///    > element(from(""), 2)
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub external fn element(
     from: Dynamic,
@@ -308,7 +309,7 @@ if erlang {
   ///    Error("Expected a 2 element tuple")
   ///
   ///    > tuple2(from(""))
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub external fn tuple2(
     from: Dynamic,
@@ -330,10 +331,10 @@ if erlang {
   ///    Ok(#(1, 2.0))
   ///
   ///    > typed_tuple2(from(#(1, 2, 3)), int, float)
-  ///    Error("Expected a 2 element tuple, got a 3 element tuple")
+  ///    Error("Expected a 2 element tuple, found a 3 element tuple")
   ///
   ///    > typed_tuple2(from(""), int, float)
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub fn typed_tuple2(
     from tup: Dynamic,
@@ -360,7 +361,7 @@ if erlang {
   ///    Error("Expected a 3 element tuple")
   ///
   ///    > tuple3(from(""))
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub external fn tuple3(
     from: Dynamic,
@@ -382,10 +383,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3"))
   ///
   ///    > typed_tuple3(from(#(1, 2)), int, float, string)
-  ///    Error("Expected a 3 element tuple, got a 2 element tuple")
+  ///    Error("Expected a 3 element tuple, found a 2 element tuple")
   ///
   ///    > typed_tuple3(from(""), int, float, string)
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub fn typed_tuple3(
     from tup: Dynamic,
@@ -414,7 +415,7 @@ if erlang {
   ///    Error("Expected a 4 element tuple")
   ///
   ///    > tuple4(from(""))
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub external fn tuple4(
     from: Dynamic,
@@ -436,10 +437,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4))
   ///
   ///    > typed_tuple4(from(#(1, 2)), int, float, string, int)
-  ///    Error("Expected a 4 element tuple, got a 2 element tuple")
+  ///    Error("Expected a 4 element tuple, found a 2 element tuple")
   ///
   ///    > typed_tuple4(from(""), int, float, string, int)
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub fn typed_tuple4(
     from tup: Dynamic,
@@ -470,7 +471,7 @@ if erlang {
   ///    Error("Expected a 5 element tuple")
   ///
   ///    > tuple5(from(""))
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub external fn tuple5(
     from: Dynamic,
@@ -492,10 +493,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4, 5))
   ///
   ///    > typed_tuple5(from(#(1, 2)), int, float, string, int, int)
-  ///    Error("Expected a 5 element tuple, got a 2 element tuple")
+  ///    Error("Expected a 5 element tuple, found a 2 element tuple")
   ///
   ///    > typed_tuple5(from(""), int, float, string, int, int)
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub fn typed_tuple5(
     from tup: Dynamic,
@@ -528,7 +529,7 @@ if erlang {
   ///    Error("Expected a 6 element tuple")
   ///
   ///    > tuple6(from(""))
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub external fn tuple6(
     from: Dynamic,
@@ -553,10 +554,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4, 5, 6))
   ///
   ///    > typed_tuple6(from(#(1, 2)), int, float, string, int, int, int)
-  ///    Error("Expected a 6 element tuple, got a 2 element tuple")
+  ///    Error("Expected a 6 element tuple, found a 2 element tuple")
   ///
   ///    > typed_tuple6(from(""), int, float, string, int, int, int)
-  ///    Error("Expected a tuple, got a binary")
+  ///    Error("Expected a tuple, found a binary")
   ///
   pub fn typed_tuple6(
     from tup: Dynamic,
@@ -586,10 +587,10 @@ if erlang {
   ///    Ok(map.new())
   ///
   ///    > map(from(1))
-  ///    Error("Expected a 2 element tuple, got an int")
+  ///    Error("Expected a 2 element tuple, found an int")
   ///
   ///    > map(from(""))
-  ///    Error("Expected a map, got a binary")
+  ///    Error("Expected a map, found a binary")
   ///
   pub external fn map(
     from: Dynamic,
@@ -622,7 +623,7 @@ if erlang {
     decoders
     |> list.find_map(fn(decoder) { decoder(data) })
     |> result.map_error(fn(_) {
-      DecodeError(expected: "any", got: "unexpected")
+      DecodeError(expected: "any", found: "unexpected")
     })
   }
 }

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -11,6 +11,7 @@ if erlang {
   /// IO with the outside world.
   pub external type Dynamic
 
+  /// Error returned when unexpected data is encountered
   pub type DecodeError {
     DecodeError(expected: String, found: String)
   }
@@ -42,7 +43,7 @@ if erlang {
   ///    True
   ///
   ///    > bit_string(from(123))
-  ///    Error(DecoderError(expected: "BitString", found: "Int"))
+  ///    Error(DecodeError(expected: "BitString", found: "Int"))
   ///
   pub external fn bit_string(from: Dynamic) -> Result(BitString, DecodeError) =
     "gleam_stdlib" "decode_bit_string"
@@ -56,7 +57,7 @@ if erlang {
   ///    Ok("Hello")
   ///
   ///    > string(from(123))
-  ///    Error(DecoderError(expected: "String", found: "Int"))
+  ///    Error(DecodeError(expected: "String", found: "Int"))
   ///
   pub fn string(from: Dynamic) -> Result(String, DecodeError) {
     bit_string(from)
@@ -84,7 +85,7 @@ if erlang {
   ///    Ok(123)
   ///
   ///    > int(from("Hello"))
-  ///    Error(DecoderError(expected: "Int", found: "String"))
+  ///    Error(DecodeError(expected: "Int", found: "String"))
   ///
   pub external fn int(from: Dynamic) -> Result(Int, DecodeError) =
     "gleam_stdlib" "decode_int"
@@ -98,7 +99,7 @@ if erlang {
   ///    Ok(2.0)
   ///
   ///    > float(from(123))
-  ///    Error(DecoderError(expected: "Float", found: "Int"))
+  ///    Error(DecodeError(expected: "Float", found: "Int"))
   ///
   pub external fn float(from: Dynamic) -> Result(Float, DecodeError) =
     "gleam_stdlib" "decode_float"
@@ -112,7 +113,7 @@ if erlang {
   ///    Ok(True)
   ///
   ///    > bool(from(123))
-  ///    Error(DecoderError(expected: "bool", found: "Int"))
+  ///    Error(DecodeError(expected: "bool", found: "Int"))
   ///
   pub external fn bool(from: Dynamic) -> Result(Bool, DecodeError) =
     "gleam_stdlib" "decode_bool"
@@ -128,7 +129,7 @@ if erlang {
   ///    True
   ///
   ///    > thunk(from(123))
-  ///    Error(DecoderError(expected: "zero arity function", found: "Int"))
+  ///    Error(DecodeError(expected: "zero arity function", found: "Int"))
   ///
   pub external fn thunk(from: Dynamic) -> Result(fn() -> Dynamic, DecodeError) =
     "gleam_stdlib" "decode_thunk"
@@ -145,7 +146,7 @@ if erlang {
   ///    Ok([from("a"), from("b"), from("c")])
   ///
   ///    > list(1)
-  ///    Error(DecoderError(expected: "Int", found: "Int"))
+  ///    Error(DecodeError(expected: "Int", found: "Int"))
   ///
   pub external fn list(from: Dynamic) -> Result(List(Dynamic), DecodeError) =
     "gleam_stdlib" "decode_list"
@@ -162,7 +163,7 @@ if erlang {
   ///    Ok(Error(from("boom")))
   ///
   ///    > result(from(123))
-  ///    Error(DecoderError(expected: "2 element tuple", found: "Int"))
+  ///    Error(DecodeError(expected: "2 element tuple", found: "Int"))
   ///
   pub external fn result(
     Dynamic,
@@ -184,7 +185,7 @@ if erlang {
   ///    Ok(Error("boom"))
   ///
   ///    > typed_result(of: from(123), ok: int, error: string)
-  ///    Error(DecoderError(expected: "2 element tuple", found: "Int"))
+  ///    Error(DecodeError(expected: "2 element tuple", found: "Int"))
   ///
   pub fn typed_result(
     of dynamic: Dynamic,
@@ -221,10 +222,10 @@ if erlang {
   ///    Ok(["a", "b", "c"])
   ///
   ///    > typed_list(from([1, 2, 3]), of: string)
-  ///    Error(DecoderError(expected: "String", found: "Int"))
+  ///    Error(DecodeError(expected: "String", found: "Int"))
   ///
   ///    > typed_list(from("ok"), of: string)
-  ///    Error(DecoderError(expected: "List", found: "String"))
+  ///    Error(DecodeError(expected: "List", found: "String"))
   ///
   pub fn typed_list(
     from dynamic: Dynamic,
@@ -256,7 +257,7 @@ if erlang {
   ///    Ok(None)
   ///
   ///    > option(from(123), string)
-  ///    Error(DecoderError(expected: "BitString", found: "Int"))
+  ///    Error(DecodeError(expected: "BitString", found: "Int"))
   ///
   pub external fn optional(
     from: Dynamic,
@@ -276,7 +277,7 @@ if erlang {
   ///    Ok(Dynamic)
   ///
   ///    > field(from(123), "Hello")
-  ///    Error(DecoderError(expected: "Map", found: "Int"))
+  ///    Error(DecodeError(expected: "Map", found: "Int"))
   ///
   pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, DecodeError) =
     "gleam_stdlib" "decode_field"
@@ -290,10 +291,10 @@ if erlang {
   ///    Ok(from(1))
   ///
   ///    > element(from(#(1, 2)), 2)
-  ///    Error(DecoderError(expected: "3 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "3 element tuple", found: "2 element tuple"))
   ///
   ///    > element(from(""), 2)
-  ///    Error(DecoderError(expected: "Tuple", found: "String"))
+  ///    Error(DecodeError(expected: "Tuple", found: "String"))
   ///
   pub external fn element(
     from: Dynamic,
@@ -312,10 +313,10 @@ if erlang {
   ///    Ok(#(from(1), from(2)))
   ///
   ///    > tuple2(from(#(1, 2, 3)))
-  ///    Error(DecoderError(expected: "2 element tuple", found: "3 element tuple"))
+  ///    Error(DecodeError(expected: "2 element tuple", found: "3 element tuple"))
   ///
   ///    > tuple2(from(""))
-  ///    Error(DecoderError(expected: "2 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "2 element tuple", found: "String"))
   ///
   pub external fn tuple2(
     from: Dynamic,
@@ -337,10 +338,10 @@ if erlang {
   ///    Ok(#(1, 2.0))
   ///
   ///    > typed_tuple2(from(#(1, 2, 3)), int, float)
-  ///    Error(DecoderError(expected: "2 element tuple", found: "3 element tuple"))
+  ///    Error(DecodeError(expected: "2 element tuple", found: "3 element tuple"))
   ///
   ///    > typed_tuple2(from(""), int, float)
-  ///    Error(DecoderError(expected: "2 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "2 element tuple", found: "String"))
   ///
   pub fn typed_tuple2(
     from tup: Dynamic,
@@ -364,10 +365,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3)))
   ///
   ///    > tuple3(from(#(1, 2)))
-  ///    Error(DecoderError(expected: "3 element tuple", found: "3 element tuple"))
+  ///    Error(DecodeError(expected: "3 element tuple", found: "3 element tuple"))
   ///
   ///    > tuple3(from(""))
-  ///    Error(DecoderError(expected: "3 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "3 element tuple", found: "String"))
   ///
   pub external fn tuple3(
     from: Dynamic,
@@ -389,10 +390,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3"))
   ///
   ///    > typed_tuple3(from(#(1, 2)), int, float, string)
-  ///    Error(DecoderError(expected: "3 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "3 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple3(from(""), int, float, string)
-  ///    Error(DecoderError(expected: "3 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "3 element tuple", found: "String"))
   ///
   pub fn typed_tuple3(
     from tup: Dynamic,
@@ -418,10 +419,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3), from(4)))
   ///
   ///    > tuple4(from(#(1, 2)))
-  ///    Error(DecoderError(expected: "4 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "4 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple4(from(""))
-  ///    Error(DecoderError(expected: "4 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "4 element tuple", found: "String"))
   ///
   pub external fn tuple4(
     from: Dynamic,
@@ -444,10 +445,10 @@ if erlang {
   ///
   ///    > typed_tuple4(from(#(1, 2)), int, float, string, int)
   ///    Error("Expected a 4 element tuple, found a 2 element tuple")
-  ///    Error(DecoderError(expected: "4 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "4 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple4(from(""), int, float, string, int)
-  ///    Error(DecoderError(expected: "4 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "4 element tuple", found: "String"))
   ///
   pub fn typed_tuple4(
     from tup: Dynamic,
@@ -475,10 +476,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3), from(4), from(5)))
   ///
   ///    > tuple5(from(#(1, 2)))
-  ///    Error(DecoderError(expected: "5 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "5 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple5(from(""))
-  ///    Error(DecoderError(expected: "5 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "5 element tuple", found: "String"))
   ///
   pub external fn tuple5(
     from: Dynamic,
@@ -500,10 +501,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4, 5))
   ///
   ///    > typed_tuple5(from(#(1, 2)), int, float, string, int, int)
-  ///    Error(DecoderError(expected: "5 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "5 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple5(from(""), int, float, string, int, int)
-  ///    Error(DecoderError(expected: "5 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "5 element tuple", found: "String"))
   ///
   pub fn typed_tuple5(
     from tup: Dynamic,
@@ -533,10 +534,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3), from(4), from(5), from(6)))
   ///
   ///    > tuple6(from(#(1, 2)))
-  ///    Error(DecoderError(expected: "6 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "6 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple6(from(""))
-  ///    Error(DecoderError(expected: "6 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "6 element tuple", found: "String"))
   ///
   pub external fn tuple6(
     from: Dynamic,
@@ -561,10 +562,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4, 5, 6))
   ///
   ///    > typed_tuple6(from(#(1, 2)), int, float, string, int, int, int)
-  ///    Error(DecoderError(expected: "6 element tuple", found: "2 element tuple"))
+  ///    Error(DecodeError(expected: "6 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple6(from(""), int, float, string, int, int, int)
-  ///    Error(DecoderError(expected: "6 element tuple", found: "String"))
+  ///    Error(DecodeError(expected: "6 element tuple", found: "String"))
   ///
   pub fn typed_tuple6(
     from tup: Dynamic,
@@ -594,10 +595,10 @@ if erlang {
   ///    Ok(map.new())
   ///
   ///    > map(from(1))
-  ///    Error(DecoderError(expected: "Map", found: "Int"))
+  ///    Error(DecodeError(expected: "Map", found: "Int"))
   ///
   ///    > map(from(""))
-  ///    Error(DecoderError(expected: "Map", found: "String"))
+  ///    Error(DecodeError(expected: "Map", found: "String"))
   ///
   pub external fn map(
     from: Dynamic,
@@ -621,7 +622,7 @@ if erlang {
   ///    Ok("a bool")
   ///
   ///    > bool_or_string(from(1))
-  ///    Error(DecoderError(expected: "unknown", found: "unknown"))
+  ///    Error(DecodeError(expected: "unknown", found: "unknown"))
   ///
   pub fn any(
     from data: Dynamic,

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -42,7 +42,7 @@ if erlang {
   ///    True
   ///
   ///    > bit_string(from(123))
-  ///    Error("Expected a BitString, found `123`")
+  ///    Error(DecoderError(expected: "bit_string", found: "int"))
   ///
   pub external fn bit_string(from: Dynamic) -> Result(BitString, DecodeError) =
     "gleam_stdlib" "decode_bit_string"
@@ -56,7 +56,7 @@ if erlang {
   ///    Ok("Hello")
   ///
   ///    > string(from(123))
-  ///    Error("Expected a String, found `123`")
+  ///    Error(DecoderError(expected: "string", found: "int"))
   ///
   pub fn string(from: Dynamic) -> Result(String, DecodeError) {
     bit_string(from)
@@ -78,7 +78,7 @@ if erlang {
   ///    Ok(123)
   ///
   ///    > int(from("Hello"))
-  ///    Error("Expected an Int, found `\"Hello World\"`")
+  ///    Error(DecoderError(expected: "int", found: "string"))
   ///
   pub external fn int(from: Dynamic) -> Result(Int, DecodeError) =
     "gleam_stdlib" "decode_int"
@@ -92,7 +92,7 @@ if erlang {
   ///    Ok(2.0)
   ///
   ///    > float(from(123))
-  ///    Error("Expected a Float, found `123`")
+  ///    Error(DecoderError(expected: "float", found: "int"))
   ///
   pub external fn float(from: Dynamic) -> Result(Float, DecodeError) =
     "gleam_stdlib" "decode_float"
@@ -106,7 +106,7 @@ if erlang {
   ///    Ok(True)
   ///
   ///    > bool(from(123))
-  ///    Error("Expected a Bool, found `123`")
+  ///    Error(DecoderError(expected: "bool", found: "int"))
   ///
   pub external fn bool(from: Dynamic) -> Result(Bool, DecodeError) =
     "gleam_stdlib" "decode_bool"
@@ -122,7 +122,7 @@ if erlang {
   ///    True
   ///
   ///    > thunk(from(123))
-  ///    Error("Expected a zero arity function, found `123`")
+  ///    Error(DecoderError(expected: "zero arity function", found: "int"))
   ///
   pub external fn thunk(from: Dynamic) -> Result(fn() -> Dynamic, DecodeError) =
     "gleam_stdlib" "decode_thunk"
@@ -139,7 +139,7 @@ if erlang {
   ///    Ok([from("a"), from("b"), from("c")])
   ///
   ///    > list(1)
-  ///    Error("Expected an Int, found a binary")
+  ///    Error(DecoderError(expected: "int", found: "binary"))
   ///
   pub external fn list(from: Dynamic) -> Result(List(Dynamic), DecodeError) =
     "gleam_stdlib" "decode_list"
@@ -156,7 +156,7 @@ if erlang {
   ///    Ok(Error(from("boom")))
   ///
   ///    > result(from(123))
-  ///    Error("Expected a 2 element tuple, found an int")
+  ///    Error(DecoderError(expected: "2 element tuple", found: "int"))
   ///
   pub external fn result(
     Dynamic,
@@ -178,7 +178,7 @@ if erlang {
   ///    Ok(Error("boom"))
   ///
   ///    > typed_result(of: from(123), ok: int, error: string)
-  ///    Error("Expected a 2 element tuple, found an int")
+  ///    Error(DecoderError(expected: "2 element tuple", found: "int"))
   ///
   pub fn typed_result(
     of dynamic: Dynamic,
@@ -215,10 +215,10 @@ if erlang {
   ///    Ok(["a", "b", "c"])
   ///
   ///    > typed_list(from([1, 2, 3]), of: string)
-  ///    Error("Expected an Int, found a binary")
+  ///    Error(DecoderError(expected: "int", found: "binary"))
   ///
   ///    > typed_list(from("ok"), of: string)
-  ///    Error("Expected a List, found a binary")
+  ///    Error(DecoderError(expected: "list", found: "binary"))
   ///
   pub fn typed_list(
     from dynamic: Dynamic,
@@ -250,7 +250,7 @@ if erlang {
   ///    Ok(None)
   ///
   ///    > option(from(123), string)
-  ///    Error("Expected a bit_string, found an int")
+  ///    Error(DecoderError(expected: "bit_string", found: "int"))
   ///
   pub external fn optional(
     from: Dynamic,
@@ -270,7 +270,7 @@ if erlang {
   ///    Ok(Dynamic)
   ///
   ///    > field(from(123), "Hello")
-  ///    Error("Expected a map with key `\"Hello\"`, found an Int")
+  ///    Error(DecoderError(expected: "map", found: "int"))
   ///
   pub external fn field(from: Dynamic, named: a) -> Result(Dynamic, DecodeError) =
     "gleam_stdlib" "decode_field"
@@ -284,10 +284,10 @@ if erlang {
   ///    Ok(from(1))
   ///
   ///    > element(from(#(1, 2)), 2)
-  ///    Error("Expected a tuple of at least 3 size, found a tuple of 2 size")
+  ///    Error(DecoderError(expected: "3 element tuple", found: "2 element tuple"))
   ///
   ///    > element(from(""), 2)
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "tuple", found: "binary"))
   ///
   pub external fn element(
     from: Dynamic,
@@ -306,10 +306,10 @@ if erlang {
   ///    Ok(#(from(1), from(2)))
   ///
   ///    > tuple2(from(#(1, 2, 3)))
-  ///    Error("Expected a 2 element tuple")
+  ///    Error(DecoderError(expected: "2 element tuple", found: "3 element tuple"))
   ///
   ///    > tuple2(from(""))
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "2 element tuple", found: "binary"))
   ///
   pub external fn tuple2(
     from: Dynamic,
@@ -331,10 +331,10 @@ if erlang {
   ///    Ok(#(1, 2.0))
   ///
   ///    > typed_tuple2(from(#(1, 2, 3)), int, float)
-  ///    Error("Expected a 2 element tuple, found a 3 element tuple")
+  ///    Error(DecoderError(expected: "2 element tuple", found: "3 element tuple"))
   ///
   ///    > typed_tuple2(from(""), int, float)
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "2 element tuple", found: "binary"))
   ///
   pub fn typed_tuple2(
     from tup: Dynamic,
@@ -358,10 +358,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3)))
   ///
   ///    > tuple3(from(#(1, 2)))
-  ///    Error("Expected a 3 element tuple")
+  ///    Error(DecoderError(expected: "3 element tuple", found: "3 element tuple"))
   ///
   ///    > tuple3(from(""))
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "3 element tuple", found: "binary"))
   ///
   pub external fn tuple3(
     from: Dynamic,
@@ -383,10 +383,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3"))
   ///
   ///    > typed_tuple3(from(#(1, 2)), int, float, string)
-  ///    Error("Expected a 3 element tuple, found a 2 element tuple")
+  ///    Error(DecoderError(expected: "3 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple3(from(""), int, float, string)
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "3 element tuple", found: "binary"))
   ///
   pub fn typed_tuple3(
     from tup: Dynamic,
@@ -412,10 +412,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3), from(4)))
   ///
   ///    > tuple4(from(#(1, 2)))
-  ///    Error("Expected a 4 element tuple")
+  ///    Error(DecoderError(expected: "4 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple4(from(""))
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "4 element tuple", found: "binary"))
   ///
   pub external fn tuple4(
     from: Dynamic,
@@ -438,9 +438,10 @@ if erlang {
   ///
   ///    > typed_tuple4(from(#(1, 2)), int, float, string, int)
   ///    Error("Expected a 4 element tuple, found a 2 element tuple")
+  ///    Error(DecoderError(expected: "4 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple4(from(""), int, float, string, int)
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "4 element tuple", found: "binary"))
   ///
   pub fn typed_tuple4(
     from tup: Dynamic,
@@ -468,10 +469,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3), from(4), from(5)))
   ///
   ///    > tuple5(from(#(1, 2)))
-  ///    Error("Expected a 5 element tuple")
+  ///    Error(DecoderError(expected: "5 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple5(from(""))
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "5 element tuple", found: "binary"))
   ///
   pub external fn tuple5(
     from: Dynamic,
@@ -493,10 +494,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4, 5))
   ///
   ///    > typed_tuple5(from(#(1, 2)), int, float, string, int, int)
-  ///    Error("Expected a 5 element tuple, found a 2 element tuple")
+  ///    Error(DecoderError(expected: "5 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple5(from(""), int, float, string, int, int)
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "5 element tuple", found: "binary"))
   ///
   pub fn typed_tuple5(
     from tup: Dynamic,
@@ -526,10 +527,10 @@ if erlang {
   ///    Ok(#(from(1), from(2), from(3), from(4), from(5), from(6)))
   ///
   ///    > tuple6(from(#(1, 2)))
-  ///    Error("Expected a 6 element tuple")
+  ///    Error(DecoderError(expected: "6 element tuple", found: "2 element tuple"))
   ///
   ///    > tuple6(from(""))
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "6 element tuple", found: "binary"))
   ///
   pub external fn tuple6(
     from: Dynamic,
@@ -554,10 +555,10 @@ if erlang {
   ///    Ok(#(1, 2.0, "3", 4, 5, 6))
   ///
   ///    > typed_tuple6(from(#(1, 2)), int, float, string, int, int, int)
-  ///    Error("Expected a 6 element tuple, found a 2 element tuple")
+  ///    Error(DecoderError(expected: "6 element tuple", found: "2 element tuple"))
   ///
   ///    > typed_tuple6(from(""), int, float, string, int, int, int)
-  ///    Error("Expected a tuple, found a binary")
+  ///    Error(DecoderError(expected: "6 element tuple", found: "binary"))
   ///
   pub fn typed_tuple6(
     from tup: Dynamic,
@@ -587,10 +588,10 @@ if erlang {
   ///    Ok(map.new())
   ///
   ///    > map(from(1))
-  ///    Error("Expected a 2 element tuple, found an int")
+  ///    Error(DecoderError(expected: "map", found: "int"))
   ///
   ///    > map(from(""))
-  ///    Error("Expected a map, found a binary")
+  ///    Error(DecoderError(expected: "map", found: "binary"))
   ///
   pub external fn map(
     from: Dynamic,
@@ -614,7 +615,7 @@ if erlang {
   ///    Ok("a bool")
   ///
   ///    > bool_or_string(from(1))
-  ///    Error("Unexpected value")
+  ///    Error(DecoderError(expected: "unknown", found: "unknown"))
   ///
   pub fn any(
     from data: Dynamic,
@@ -623,7 +624,7 @@ if erlang {
     decoders
     |> list.find_map(fn(decoder) { decoder(data) })
     |> result.map_error(fn(_) {
-      DecodeError(expected: "any", found: "unexpected")
+      DecodeError(expected: "unknown", found: "unknown")
     })
   }
 }

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -39,12 +39,13 @@ identity(X) -> X.
 decode_error_msg(Expected, Data) ->
     {error, {decode_error, Expected, classify(Data)}}.
 
-classify(X) when is_atom(X) -> <<"atom">>;
-classify(X) when is_binary(X) -> <<"binary">>;
-classify(X) when is_integer(X) -> <<"int">>;
-classify(X) when is_float(X) -> <<"float">>;
-classify(X) when is_list(X) -> <<"list">>;
-classify(X) when is_boolean(X) -> <<"bool">>;
+classify(X) when is_atom(X) -> <<"Atom">>;
+classify(X) when is_binary(X) -> <<"String">>;
+classify(X) when is_bitstring(X) -> <<"BitString">>;
+classify(X) when is_integer(X) -> <<"Int">>;
+classify(X) when is_float(X) -> <<"Float">>;
+classify(X) when is_list(X) -> <<"List">>;
+classify(X) when is_boolean(X) -> <<"Bool">>;
 classify(X) when is_function(X, 0) -> <<"zero arity function">>;
 classify(X) when is_tuple(X) -> iolist_to_binary([integer_to_list(tuple_size(X)), " element tuple"]);
 classify(_) -> "some other type".
@@ -65,25 +66,25 @@ decode_tuple6({_, _, _, _, _, _} = T) -> {ok, T};
 decode_tuple6(Data) -> decode_error_msg(<<"6 element tuple">>, Data).
 
 decode_map(Data) when is_map(Data) -> {ok, Data};
-decode_map(Data) -> decode_error_msg(<<"map">>, Data).
+decode_map(Data) -> decode_error_msg(<<"Map">>, Data).
 
 decode_bit_string(Data) when is_bitstring(Data) -> {ok, Data};
-decode_bit_string(Data) -> decode_error_msg(<<"bit_string">>, Data).
+decode_bit_string(Data) -> decode_error_msg(<<"BitString">>, Data).
 
 decode_int(Data) when is_integer(Data) -> {ok, Data};
-decode_int(Data) -> decode_error_msg(<<"int">>, Data).
+decode_int(Data) -> decode_error_msg(<<"Int">>, Data).
 
 decode_float(Data) when is_float(Data) -> {ok, Data};
-decode_float(Data) -> decode_error_msg(<<"float">>, Data).
+decode_float(Data) -> decode_error_msg(<<"Float">>, Data).
 
 decode_bool(Data) when is_boolean(Data) -> {ok, Data};
-decode_bool(Data) -> decode_error_msg(<<"bool">>, Data).
+decode_bool(Data) -> decode_error_msg(<<"Bool">>, Data).
 
 decode_thunk(Data) when is_function(Data, 0) -> {ok, Data};
 decode_thunk(Data) -> decode_error_msg("zero arity function", Data).
 
 decode_list(Data) when is_list(Data) -> {ok, Data};
-decode_list(Data) -> decode_error_msg(<<"list">>, Data).
+decode_list(Data) -> decode_error_msg(<<"List">>, Data).
 
 decode_field(Data, Key) ->
     case Data of
@@ -102,7 +103,7 @@ decode_element(Data, Position) when is_tuple(Data) ->
         Value ->
             {ok, Value}
     end;
-decode_element(Data, _Position) -> decode_error_msg("a tuple", Data).
+decode_element(Data, _Position) -> decode_error_msg(<<"Tuple">>, Data).
 
 decode_optional(Term, F) ->
     Decode = fun(Inner) ->

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -36,54 +36,54 @@ iodata_append(Iodata, String) -> [Iodata, String].
 
 identity(X) -> X.
 
-decode_error_msg(Type, Data) ->
-    {error, iolist_to_binary(io_lib:format("Expected ~s, got ~s", [Type, classify(Data)]))}.
+decode_error_msg(Expected, Data) ->
+    {error, {decode_error, Expected, classify(Data)}}.
 
-classify(X) when is_atom(X) -> "an atom";
-classify(X) when is_binary(X) -> "a binary";
-classify(X) when is_integer(X) -> "an int";
-classify(X) when is_float(X) -> "a float";
-classify(X) when is_list(X) -> "a list";
-classify(X) when is_boolean(X) -> "a bool";
-classify(X) when is_function(X, 0) -> "a zero arity function";
-classify(X) when is_tuple(X) -> ["a ", integer_to_list(tuple_size(X)), " element tuple"];
+classify(X) when is_atom(X) -> <<"atom">>;
+classify(X) when is_binary(X) -> <<"binary">>;
+classify(X) when is_integer(X) -> <<"int">>;
+classify(X) when is_float(X) -> <<"float">>;
+classify(X) when is_list(X) -> <<"list">>;
+classify(X) when is_boolean(X) -> <<"bool">>;
+classify(X) when is_function(X, 0) -> <<"zero arity function">>;
+classify(X) when is_tuple(X) -> iolist_to_binary([integer_to_list(tuple_size(X)), " element tuple"]);
 classify(_) -> "some other type".
 
 decode_tuple2({_, _} = T) -> {ok, T};
-decode_tuple2(Data) -> decode_error_msg("a 2 element tuple", Data).
+decode_tuple2(Data) -> decode_error_msg(<<"2 element tuple">>, Data).
 
 decode_tuple3({_, _, _} = T) -> {ok, T};
-decode_tuple3(Data) -> decode_error_msg("a 3 element tuple", Data).
+decode_tuple3(Data) -> decode_error_msg(<<"3 element tuple">>, Data).
 
 decode_tuple4({_, _, _, _} = T) -> {ok, T};
-decode_tuple4(Data) -> decode_error_msg("a 4 element tuple", Data).
+decode_tuple4(Data) -> decode_error_msg(<<"4 element tuple">>, Data).
 
 decode_tuple5({_, _, _, _, _} = T) -> {ok, T};
-decode_tuple5(Data) -> decode_error_msg("a 5 element tuple", Data).
+decode_tuple5(Data) -> decode_error_msg(<<"5 element tuple">>, Data).
 
 decode_tuple6({_, _, _, _, _, _} = T) -> {ok, T};
-decode_tuple6(Data) -> decode_error_msg("a 6 element tuple", Data).
+decode_tuple6(Data) -> decode_error_msg(<<"6 element tuple">>, Data).
 
 decode_map(Data) when is_map(Data) -> {ok, Data};
-decode_map(Data) -> decode_error_msg("a map", Data).
+decode_map(Data) -> decode_error_msg(<<"map">>, Data).
 
 decode_bit_string(Data) when is_bitstring(Data) -> {ok, Data};
-decode_bit_string(Data) -> decode_error_msg("a bit_string", Data).
+decode_bit_string(Data) -> decode_error_msg(<<"bit_string">>, Data).
 
 decode_int(Data) when is_integer(Data) -> {ok, Data};
-decode_int(Data) -> decode_error_msg("an int", Data).
+decode_int(Data) -> decode_error_msg(<<"int">>, Data).
 
 decode_float(Data) when is_float(Data) -> {ok, Data};
-decode_float(Data) -> decode_error_msg("a float", Data).
+decode_float(Data) -> decode_error_msg(<<"float">>, Data).
 
 decode_bool(Data) when is_boolean(Data) -> {ok, Data};
-decode_bool(Data) -> decode_error_msg("a bool", Data).
+decode_bool(Data) -> decode_error_msg(<<"bool">>, Data).
 
 decode_thunk(Data) when is_function(Data, 0) -> {ok, Data};
-decode_thunk(Data) -> decode_error_msg("a zero arity function", Data).
+decode_thunk(Data) -> decode_error_msg("zero arity function", Data).
 
 decode_list(Data) when is_list(Data) -> {ok, Data};
-decode_list(Data) -> decode_error_msg("a list", Data).
+decode_list(Data) -> decode_error_msg(<<"list">>, Data).
 
 decode_field(Data, Key) ->
     case Data of
@@ -127,7 +127,7 @@ decode_result(Term) ->
         ok -> {ok, {ok, nil}};
         {error, Inner} -> {ok, {error, Inner}};
         error -> {ok, {error, nil}};
-        _ -> decode_error_msg("a result tuple", Term)
+        _ -> decode_error_msg(<<"result tuple">>, Term)
     end.
 
 parse_int(String) ->

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -26,12 +26,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.bit_string
-    |> should.equal(Error(DecodeError(expected: "bit_string", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "bit_string", found: "int")))
 
     []
     |> dynamic.from
     |> dynamic.bit_string
-    |> should.equal(Error(DecodeError(expected: "bit_string", got: "list")))
+    |> should.equal(Error(DecodeError(expected: "bit_string", found: "list")))
   }
 
   pub fn string_test() {
@@ -48,17 +48,17 @@ if erlang {
     <<65535:16>>
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error(DecodeError(expected: "string", got: "bit_string")))
+    |> should.equal(Error(DecodeError(expected: "string", found: "bit_string")))
 
     1
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error(DecodeError(expected: "bit_string", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "bit_string", found: "int")))
 
     []
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error(DecodeError(expected: "bit_string", got: "list")))
+    |> should.equal(Error(DecodeError(expected: "bit_string", found: "list")))
   }
 
   pub fn int_test() {
@@ -75,12 +75,12 @@ if erlang {
     1.0
     |> dynamic.from
     |> dynamic.int
-    |> should.equal(Error(DecodeError(expected: "int", got: "float")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "float")))
 
     []
     |> dynamic.from
     |> dynamic.int
-    |> should.equal(Error(DecodeError(expected: "int", got: "list")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "list")))
   }
 
   pub fn float_test() {
@@ -97,12 +97,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.float
-    |> should.equal(Error(DecodeError(expected: "float", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "float", found: "int")))
 
     []
     |> dynamic.from
     |> dynamic.float
-    |> should.equal(Error(DecodeError(expected: "float", got: "list")))
+    |> should.equal(Error(DecodeError(expected: "float", found: "list")))
   }
 
   pub fn thunk_test() {
@@ -147,12 +147,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.bool
-    |> should.equal(Error(DecodeError(expected: "bool", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "bool", found: "int")))
 
     []
     |> dynamic.from
     |> dynamic.bool
-    |> should.equal(Error(DecodeError(expected: "bool", got: "list")))
+    |> should.equal(Error(DecodeError(expected: "bool", found: "list")))
   }
 
   pub fn typed_list_test() {
@@ -300,13 +300,13 @@ if erlang {
     |> dynamic.tuple2
     |> should.equal(Error(DecodeError(
       expected: "2 element tuple",
-      got: "3 element tuple",
+      found: "3 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.tuple2
-    |> should.equal(Error(DecodeError(expected: "2 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "2 element tuple", found: "int")))
   }
 
   pub fn typed_tuple2_test() {
@@ -323,20 +323,20 @@ if erlang {
     #(1, "")
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
 
     #(1, 2, 3)
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
     |> should.equal(Error(DecodeError(
       expected: "2 element tuple",
-      got: "3 element tuple",
+      found: "3 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "2 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "2 element tuple", found: "int")))
   }
 
   pub fn tuple3_test() {
@@ -355,13 +355,13 @@ if erlang {
     |> dynamic.tuple3
     |> should.equal(Error(DecodeError(
       expected: "3 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.tuple3
-    |> should.equal(Error(DecodeError(expected: "3 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "3 element tuple", found: "int")))
   }
 
   pub fn typed_tuple3_test() {
@@ -378,20 +378,20 @@ if erlang {
     #(1, 2, "")
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
 
     #(1, 2)
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
     |> should.equal(Error(DecodeError(
       expected: "3 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "3 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "3 element tuple", found: "int")))
   }
 
   pub fn tuple4_test() {
@@ -420,13 +420,13 @@ if erlang {
     |> dynamic.tuple4
     |> should.equal(Error(DecodeError(
       expected: "4 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.tuple4
-    |> should.equal(Error(DecodeError(expected: "4 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "4 element tuple", found: "int")))
   }
 
   pub fn typed_tuple4_test() {
@@ -448,20 +448,20 @@ if erlang {
     #(1, 2, 3, "")
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
 
     #(1, 2)
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
     |> should.equal(Error(DecodeError(
       expected: "4 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "4 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "4 element tuple", found: "int")))
   }
 
   pub fn tuple5_test() {
@@ -492,13 +492,13 @@ if erlang {
     |> dynamic.tuple5
     |> should.equal(Error(DecodeError(
       expected: "5 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.tuple5
-    |> should.equal(Error(DecodeError(expected: "5 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "5 element tuple", found: "int")))
   }
 
   pub fn typed_tuple5_test() {
@@ -533,7 +533,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
 
     #(1, 2)
     |> dynamic.from
@@ -546,7 +546,7 @@ if erlang {
     )
     |> should.equal(Error(DecodeError(
       expected: "5 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
@@ -558,7 +558,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "5 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "5 element tuple", found: "int")))
   }
 
   pub fn tuple6_test() {
@@ -591,13 +591,13 @@ if erlang {
     |> dynamic.tuple6
     |> should.equal(Error(DecodeError(
       expected: "6 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
     |> dynamic.from
     |> dynamic.tuple6
-    |> should.equal(Error(DecodeError(expected: "6 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "6 element tuple", found: "int")))
   }
 
   pub fn typed_tuple6_test() {
@@ -635,7 +635,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
 
     #(1, 2)
     |> dynamic.from
@@ -649,7 +649,7 @@ if erlang {
     )
     |> should.equal(Error(DecodeError(
       expected: "6 element tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
 
     1
@@ -662,7 +662,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "6 element tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "6 element tuple", found: "int")))
   }
 
   pub fn map_test() {
@@ -674,7 +674,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.map
-    |> should.equal(Error(DecodeError(expected: "map", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "map", found: "int")))
   }
 
   pub fn list_test() {
@@ -696,7 +696,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.list
-    |> should.equal(Error(DecodeError(expected: "list", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "list", found: "int")))
   }
 
   pub fn result_test() {
@@ -713,14 +713,14 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.result
-    |> should.equal(Error(DecodeError(expected: "result tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "result tuple", found: "int")))
 
     #("bad", "value")
     |> dynamic.from
     |> dynamic.result
     |> should.equal(Error(DecodeError(
       expected: "result tuple",
-      got: "2 element tuple",
+      found: "2 element tuple",
     )))
   }
 
@@ -738,16 +738,16 @@ if erlang {
     Ok("1")
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
+    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
 
     Error(1)
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error(DecodeError(expected: "bit_string", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "bit_string", found: "int")))
 
     1
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error(DecodeError(expected: "result tuple", got: "int")))
+    |> should.equal(Error(DecodeError(expected: "result tuple", found: "int")))
   }
 }

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -26,12 +26,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.bit_string
-    |> should.equal(Error(DecodeError(expected: "bit_string", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "BitString", found: "Int")))
 
     []
     |> dynamic.from
     |> dynamic.bit_string
-    |> should.equal(Error(DecodeError(expected: "bit_string", found: "list")))
+    |> should.equal(Error(DecodeError(expected: "BitString", found: "List")))
   }
 
   pub fn string_test() {
@@ -48,17 +48,17 @@ if erlang {
     <<65535:16>>
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error(DecodeError(expected: "string", found: "bit_string")))
+    |> should.equal(Error(DecodeError(expected: "String", found: "BitString")))
 
     1
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error(DecodeError(expected: "bit_string", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "String", found: "Int")))
 
     []
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error(DecodeError(expected: "bit_string", found: "list")))
+    |> should.equal(Error(DecodeError(expected: "String", found: "List")))
   }
 
   pub fn int_test() {
@@ -75,12 +75,12 @@ if erlang {
     1.0
     |> dynamic.from
     |> dynamic.int
-    |> should.equal(Error(DecodeError(expected: "int", found: "float")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "Float")))
 
     []
     |> dynamic.from
     |> dynamic.int
-    |> should.equal(Error(DecodeError(expected: "int", found: "list")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "List")))
   }
 
   pub fn float_test() {
@@ -97,12 +97,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.float
-    |> should.equal(Error(DecodeError(expected: "float", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "Float", found: "Int")))
 
     []
     |> dynamic.from
     |> dynamic.float
-    |> should.equal(Error(DecodeError(expected: "float", found: "list")))
+    |> should.equal(Error(DecodeError(expected: "Float", found: "List")))
   }
 
   pub fn thunk_test() {
@@ -147,12 +147,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.bool
-    |> should.equal(Error(DecodeError(expected: "bool", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "Bool", found: "Int")))
 
     []
     |> dynamic.from
     |> dynamic.bool
-    |> should.equal(Error(DecodeError(expected: "bool", found: "list")))
+    |> should.equal(Error(DecodeError(expected: "Bool", found: "List")))
   }
 
   pub fn typed_list_test() {
@@ -306,7 +306,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.tuple2
-    |> should.equal(Error(DecodeError(expected: "2 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "2 element tuple", found: "Int")))
   }
 
   pub fn typed_tuple2_test() {
@@ -323,7 +323,7 @@ if erlang {
     #(1, "")
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "String")))
 
     #(1, 2, 3)
     |> dynamic.from
@@ -336,7 +336,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "2 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "2 element tuple", found: "Int")))
   }
 
   pub fn tuple3_test() {
@@ -361,7 +361,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.tuple3
-    |> should.equal(Error(DecodeError(expected: "3 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "3 element tuple", found: "Int")))
   }
 
   pub fn typed_tuple3_test() {
@@ -378,7 +378,7 @@ if erlang {
     #(1, 2, "")
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "String")))
 
     #(1, 2)
     |> dynamic.from
@@ -391,7 +391,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "3 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "3 element tuple", found: "Int")))
   }
 
   pub fn tuple4_test() {
@@ -426,7 +426,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.tuple4
-    |> should.equal(Error(DecodeError(expected: "4 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "4 element tuple", found: "Int")))
   }
 
   pub fn typed_tuple4_test() {
@@ -448,7 +448,7 @@ if erlang {
     #(1, 2, 3, "")
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "String")))
 
     #(1, 2)
     |> dynamic.from
@@ -461,7 +461,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error(DecodeError(expected: "4 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "4 element tuple", found: "Int")))
   }
 
   pub fn tuple5_test() {
@@ -498,7 +498,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.tuple5
-    |> should.equal(Error(DecodeError(expected: "5 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "5 element tuple", found: "Int")))
   }
 
   pub fn typed_tuple5_test() {
@@ -533,7 +533,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "String")))
 
     #(1, 2)
     |> dynamic.from
@@ -558,7 +558,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "5 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "5 element tuple", found: "Int")))
   }
 
   pub fn tuple6_test() {
@@ -597,7 +597,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.tuple6
-    |> should.equal(Error(DecodeError(expected: "6 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "6 element tuple", found: "Int")))
   }
 
   pub fn typed_tuple6_test() {
@@ -635,7 +635,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "String")))
 
     #(1, 2)
     |> dynamic.from
@@ -662,7 +662,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error(DecodeError(expected: "6 element tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "6 element tuple", found: "Int")))
   }
 
   pub fn map_test() {
@@ -674,7 +674,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.map
-    |> should.equal(Error(DecodeError(expected: "map", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "Map", found: "Int")))
   }
 
   pub fn list_test() {
@@ -696,7 +696,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.list
-    |> should.equal(Error(DecodeError(expected: "list", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "List", found: "Int")))
   }
 
   pub fn result_test() {
@@ -713,7 +713,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.result
-    |> should.equal(Error(DecodeError(expected: "result tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "result tuple", found: "Int")))
 
     #("bad", "value")
     |> dynamic.from
@@ -738,16 +738,16 @@ if erlang {
     Ok("1")
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error(DecodeError(expected: "int", found: "binary")))
+    |> should.equal(Error(DecodeError(expected: "Int", found: "String")))
 
     Error(1)
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error(DecodeError(expected: "bit_string", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "String", found: "Int")))
 
     1
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error(DecodeError(expected: "result tuple", found: "int")))
+    |> should.equal(Error(DecodeError(expected: "result tuple", found: "Int")))
   }
 }

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -1,6 +1,6 @@
 if erlang {
   import gleam/bit_string
-  import gleam/dynamic
+  import gleam/dynamic.{DecodeError}
   import gleam/list
   import gleam/should
   import gleam/result
@@ -26,12 +26,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.bit_string
-    |> should.equal(Error("Expected a bit_string, got an int"))
+    |> should.equal(Error(DecodeError(expected: "bit_string", got: "int")))
 
     []
     |> dynamic.from
     |> dynamic.bit_string
-    |> should.equal(Error("Expected a bit_string, got a list"))
+    |> should.equal(Error(DecodeError(expected: "bit_string", got: "list")))
   }
 
   pub fn string_test() {
@@ -48,17 +48,17 @@ if erlang {
     <<65535:16>>
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error("Expected a string, got a bit_string"))
+    |> should.equal(Error(DecodeError(expected: "string", got: "bit_string")))
 
     1
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error("Expected a bit_string, got an int"))
+    |> should.equal(Error(DecodeError(expected: "bit_string", got: "int")))
 
     []
     |> dynamic.from
     |> dynamic.string
-    |> should.equal(Error("Expected a bit_string, got a list"))
+    |> should.equal(Error(DecodeError(expected: "bit_string", got: "list")))
   }
 
   pub fn int_test() {
@@ -75,12 +75,12 @@ if erlang {
     1.0
     |> dynamic.from
     |> dynamic.int
-    |> should.equal(Error("Expected an int, got a float"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "float")))
 
     []
     |> dynamic.from
     |> dynamic.int
-    |> should.equal(Error("Expected an int, got a list"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "list")))
   }
 
   pub fn float_test() {
@@ -97,12 +97,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.float
-    |> should.equal(Error("Expected a float, got an int"))
+    |> should.equal(Error(DecodeError(expected: "float", got: "int")))
 
     []
     |> dynamic.from
     |> dynamic.float
-    |> should.equal(Error("Expected a float, got a list"))
+    |> should.equal(Error(DecodeError(expected: "float", got: "list")))
   }
 
   pub fn thunk_test() {
@@ -147,12 +147,12 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.bool
-    |> should.equal(Error("Expected a bool, got an int"))
+    |> should.equal(Error(DecodeError(expected: "bool", got: "int")))
 
     []
     |> dynamic.from
     |> dynamic.bool
-    |> should.equal(Error("Expected a bool, got a list"))
+    |> should.equal(Error(DecodeError(expected: "bool", got: "list")))
   }
 
   pub fn typed_list_test() {
@@ -298,12 +298,15 @@ if erlang {
     #(1, 2, 3)
     |> dynamic.from
     |> dynamic.tuple2
-    |> should.equal(Error("Expected a 2 element tuple, got a 3 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "2 element tuple",
+      got: "3 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.tuple2
-    |> should.equal(Error("Expected a 2 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "2 element tuple", got: "int")))
   }
 
   pub fn typed_tuple2_test() {
@@ -320,17 +323,20 @@ if erlang {
     #(1, "")
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected an int, got a binary"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
 
     #(1, 2, 3)
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected a 2 element tuple, got a 3 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "2 element tuple",
+      got: "3 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.typed_tuple2(dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected a 2 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "2 element tuple", got: "int")))
   }
 
   pub fn tuple3_test() {
@@ -347,12 +353,15 @@ if erlang {
     #(1, 2)
     |> dynamic.from
     |> dynamic.tuple3
-    |> should.equal(Error("Expected a 3 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "3 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.tuple3
-    |> should.equal(Error("Expected a 3 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "3 element tuple", got: "int")))
   }
 
   pub fn typed_tuple3_test() {
@@ -369,17 +378,20 @@ if erlang {
     #(1, 2, "")
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected an int, got a binary"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
 
     #(1, 2)
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected a 3 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "3 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.typed_tuple3(dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected a 3 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "3 element tuple", got: "int")))
   }
 
   pub fn tuple4_test() {
@@ -406,12 +418,15 @@ if erlang {
     #(1, 2)
     |> dynamic.from
     |> dynamic.tuple4
-    |> should.equal(Error("Expected a 4 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "4 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.tuple4
-    |> should.equal(Error("Expected a 4 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "4 element tuple", got: "int")))
   }
 
   pub fn typed_tuple4_test() {
@@ -433,17 +448,20 @@ if erlang {
     #(1, 2, 3, "")
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected an int, got a binary"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
 
     #(1, 2)
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected a 4 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "4 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.typed_tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
-    |> should.equal(Error("Expected a 4 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "4 element tuple", got: "int")))
   }
 
   pub fn tuple5_test() {
@@ -472,12 +490,15 @@ if erlang {
     #(1, 2)
     |> dynamic.from
     |> dynamic.tuple5
-    |> should.equal(Error("Expected a 5 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "5 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.tuple5
-    |> should.equal(Error("Expected a 5 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "5 element tuple", got: "int")))
   }
 
   pub fn typed_tuple5_test() {
@@ -512,7 +533,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error("Expected an int, got a binary"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
 
     #(1, 2)
     |> dynamic.from
@@ -523,7 +544,10 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error("Expected a 5 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "5 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
@@ -534,7 +558,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error("Expected a 5 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "5 element tuple", got: "int")))
   }
 
   pub fn tuple6_test() {
@@ -565,12 +589,15 @@ if erlang {
     #(1, 2)
     |> dynamic.from
     |> dynamic.tuple6
-    |> should.equal(Error("Expected a 6 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "6 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
     |> dynamic.tuple6
-    |> should.equal(Error("Expected a 6 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "6 element tuple", got: "int")))
   }
 
   pub fn typed_tuple6_test() {
@@ -608,7 +635,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error("Expected an int, got a binary"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
 
     #(1, 2)
     |> dynamic.from
@@ -620,7 +647,10 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error("Expected a 6 element tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "6 element tuple",
+      got: "2 element tuple",
+    )))
 
     1
     |> dynamic.from
@@ -632,7 +662,7 @@ if erlang {
       dynamic.int,
       dynamic.int,
     )
-    |> should.equal(Error("Expected a 6 element tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "6 element tuple", got: "int")))
   }
 
   pub fn map_test() {
@@ -644,7 +674,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.map
-    |> should.equal(Error("Expected a map, got an int"))
+    |> should.equal(Error(DecodeError(expected: "map", got: "int")))
   }
 
   pub fn list_test() {
@@ -666,7 +696,7 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.list
-    |> should.equal(Error("Expected a list, got an int"))
+    |> should.equal(Error(DecodeError(expected: "list", got: "int")))
   }
 
   pub fn result_test() {
@@ -683,12 +713,15 @@ if erlang {
     1
     |> dynamic.from
     |> dynamic.result
-    |> should.equal(Error("Expected a result tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "result tuple", got: "int")))
 
     #("bad", "value")
     |> dynamic.from
     |> dynamic.result
-    |> should.equal(Error("Expected a result tuple, got a 2 element tuple"))
+    |> should.equal(Error(DecodeError(
+      expected: "result tuple",
+      got: "2 element tuple",
+    )))
   }
 
   pub fn typed_result_test() {
@@ -705,16 +738,16 @@ if erlang {
     Ok("1")
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error("Expected an int, got a binary"))
+    |> should.equal(Error(DecodeError(expected: "int", got: "binary")))
 
     Error(1)
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error("Expected a bit_string, got an int"))
+    |> should.equal(Error(DecodeError(expected: "bit_string", got: "int")))
 
     1
     |> dynamic.from
     |> dynamic.typed_result(ok: dynamic.int, error: dynamic.string)
-    |> should.equal(Error("Expected a result tuple, got an int"))
+    |> should.equal(Error(DecodeError(expected: "result tuple", got: "int")))
   }
 }


### PR DESCRIPTION
Instead of returning a string we return a structured error.

We update all the call sites and tests and then update the
implementation of 'decode_int', 'decode_error_msg' and 'classify' as an
example of how it might go for the rest of them.

For gleam-lang/gleam#1226

---

Does this seem like it is going in the right direction or have I misunderstood something? My knowledge of erlang is still practically zero unfortunately.