### PR TITLE
Nitpickery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fn more_usage() {
 
 ## Targets
 
-Gleam's standard library supports both targets: Erlang and Javascript.
+Gleam's standard library supports both targets: Erlang and JavaScript.
 
 ### Compatibility
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -1,10 +1,10 @@
+import gleam/int
 import gleam/list
 import gleam/map
-import gleam/int
-import gleam/result
-import gleam/string_builder
 import gleam/map.{Map}
 import gleam/option.{Option}
+import gleam/result
+import gleam/string_builder
 
 if erlang {
   import gleam/bit_string
@@ -788,7 +788,7 @@ pub fn tuple5(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2, 3, 4, 5, 6)) 
+/// > from(#(1, 2, 3, 4, 5, 6))
 /// > |> tuple6(int, int, int, int, int, int)
 /// Ok(#(1, 2, 3, 4, 5, 6))
 ///

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -1,5 +1,5 @@
-import gleam/order.{Order}
 import gleam/float
+import gleam/order.{Order}
 
 /// Returns the absolute value of the input.
 ///

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1,6 +1,6 @@
 import gleam/list
-import gleam/option.{None, Option, Some}
 import gleam/map.{Map}
+import gleam/option.{None, Option, Some}
 
 // Internal private representation of an Iterator
 type Action(element) {
@@ -1127,7 +1127,7 @@ fn do_fold_until(
 /// >
 /// > [1, 2, 3, 4]
 /// > |> from_list
-/// > |> iterator.fold_until(from: acc, with: f) 
+/// > |> iterator.fold_until(from: acc, with: f)
 /// 6
 /// ```
 ///
@@ -1155,7 +1155,7 @@ fn do_try_fold(
 }
 
 /// A variant of fold that might fail.
-/// 
+///
 ///
 /// The folding function should return `Result(accumulator, error)`.
 /// If the returned value is `Ok(accumulator)` try_fold will try the next value in the iterator.

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -23,8 +23,8 @@
 ////
 
 import gleam/int
-import gleam/pair
 import gleam/order.{Order}
+import gleam/pair
 
 /// An error value returned by the `strict_zip` function.
 ///

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -1,5 +1,5 @@
-import gleam/option.{Option}
 import gleam/list
+import gleam/option.{Option}
 
 if javascript {
   import gleam/pair

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -1,6 +1,6 @@
+import gleam/list
 import gleam/map.{Map}
 import gleam/result
-import gleam/list
 
 if erlang {
   // A list is used as the map value as an empty list has the smallest

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -1,11 +1,11 @@
 //// Strings in Gleam are UTF-8 binaries. They can be written in your code as
 //// text surrounded by `"double quotes"`.
 
-import gleam/string_builder
 import gleam/iterator.{Iterator}
 import gleam/list
-import gleam/order
 import gleam/option.{None, Option, Some}
+import gleam/order
+import gleam/string_builder
 
 if erlang {
   import gleam/result

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -7,11 +7,11 @@
 //// Query encoding (Form encoding) is defined in the w3c specification.
 //// https://www.w3.org/TR/html52/sec-forms.html#urlencoded-form-data
 
-import gleam/string_builder.{StringBuilder}
 import gleam/int
 import gleam/list
 import gleam/option.{None, Option, Some}
 import gleam/string
+import gleam/string_builder.{StringBuilder}
 
 if javascript {
   import gleam/pair
@@ -60,7 +60,7 @@ if javascript {
   fn do_parse(uri_string: String) -> Result(Uri, Nil) {
     // From https://tools.ietf.org/html/rfc3986#appendix-B
     let pattern =
-      //    12                        3  4          5       6  7        8 
+      //    12                        3  4          5       6  7        8
       "^(([a-z][a-z0-9\\+\\-\\.]*):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#.*)?"
     let matches =
       pattern

--- a/test/gleam/bit_builder_test.gleam
+++ b/test/gleam/bit_builder_test.gleam
@@ -1,5 +1,5 @@
-import gleam/should
 import gleam/bit_builder
+import gleam/should
 
 pub fn builder_test() {
   let data =

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -1,8 +1,8 @@
-import gleam/should
 import gleam/dynamic.{DecodeError}
-import gleam/result
 import gleam/map
 import gleam/option.{None, Some}
+import gleam/result
+import gleam/should
 
 pub fn bit_string_test() {
   <<>>

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -337,12 +337,7 @@ pub fn random_test() {
   |> iterator.from_list()
   |> iterator.fold(Nil, test_boundaries)
 
-  let run_mean_tests = fn(
-    iterations: Int,
-    min: Float,
-    max: Float,
-    tolerance: Float,
-  ) {
+  let test_mean = fn(iterations: Int, min: Float, max: Float, tolerance: Float) {
     let expected_average = float.sum([min, max]) /. 2.0
     list.range(0, iterations)
     |> iterator.from_list()
@@ -354,9 +349,9 @@ pub fn random_test() {
     |> float.loosely_compare(expected_average, tolerance)
     |> should.equal(order.Eq)
   }
-  run_mean_tests(100, 0.0, 0.0, 5.0)
-  run_mean_tests(1_000, 0.0, 100.0, 5.0)
-  run_mean_tests(1_000, -100.0, 100.0, 5.0)
-  run_mean_tests(1_000, -100.0, 0.0, 5.0)
-  run_mean_tests(1_000, 0.0, -100.0, 5.0)
+  test_mean(100, 0.0, 0.0, 5.0)
+  test_mean(1_000, 0.0, 100.0, 5.0)
+  test_mean(1_000, -100.0, 100.0, 5.0)
+  test_mean(1_000, -100.0, 0.0, 5.0)
+  test_mean(1_000, 0.0, -100.0, 5.0)
 }

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -1,9 +1,9 @@
-import gleam/should
 import gleam/float
-import gleam/order
-import gleam/list
-import gleam/iterator
 import gleam/int
+import gleam/iterator
+import gleam/list
+import gleam/order
+import gleam/should
 
 pub fn parse_test() {
   "1.23"

--- a/test/gleam/function_test.gleam
+++ b/test/gleam/function_test.gleam
@@ -1,9 +1,9 @@
-import gleam/should
 import gleam/function
 import gleam/int
-import gleam/pair
 import gleam/list
+import gleam/pair
 import gleam/result
+import gleam/should
 import gleam/string
 
 pub fn compose_test() {

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -349,8 +349,8 @@ pub fn random_test() {
       with: fn(accumulator, _element) { accumulator + int.random(min, max) },
     )
     |> fn(sum) { sum / iterations }
-    |> fn(sum) {
-      sum - tolerance <= expected_average || sum + tolerance >= expected_average
+    |> fn(average) {
+      average - tolerance <= expected_average || average + tolerance >= expected_average
     }
     |> should.be_true
   }

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -340,7 +340,7 @@ pub fn random_test() {
   |> iterator.from_list
   |> iterator.fold(Nil, test_boundaries)
 
-  let run_mean_tests = fn(iterations: Int, min: Int, max: Int, tolerance: Int) {
+  let test_average = fn(iterations: Int, min: Int, max: Int, tolerance: Int) {
     let expected_average = int.sum([min, max]) / 2
     list.range(0, iterations)
     |> iterator.from_list
@@ -354,9 +354,9 @@ pub fn random_test() {
     }
     |> should.be_true
   }
-  run_mean_tests(100, 0, 0, 5)
-  run_mean_tests(1_000, 0, 100, 5)
-  run_mean_tests(1_000, -100, 100, 5)
-  run_mean_tests(1_000, -100, 0, 5)
-  run_mean_tests(1_000, 0, -100, 5)
+  test_average(100, 0, 0, 5)
+  test_average(1_000, 0, 100, 5)
+  test_average(1_000, -100, 100, 5)
+  test_average(1_000, -100, 0, 5)
+  test_average(1_000, 0, -100, 5)
 }

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -1,8 +1,8 @@
-import gleam/should
 import gleam/int
-import gleam/order
-import gleam/list
 import gleam/iterator
+import gleam/list
+import gleam/order
+import gleam/should
 
 pub fn absolute_value_test() {
   123

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -1,7 +1,7 @@
-import gleam/should
 import gleam/iterator.{Done, Next}
 import gleam/list
 import gleam/map
+import gleam/should
 
 // a |> from_list |> to_list == a
 pub fn to_from_list_test() {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1,7 +1,7 @@
-import gleam/should
-import gleam/list
-import gleam/int
 import gleam/float
+import gleam/int
+import gleam/list
+import gleam/should
 
 pub fn length_test() {
   list.length([])

--- a/test/gleam/map_test.gleam
+++ b/test/gleam/map_test.gleam
@@ -1,7 +1,7 @@
-import gleam/string
-import gleam/should
 import gleam/map
 import gleam/option.{None, Some}
+import gleam/should
+import gleam/string
 
 pub fn from_list_test() {
   [#(4, 0), #(1, 0)]

--- a/test/gleam/option_test.gleam
+++ b/test/gleam/option_test.gleam
@@ -1,5 +1,5 @@
-import gleam/should
 import gleam/option.{None, Some}
+import gleam/should
 
 pub fn all_test() {
   option.all([Some(1), Some(2), Some(3)])

--- a/test/gleam/order_test.gleam
+++ b/test/gleam/order_test.gleam
@@ -1,5 +1,5 @@
-import gleam/should
 import gleam/order.{Eq, Gt, Lt}
+import gleam/should
 
 pub fn reverse_test() {
   order.reverse(Lt)

--- a/test/gleam/pair_test.gleam
+++ b/test/gleam/pair_test.gleam
@@ -1,5 +1,5 @@
-import gleam/should
 import gleam/pair
+import gleam/should
 
 pub fn first_test() {
   #(1, 2)

--- a/test/gleam/queue_test.gleam
+++ b/test/gleam/queue_test.gleam
@@ -1,8 +1,8 @@
-import gleam/queue
 import gleam/int
 import gleam/list
-import gleam/should
 import gleam/pair
+import gleam/queue
+import gleam/should
 
 pub fn from_and_to_list_test() {
   queue.from_list([])

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -1,6 +1,6 @@
+import gleam/option.{None, Some}
 import gleam/regex.{Match, Options}
 import gleam/should
-import gleam/option.{None, Some}
 
 pub fn from_string_test() {
   assert Ok(re) = regex.from_string("[0-9]")

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -1,5 +1,5 @@
-import gleam/should
 import gleam/result
+import gleam/should
 
 pub fn is_ok_test() {
   result.is_ok(Ok(1))

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -1,7 +1,7 @@
-import gleam/should
-import gleam/set
-import gleam/list
 import gleam/int
+import gleam/list
+import gleam/set
+import gleam/should
 
 pub fn size_test() {
   set.new()

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -1,7 +1,7 @@
-import gleam/string
-import gleam/should
-import gleam/order
 import gleam/option.{None, Some}
+import gleam/order
+import gleam/should
+import gleam/string
 
 pub fn length_test() {
   string.length("ß↑e̊")

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -1,10 +1,10 @@
 // TODO: IPv6 URI parse tests
 // https://github.com/elixir-lang/elixir/blob/2d43b9670f54c4d8e0be1ee4d2ee8f99d7378480/lib/elixir/test/elixir/uri_test.exs
-import gleam/uri
-import gleam/should
-import gleam/option.{None, Some}
-import gleam/string
 import gleam/list
+import gleam/option.{None, Some}
+import gleam/should
+import gleam/string
+import gleam/uri
 
 pub fn full_parse_test() {
   assert Ok(parsed) =


### PR DESCRIPTION
- fix docs typo
- fix test missleading/inconsistent variable naming (of prev own PR)
- sort all imports
- remove useless docs trailing whitespaces