### PR TITLE
✨ Add `new` constructor functions for empty `BitBuilder`s and `StringBuilder`s.

### DIFF
--- a/src/gleam/bit_builder.gleam
+++ b/src/gleam/bit_builder.gleam
@@ -28,6 +28,13 @@ if javascript {
   }
 }
 
+/// Create an empty `BitBuilder`. Useful as the start of a pipe chaning many
+/// builders together.
+///
+pub fn new () -> BitBuilder {
+  do_concat([])
+}
+
 /// Prepends a bit string to the start of a builder.
 ///
 /// Runs in constant time.

--- a/src/gleam/bit_builder.gleam
+++ b/src/gleam/bit_builder.gleam
@@ -31,7 +31,7 @@ if javascript {
 /// Create an empty `BitBuilder`. Useful as the start of a pipe chaning many
 /// builders together.
 ///
-pub fn new () -> BitBuilder {
+pub fn new() -> BitBuilder {
   do_concat([])
 }
 

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -14,6 +14,13 @@
 ///
 pub external type StringBuilder
 
+/// Create an empty `StringBuilder`. Useful as the start of a pipe chaning many
+/// builders together.
+///
+pub fn new() -> StringBuilder {
+  do_from_strings([])
+}
+
 /// Prepends a `String` onto the start of some `StringBuilder`.
 ///
 /// Runs in constant time.


### PR DESCRIPTION
Does what it says on the tin, really. Some people might prefer to construct builders starting from "nothing", so:
```
new()
|> append(foo_builder)
|> append(bar_builder)
```
instead of:
```
foo_builder
|> append(bar_builder)
```