### PR TITLE
Update order of arguments in the docs for `map.fold`

### DIFF
--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -472,11 +472,11 @@ fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(acc, k, v) -> acc) -> acc 
 /// # Examples
 ///
 ///    > let map = from_list([#("a", 1), #("b", 3), #("c", 9)])
-///    > fold(map, 0, fn(key, value, accumulator) { accumulator + value })
+///    > fold(map, 0, fn(accumulator, key, value) { accumulator + value })
 ///    13
 ///
 ///    > import gleam/string.{append}
-///    > fold(map, "", fn(key, value, accumulator) { append(accumulator, value) })
+///    > fold(map, "", fn(accumulator, key, value) { append(accumulator, key) })
 ///    "abc"
 ///
 pub fn fold(


### PR DESCRIPTION
Closes https://github.com/gleam-lang/stdlib/issues/245

## Problem

The docs for `map.fold` do not match the code. Going purely off  the docs can lead to confusing results, like me, which resulted in me opening #245. 

## Solution

- Switch the order of arguments in the documentation to match the code. 
- Switch `value` to `key` in one of the examples so that it's correct.
