### PR TITLE
tidy function.tap_test

### DIFF
--- a/test/gleam/function_test.gleam
+++ b/test/gleam/function_test.gleam
@@ -118,6 +118,9 @@ pub fn constant_test() {
 
 pub fn tap_test() {
   "Thanks Joe & Louis"
-  |> function.tap(io.print)
+  |> function.tap(fn(s: String) {
+    string.append(s, "... and Jose!")
+    Nil
+  })
   |> should.equal("Thanks Joe & Louis")
 }


### PR DESCRIPTION
Cleans up test https://github.com/gleam-lang/stdlib/pull/282
The test was pushing data to stdout.
`gleam test` did not show io.print but `gleam test --target javascript` would.