### PR TITLE
Add map functions to iterator module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - The `float` module gains the `divide` function.
 - The `int` module gains the `divide`, `power`, and `square_root` functions.
 - The `string` module gains the `first`, `last`, and `capitalise` functions.
+- The `iterator` module gains the `to_map` function.
+- The `iterator` module gains the `from_map`, `from_map_keys` and `from_map_values` functions (Erlang only).
 
 ## v0.21.0 - 2022-04-24
 

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1227,3 +1227,67 @@ pub fn at(in iterator: Iterator(e), get index: Int) -> Result(e, Nil) {
   |> drop(index)
   |> first
 }
+
+/// Evaluates an iterator of `#(key, value)` pairs and returns them as a map.
+///
+/// If called on an iterator of infinite length then this function will never return.
+///
+/// ## Examples
+///
+/// ```
+/// > from_list([#("a", 1), #("b", 2)]) |> to_map
+/// {"a": 1, "b": 2}
+/// ```
+pub fn to_map(iterator: Iterator(#(k, v))) -> Map(k, v) {
+  iterator
+  |> fold(
+    map.new(),
+    fn(map, pair: #(k, v)) {
+      map
+      |> map.insert(pair.0, pair.1)
+    },
+  )
+}
+
+if erlang {
+  external fn do_from_map(Map(k, v)) -> Iterator(#(k, v)) =
+    "gleam_stdlib" "map_iterator"
+
+  /// Creates an iterator that yields `#(key, value)` pairs from the given map.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// > map.from_list([#("a", 1), #("b", 2)]) |> from_map |> to_list
+  /// [#("a", 1), #("b", 2)]
+  /// ```
+  pub fn from_map(map: Map(k, v)) -> Iterator(#(k, v)) {
+    do_from_map(map)
+  }
+
+  /// Creates an iterator that yields keys from the given map.
+  ///
+  /// ## Examples
+  ///
+  /// ```
+  /// > map.from_list([#("a", 1), #("b", 2)]) |> from_map_keys |> to_list
+  /// ["a", "b"]
+  /// ```
+  pub fn from_map_keys(m: Map(k, v)) -> Iterator(k) {
+    from_map(m)
+    |> map(fn(pair: #(k, v)) { pair.0 })
+  }
+
+  /// Creates an iterator that yields values from the given map.
+  ///
+  /// ## Examples
+  ///
+  /// ```
+  /// > map.from_list([#("a", 1), #("b", 2)]) |> from_map_values |> to_list
+  /// [1, 2]
+  /// ```
+  pub fn from_map_values(m: Map(k, v)) -> Iterator(v) {
+    from_map(m)
+    |> map(fn(pair: #(k, v)) { pair.1 })
+  }
+}

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -1,6 +1,6 @@
 -module(gleam_stdlib).
 
--export([map_get/2, iodata_append/2, identity/1, decode_int/1, decode_bool/1,
+-export([map_get/2, map_iterator/1, iodata_append/2, identity/1, decode_int/1, decode_bool/1,
          decode_float/1, decode_thunk/1, decode_list/1, decode_option/2,
          decode_field/2, parse_int/1, parse_float/1, less_than/2,
          string_pop_grapheme/1, string_starts_with/2, wrap_list/1,
@@ -319,3 +319,16 @@ print(String) ->
 println(String) ->
     io:put_chars([String, $\n]),
     nil.
+
+map_continuation(Iter) ->
+    fun() ->
+        case maps:next(Iter) of
+            none -> stop;
+            {Key, Value, Next} ->
+                {continue, {Key, Value}, map_continuation(Next)}
+        end
+    end.
+
+map_iterator(Map) ->
+    Iter = maps:iterator(Map),
+    {iterator, map_continuation(Iter)}.

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -505,3 +505,29 @@ pub fn at_test() {
   |> iterator.at(0)
   |> should.equal(Error(Nil))
 }
+
+if erlang {
+  pub fn from_map_test() {
+    let map = map.from_list([#("a", 1), #("b", 2)])
+
+    iterator.from_map(map)
+    |> iterator.to_list
+    |> should.equal([#("a", 1), #("b", 2)])
+  }
+
+  pub fn from_map_keys_test() {
+    let map = map.from_list([#("a", 1), #("b", 2)])
+
+    iterator.from_map_keys(map)
+    |> iterator.to_list
+    |> should.equal(["a", "b"])
+  }
+
+  pub fn from_map_values_test() {
+    let map = map.from_list([#("a", 1), #("b", 2)])
+
+    iterator.from_map_values(map)
+    |> iterator.to_list()
+    |> should.equal([1, 2])
+  }
+}


### PR DESCRIPTION
Currently `from_map*` functions are there only for Erlang because I haven't figured out how to work with the `gleam_stdlib.js` one.