### PR TITLE
fix unit test failing over missing string.replaceAll() implementation on nodejs <= 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   for empty strings on older JavaScript runtimes.
 - The `bool` module gains the `to_string` function.
 - The `function` module gains the `tap` function.
-- The JavaScript implementation of the `string` module's `string_replace` received fallback code for NodeJS 14 compatibility.
+- The JavaScript target implementation of the `string.replace` received fallback code for NodeJS 14 compatibility.
 
 ## v0.20.0 - 2022-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   for empty strings on older JavaScript runtimes.
 - The `bool` module gains the `to_string` function.
 - The `function` module gains the `tap` function.
+- The JavaScript implementation of the `string` module's `string_replace` received fallback code for NodeJS 14 compatibility.
 
 ## v0.20.0 - 2022-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   for empty strings on older JavaScript runtimes.
 - The `bool` module gains the `to_string` function.
 - The `function` module gains the `tap` function.
-- The JavaScript target implementation of the `string.replace` received fallback code for NodeJS 14 compatibility.
+- The JavaScript target implementation of the `string.replace` received
+  fallback code for NodeJS 14 compatibility.
 
 ## v0.20.0 - 2022-02-22
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -58,7 +58,19 @@ export function int_to_base_string(int, base) {
 }
 
 export function string_replace(string, target, substitute) {
-  return string.replaceAll(target, substitute);
+  if (typeof string.replaceAll !== "undefined") {
+    return string.replaceAll(target, substitute);
+  }
+  // Fallback for older Node.js versions:
+  // 1. <https://stackoverflow.com/a/1144788>
+  // 2. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping>
+  // TODO: This fallback could be remove once Node.js 14 is EOL
+  // aka <https://nodejs.org/en/about/releases/> on or after 2024-04-30
+  return string.replace(
+    // $& means the whole matched string
+    new RegExp(target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+    substitute
+  );
 }
 
 export function string_reverse(string) {


### PR DESCRIPTION
Fixes this on nodejs v14, the error did not occur on nodejs v16 or v17 as replaceAll is implemented there natively:

```
❯ nvm use 14
Now using node v14.17.0 (npm v8.5.3)
❯ gleam test --target javascript
  Compiling gleam_stdlib
   Compiled in 0.57s
    Running gleam_stdlib_test.main
Running tests...
................
❌ 
gleam/string_test..replace_test: TypeError: Cannot use 'in' operator to search for 'replaceAll' in Gleam,Erlang,Elixir

❌ 
gleam/base_test..encode64_test: TypeError: Cannot use 'in' operator to search for 'replaceAll' in /3/+/A==

❌ 
gleam/base_test..url_decode64_test: TypeError: Cannot use 'in' operator to search for 'replaceAll' in _3_-_A==

❌ 
gleam/base_test..url_encode64_test: TypeError: Cannot use 'in' operator to search for 'replaceAll' in /3/+/A==
...........................

375 tests
371 passes
4 failures
```