### PR TITLE
Update JavaScript import paths from .js to .mjs

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -8,13 +8,13 @@ import {
   inspect,
   stringBits,
   toBitString,
-} from "./gleam.js";
+} from "./gleam.mjs";
 import {
   CompileError as RegexCompileError,
   Match as RegexMatch,
-} from "./gleam/regex.js";
-import { DecodeError } from "./gleam/dynamic.js";
-import { Some, None } from "./gleam/option.js";
+} from "./gleam/regex.mjs";
+import { DecodeError } from "./gleam/dynamic.mjs";
+import { Some, None } from "./gleam/option.mjs";
 
 const HASHCODE_CACHE = new WeakMap();
 


### PR DESCRIPTION
Currently (using gleam/main) these do not import the correct files as the generated files have the `.mjs` extension.