### PR TITLE
docs: improve string.to_option example

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -675,8 +675,8 @@ pub fn utf_codepoint(value: Int) -> Result(UtfCodepoint, Nil) {
 /// ```
 ///
 /// ```gleam
-/// > to_option("")
-/// None
+/// > to_option("hats")
+/// Some("hats")
 /// ```
 ///
 pub fn to_option(s: String) -> Option(String) {


### PR DESCRIPTION
the `to_option("")` example was repeated twice, I figured it was a mistake. Other examples use the word hats so I added it here too.