### PR TITLE
add string.is_blank and list.drop_where functions with tests.

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -21,6 +21,7 @@
 import gleam/int
 import gleam/pair
 import gleam/order.{Order}
+import gleam/bool.{negate}
 
 /// An error value returned by the `strict_zip` function.
 ///
@@ -412,6 +413,26 @@ pub fn drop(from list: List(a), up_to n: Int) -> List(a) {
         [_, ..xs] -> drop(xs, n - 1)
       }
   }
+}
+
+/// Returns a list containing all elements except the elements
+/// that satisfy the given predicate.
+///
+/// ## Examples
+///
+///    > drop([1, 2, 3, 4, 3, 2, 1], fn (x) { x < 3 })
+///    [3, 4]
+///
+///    > ["hello", " ", "World!"]
+///      |> drop_where(string.is_blank)
+///    ["hello","World!"]
+///
+pub fn drop_where(
+  from list: List(a),
+  satisfying predicate: fn(a) -> Bool,
+) -> List(a) {
+  list
+  |> filter(fn(e) { negate(predicate(e)) })
 }
 
 fn do_take(list: List(a), n: Int, acc: List(a)) -> List(a) {

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -26,6 +26,25 @@ pub fn is_empty(str: String) -> Bool {
   str == ""
 }
 
+/// Determines if a string only contains whitespace characters.
+///
+/// ## Examples
+///
+///    > is_blank("  ")
+///    True
+///
+///    > is_blank("")
+///    True
+///
+///    > is_blank("the world")
+///    False
+///
+pub fn is_blank(str: String) -> Bool {
+  str
+  |> trim
+  |> is_empty
+}
+
 /// Gets the number of grapheme clusters in a given string.
 ///
 /// This function has to iterate across the whole string to count the number of

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -26,7 +26,6 @@ pub fn is_empty(str: String) -> Bool {
   str == ""
 }
 
-
 /// Determines if a string only contains whitespace characters.
 ///
 /// ## Examples

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -139,6 +139,20 @@ pub fn drop_test() {
   |> should.equal([6, 7, 8])
 }
 
+pub fn drop_where_test() {
+  []
+  |> list.drop_where(fn(x) { x > 1 })
+  |> should.equal([])
+
+  [1, 2, 3, 4, 5, 6, 7, 8]
+  |> list.drop_where(fn(x) { x > 5 })
+  |> should.equal([1, 2, 3, 4, 5])
+
+  ["hello", " ", "World!"]
+  |> list.drop_where(string.is_blank)
+  |> should.equal(["hello", "World!"])
+}
+
 pub fn take_test() {
   []
   |> list.take(5)

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -14,6 +14,14 @@ pub fn is_blank_test() {
 
   string.is_blank("")
   |> should.be_true
+
+  //tabs
+  string.is_blank("       ")
+  |> should.be_true
+
+  //unicode
+  string.is_blank("‎‏‏‎")
+  |> should.be_true
 }
 
 pub fn length_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -5,6 +5,17 @@ import gleam/option.{None, Some}
 import gleam/io
 import gleam/bit_string
 
+pub fn is_blank_test() {
+  string.is_blank("    ")
+  |> should.equal(True)
+
+  string.is_blank("Gleam")
+  |> should.equal(False)
+
+  string.is_blank("")
+  |> should.equal(True)
+}
+
 pub fn length_test() {
   string.length("ß↑e̊")
   |> should.equal(3)

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -7,13 +7,13 @@ import gleam/bit_string
 
 pub fn is_blank_test() {
   string.is_blank("    ")
-  |> should.equal(True)
+  |> should.be_true
 
   string.is_blank("Gleam")
-  |> should.equal(False)
+  |> should.be_false
 
   string.is_blank("")
-  |> should.equal(True)
+  |> should.be_true
 }
 
 pub fn length_test() {


### PR DESCRIPTION
These are small convenient functions. 

is_blank determines if a string only contains whitespace characters
drop_where removes elements satisfying a predicate, mainly to improve readability of negation filtering.

```
"hello   world"
|> string.to_graphemes()
|> list.drop_where(string.is_blank) 
```
the above reads like english compared to:

```
"hello    world"
|> string.to_graphemes()
|> list.filter(fn(e) { string.trim(e) != "" })
```