### PR TITLE
Simplify and unify `list.at` with `iterator.at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `iterator` module gains the `first` and `at` functions.
 - The `list` module renames the `head` and `tail` functions to `first` and `rest`.
+- The `list.at` function now behaves uniformly to `iterator.at`.
 - `int.to_base_string` now returns a `Result(Int, InvalidBase)`.
 - The `int` module gains the `to_base2`, `to_base8`, `to_base16` and `to_base36` functions.
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -882,6 +882,8 @@ pub fn intersperse(list: List(a), with elem: a) -> List(a) {
 ///
 /// Error(Nil) is returned if the list is not long enough for the given index.
 ///
+/// For any `index` less than 0 this function behaves as if it was set to 0.
+///
 /// ## Examples
 ///
 ///    > at([1, 2, 3], 1)
@@ -891,18 +893,9 @@ pub fn intersperse(list: List(a), with elem: a) -> List(a) {
 ///    Error(Nil)
 ///
 pub fn at(in list: List(a), get index: Int) -> Result(a, Nil) {
-  case index < 0 {
-    True -> Error(Nil)
-    False ->
-      case list {
-        [] -> Error(Nil)
-        [x, ..rest] ->
-          case index == 0 {
-            True -> Ok(x)
-            False -> at(rest, index - 1)
-          }
-      }
-  }
+  list
+  |> drop(index)
+  |> first
 }
 
 /// Removes any duplicate elements from a given list.

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -376,7 +376,7 @@ pub fn at_test() {
   |> should.equal(Error(Nil))
 
   list.at([1, 2, 3, 4, 5, 6], -1)
-  |> should.equal(Error(Nil))
+  |> should.equal(Ok(1))
 }
 
 pub fn unique_test() {


### PR DESCRIPTION
Previously indices < 0 resulted in `Error`, now are normalized to 0, for consistence with `iterator`.