### PR TITLE
Update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Add `gleam_stdlib` to the deps section of your `rebar.config` or `mix.exs`
 
 ```erlang
 {deps, [
-    {gleam_stdlib, "~> 0.16.0"}
+    {gleam_stdlib, "~> 0.17.1"}
 ]}
 ```
 
 ```elixir
 defp deps do
   [
-    {:gleam_stdlib, "~> 0.16.0"},
+    {:gleam_stdlib, "~> 0.17.1"},
   ]
 end
 ```

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gleam_stdlib"
-version = "0.16.0"
+version = "0.17.1"
 
 [repository]
 type = "github"


### PR DESCRIPTION
The version listed in the README.md  and on HexDocs: https://hexdocs.pm/gleam_stdlib/ seem to not have been updated to v 0.17.1.