### PR TITLE
Correct accumulator argument position in documentation

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -138,7 +138,7 @@ fn do_fold(
 ///
 ///    > [1, 2, 3, 4]
 ///    > |> from_list
-///    > |> fold(from: 0, with: fn(element, acc) { element + acc })
+///    > |> fold(from: 0, with: fn(acc, element) { element + acc })
 ///    10
 ///
 pub fn fold(
@@ -601,7 +601,7 @@ fn do_scan(
 /// ## Examples
 ///
 ///    Generate a sequence of partial sums:
-///    > from_list([1, 2, 3, 4, 5]) |> scan(from: 0, with: fn(el, acc) { acc + el }) |> to_list
+///    > from_list([1, 2, 3, 4, 5]) |> scan(from: 0, with: fn(acc, el) { acc + el }) |> to_list
 ///    [1, 3, 6, 10, 15]
 ///
 pub fn scan(
@@ -1051,7 +1051,7 @@ fn do_fold_until(
 ///
 ///
 /// ## Examples
-///    > let f = fn(e, acc) {
+///    > let f = fn(acc, e) {
 ///    >   case e {
 ///    >     _ if e < 4 -> list.Continue(e + acc)
 ///    >     _ -> list.Stop(acc)
@@ -1097,7 +1097,7 @@ fn do_try_fold(
 /// 
 ///    > [1, 2, 3, 4]
 ///    > |> iterator.from_list()
-///    > |> try_fold(0, fn(i, acc) {
+///    > |> try_fold(0, fn(acc, i) {
 ///    >   case i < 3 {
 ///    >     True -> Ok(acc + i)
 ///    >     False -> Error(Nil)

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -289,7 +289,7 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
 /// > map_fold(
 ///     over: [1, 2, 3],
 ///     from: 100,
-///     with: fn(i, memo) { #(i * 2, memo + i) }
+///     with: fn(memo, i) { #(i * 2, memo + i) }
 ///  )
 ///  #([2, 4, 6], 106)
 /// ```
@@ -526,7 +526,7 @@ pub fn flat_map(over list: List(a), with fun: fn(a) -> List(b)) -> List(b) {
 /// Reduces a list of elements into a single value by calling a given function
 /// on each element, going from left to right.
 ///
-/// `fold([1, 2, 3], 0, add)` is the equivalent of `add(3, add(2, add(1, 0)))`.
+/// `fold(0, [1, 2, 3], add)` is the equivalent of `add(3, add(2, add(1, 0)))`.
 ///
 /// This function runs in linear time.
 ///
@@ -544,7 +544,7 @@ pub fn fold(
 /// Reduces a list of elements into a single value by calling a given function
 /// on each element, going from right to left.
 ///
-/// `fold_right([1, 2, 3], 0, add)` is the equivalent of
+/// `fold_right(0, [1, 2, 3], add)` is the equivalent of
 /// `add(1, add(2, add(3, 0)))`.
 ///
 /// This function runs in linear time.
@@ -582,7 +582,7 @@ fn do_index_fold(
 ///
 /// ```
 /// ["a", "b", "c"]
-/// |> list.index_fold([], fn(index, item, acc) { ... })
+/// |> list.index_fold([], fn(acc, item, index) { ... })
 /// ```
 ///
 pub fn index_fold(
@@ -603,7 +603,7 @@ pub fn index_fold(
 ///
 /// ```
 /// [1, 2, 3, 4]
-/// |> try_fold(0, fn(i, acc) {
+/// |> try_fold(0, fn(acc, i) {
 ///   case i < 3 {
 ///     True -> Ok(acc + i)
 ///     False -> Error(Nil)
@@ -640,7 +640,7 @@ pub type ContinueOrStop(a) {
 ///
 /// ```
 /// [1, 2, 3, 4]
-/// |> fold_until(0, fn(i, acc) {
+/// |> fold_until(0, fn(acc, i) {
 ///   case i < 3 {
 ///     True -> Continue(acc + i)
 ///     False -> Stop(acc)
@@ -1455,7 +1455,7 @@ pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
 /// This function acts similar to fold, but does not take an initial state.
 /// Instead, it starts from the first element in the list
 /// and combines it with each subsequent element in turn using the given function.
-/// The function is called as fun(current_element, accumulator).
+/// The function is called as fun(accumulator, current_element).
 ///
 /// Returns `Ok` to indicate a successful run, and `Error` if called on an empty list.
 ///
@@ -1464,7 +1464,7 @@ pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
 ///    > [] |> reduce(fn(x, y) { x + y })
 ///    Error(Nil)
 ///
-///    > [1, 2, 3, 4, 5] |> reduce(fn(x, y) { x + y })
+///    > [1, 2, 3, 4, 5] |> reduce(fn(acc, i) { acc + i })
 ///    Ok(15)
 ///
 pub fn reduce(over list: List(a), with fun: fn(a, a) -> a) -> Result(a, Nil) {
@@ -1493,7 +1493,7 @@ fn do_scan(
 ///
 /// ## Examples
 ///
-///    > scan(over: [1, 2, 3], from: 100, with: fn(i, acc) { acc + i })
+///    > scan(over: [1, 2, 3], from: 100, with: fn(acc, i) { acc + i })
 ///    [101, 103, 106]
 ///
 pub fn scan(

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -472,11 +472,11 @@ fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(acc, k, v) -> acc) -> acc 
 /// # Examples
 ///
 ///    > let map = from_list([#("a", 1), #("b", 3), #("c", 9)])
-///    > fold(map, 0, fn(key, value, accumulator) { accumulator + value })
+///    > fold(map, 0, fn(accumulator, key, value) { accumulator + value })
 ///    13
 ///
 ///    > import gleam/string.{append}
-///    > fold(map, "", fn(key, value, accumulator) { append(accumulator, value) })
+///    > fold(map, "", fn(accumulator, key, value) { append(accumulator, key) })
 ///    "abc"
 ///
 pub fn fold(

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -293,7 +293,7 @@ pub fn drop_while_test() {
 
 pub fn scan_test() {
   iterator.from_list([1, 2, 3, 4, 5])
-  |> iterator.scan(from: 0, with: fn(el, acc) { acc + el })
+  |> iterator.scan(from: 0, with: fn(acc, el) { acc + el })
   |> iterator.to_list
   |> should.equal([1, 3, 6, 10, 15])
 }

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -234,7 +234,7 @@ pub fn try_fold_test() {
   [1, 2, 3]
   |> list.try_fold(
     0,
-    fn(i, acc) {
+    fn(acc, i) {
       case i < 4 {
         True -> Ok(acc + i)
         False -> Error(Nil)
@@ -246,7 +246,7 @@ pub fn try_fold_test() {
   [1, 2, 3]
   |> list.try_fold(
     0,
-    fn(i, acc) {
+    fn(acc, i) {
       case i < 3 {
         True -> Ok(acc + i)
         False -> Error(Nil)


### PR DESCRIPTION
Closes #245

This is a superset of #246. This corrects all mentions I could find of the accumulator being in the incorrect argument position in the documentation and updates it to the correct position.