### PR TITLE
Correct function in doc tests

### DIFF
--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -168,13 +168,13 @@ pub fn max(a: Bool, b: Bool) -> Bool {
 ///
 /// ## Examples
 ///
-///    > max(True, False)
+///    > min(True, False)
 ///    False
 ///
-///    > max(False, True)
+///    > min(False, True)
 ///    False
 ///
-///    > max(False, False)
+///    > min(False, False)
 ///    False
 ///
 pub fn min(a: Bool, b: Bool) -> Bool {

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -405,7 +405,7 @@ pub fn filter(
 ///
 /// ## Examples
 ///
-///    > [1, 2] |> from_list |> cycle |> take(6)
+///    > [1, 2] |> from_list |> cycle |> take(6) |> to_list
 ///    [1, 2, 1, 2, 1, 2]
 ///
 pub fn cycle(iterator: Iterator(a)) -> Iterator(a) {
@@ -509,7 +509,7 @@ pub fn index(over iterator: Iterator(element)) -> Iterator(#(Int, element)) {
 ///
 /// ## Examples
 ///
-///    > iterate(1, fn(n) { n * 3 }) |> take(5)
+///    > iterate(1, fn(n) { n * 3 }) |> take(5) |> to_list
 ///    [1, 3, 9, 27, 81]
 ///
 pub fn iterate(
@@ -756,10 +756,10 @@ fn do_sized_chunk(
 ///
 /// ## Examples
 ///
-///    > from_list([1, 2, 3, 4, 5, 6]) |> chunk(into: 2) |> to_list
+///    > from_list([1, 2, 3, 4, 5, 6]) |> sized_chunk(into: 2) |> to_list
 ///    [[1, 2], [3, 4], [5, 6]]
 ///
-///    > from_list([1, 2, 3, 4, 5, 6, 7, 8]) |> chunk(into: 3) |> to_list
+///    > from_list([1, 2, 3, 4, 5, 6, 7, 8]) |> sized_chunk(into: 3) |> to_list
 ///    [[1, 2, 3], [4, 5, 6], [7, 8]]
 ///
 pub fn sized_chunk(

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -99,7 +99,7 @@ if erlang {
 }
 
 if javascript {
-  pub fn do_reverse(list) {
+  fn do_reverse(list) {
     do_reverse_acc(list, [])
   }
 
@@ -1185,10 +1185,10 @@ pub fn pop_map(
 /// ## Examples
 ///
 ///    > key_pop([#("a", 0), #("b", 1)], "a")
-///    Ok(#(0, [#("b", 1)])
+///    Ok(#(0, [#("b", 1)]))
 ///
 ///    > key_pop([#("a", 0), #("b", 1)], "b")
-///    Ok(#(1, [#("a", 0)])
+///    Ok(#(1, [#("a", 0)]))
 ///
 ///    > key_pop([#("a", 0), #("b", 1)], "c")
 ///    Error(Nil)
@@ -1331,7 +1331,7 @@ pub fn window_by_2(l: List(a)) -> List(#(a, a)) {
 ///
 /// ## Examples
 ///
-///    > drop_while([1, 2, 3, 4], fun (x) { x < 3 })
+///    > drop_while([1, 2, 3, 4], fn (x) { x < 3 })
 ///    [3, 4]
 ///
 pub fn drop_while(
@@ -1367,7 +1367,7 @@ fn do_take_while(
 ///
 /// ## Examples
 ///
-///    > take_while([1, 2, 3, 2, 4], fun (x) { x < 3 })
+///    > take_while([1, 2, 3, 2, 4], fn (x) { x < 3 })
 ///    [1, 2]
 ///
 pub fn take_while(
@@ -1446,10 +1446,10 @@ fn do_sized_chunk(
 ///
 /// ## Examples
 ///
-///    > [1, 2, 3, 4, 5, 6] |> chunk(into: 2)
+///    > [1, 2, 3, 4, 5, 6] |> sized_chunk(into: 2)
 ///    [[1, 2], [3, 4], [5, 6]]
 ///
-///    > [1, 2, 3, 4, 5, 6, 7, 8] |> chunk(into: 3)
+///    > [1, 2, 3, 4, 5, 6, 7, 8] |> sized_chunk(into: 3)
 ///    [[1, 2, 3], [4, 5, 6], [7, 8]]
 ///
 pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -88,7 +88,7 @@ pub fn to_result(option: Option(a), e) -> Result(a, e) {
 ///
 ///    > from_result(Ok(1))
 ///    Some(1)
-///    > from_result(Error"some_error"))
+///    > from_result(Error("some_error"))
 ///    None
 ///
 pub fn from_result(result: Result(a, e)) -> Option(a) {

--- a/src/gleam/pair.gleam
+++ b/src/gleam/pair.gleam
@@ -40,7 +40,7 @@ pub fn swap(pair: #(a, b)) -> #(b, a) {
 /// ## Examples
 ///
 ///    > #(1, 2) |> map_first(fn(n) { n * 2 })
-///    2
+///    #(2, 2)
 ///
 pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
   let #(a, b) = pair
@@ -53,7 +53,7 @@ pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
 /// ## Examples
 ///
 ///    > #(1, 2) |> map_second(fn(n) { n * 2 })
-///    4
+///    #(1, 4)
 ///
 pub fn map_second(of pair: #(a, b), with fun: fn(b) -> c) -> #(a, c) {
   let #(a, b) = pair

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -188,13 +188,13 @@ pub fn pop_front(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
 ///
 /// ## Examples
 ///
-///    > reverse(from_list([]))
+///    > [] |> from_list |> reverse |> to_list
 ///    []
 ///
-///    > reverse(from_list([1]))
+///    > [1] |> from_list |> reverse |> to_list
 ///    [1]
 ///
-///    > reverse(from_list([1, 2]))
+///    > [1, 2] |> from_list |> reverse |> to_list
 ///    [2, 1]
 ///
 pub fn reverse(queue: Queue(a)) -> Queue(a) {

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -89,7 +89,7 @@ pub fn map_error(
 ///    > flatten(Ok(Ok(1)))
 ///    Ok(1)
 ///
-///    > flatten(Ok(Error(""))
+///    > flatten(Ok(Error("")))
 ///    Error("")
 ///
 ///    > flatten(Error(Nil))

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -288,12 +288,6 @@ if javascript {
 ///
 /// ## Examples
 ///
-///    > from_strings(["a", "b"]) == new("ab")
-///    False
-///
-///    > is_equal(from_strings(["a", "b"]), new("ab"))
-///    True
-///
 ///
 pub fn is_equal(a: StringBuilder, b: StringBuilder) -> Bool {
   do_is_equal(a, b)
@@ -312,12 +306,6 @@ if javascript {
 /// Inspects a builder to determine if it is equivalent to an empty string.
 ///
 /// ## Examples
-///
-///    > new("ok") |> is_empty
-///    False
-///
-///    > new("") |> is_empty
-///    True
 ///
 ///    > from_strings([]) |> is_empty
 ///    True

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -288,6 +288,12 @@ if javascript {
 ///
 /// ## Examples
 ///
+///    > from_strings(["a", "b"]) == new("ab")
+///    False
+///
+///    > is_equal(from_strings(["a", "b"]), new("ab"))
+///    True
+///
 ///
 pub fn is_equal(a: StringBuilder, b: StringBuilder) -> Bool {
   do_is_equal(a, b)
@@ -306,6 +312,12 @@ if javascript {
 /// Inspects a builder to determine if it is equivalent to an empty string.
 ///
 /// ## Examples
+///
+///    > new("ok") |> is_empty
+///    False
+///
+///    > new("") |> is_empty
+///    True
 ///
 ///    > from_strings([]) |> is_empty
 ///    True


### PR DESCRIPTION
Found with a hacky little doc-test script.

This node script generates an ugly little test file with some of the doc tests:
```javascript
import * as fs from "fs";

const doctextRegex = /\/\/\/    > ([^\n]*)\n\/\/\/    ([^>].*)\n/gm;

function main(args) {
    const file = args[1];
    const contents = fs.readFileSync(file, "utf8");

    const matches = contents.matchAll(doctextRegex);

    const testBlocks = [];
    let index = 1;
    for (const entry of matches) {
        testBlocks.push(`pub fn doc_${index}_test() {
  ${entry[1]}
  |> should.equal(${entry[2]})
}`);
        index++;
    }

    const output = `

import gleam/should
import gleam/order
import gleam/bool.{to_int, negate, nor, nand, exclusive_or, exclusive_nor, compare, max, min}

${testBlocks.join("\n")}
`;

    fs.writeFileSync("test/gleam/doc_test.gleam", output);
}

main(process.argv.slice(1));
```
And identified these as failing. For what is obvious reason. Might be fun to try it on other modules. I'm happy to leave this PR open until it has been tried on other modules.

Checked with:
```bash
node doctest.js src/gleam/bool.gleam && bash ./bin/test.sh
```