### PR TITLE
Add functions to `String`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `float` module gains the `divide` function.
 - The `int` module gains the `divide`, `power`, and `square_root` functions.
+- The `string` module gains the `first`, `last`, and `capitalize` functions.
 
 ## v0.21.0 - 2022-04-24
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -740,26 +740,26 @@ pub fn to_option(s: String) -> Option(String) {
   }
 }
 
-/// Returns the first element in a grapheme and wraps it in an `Option(String)`.
-/// If the `String` is empty, it returns `None`. Otherwise, it returns
-/// `Some(String)`.
+/// Returns the first grapheme cluster in a given `String` and wraps it in a
+/// `Result(String, Nil)`. If the `String` is empty, it returns `Error(Nil)`.
+/// Otherwise, it returns `Ok(String)`.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > first("")
-/// None
+/// Error(Nil)
 /// ```
 ///
 /// ```gleam
 /// > first("icecream")
-/// Some("i")
+/// Ok("i")
 /// ```
 ///
-pub fn first(s: String) -> Option(String) {
-  case length(s) {
-    0 -> None
-    _ -> Some(slice(s, 0, 1))
+pub fn first(s: String) -> Result(String, Nil) {
+  case pop_grapheme(s) {
+    Ok(#(first, _)) -> Ok(first)
+    Error(e) -> Error(e)
   }
 }
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -797,12 +797,8 @@ pub fn last(s: String) -> Option(String) {
 /// ```
 ///
 pub fn capitalize(s: String) -> String {
-  let first =
-    slice(s, 0, 1)
-    |> uppercase
-  let rest =
-    slice(s, 1, length(s))
-    |> lowercase
-
-  append(to: first, suffix: rest)
+  case pop_grapheme(s) {
+    Ok(#(first, rest)) -> append(to: uppercase(first), suffix: lowercase(rest))
+    _ -> ""
+  }
 }

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -782,7 +782,7 @@ pub fn first(s: String) -> Option(String) {
 pub fn last(s: String) -> Option(String) {
   case length(s) {
     0 -> None
-    _ -> Some(slice(s, length(s) - 1, 1))
+    _ -> Some(slice(s, -1, 1))
   }
 }
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -781,6 +781,7 @@ pub fn first(s: String) -> Result(String, Nil) {
 ///
 pub fn last(s: String) -> Result(String, Nil) {
   case pop_grapheme(s) {
+    Ok(#(first, "")) -> Ok(first)
     Ok(#(_, rest)) -> Ok(slice(rest, -1, 1))
     Error(e) -> Error(e)
   }

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -762,3 +762,26 @@ pub fn first(s: String) -> Option(String) {
     _ -> Some(slice(s, 0, 1))
   }
 }
+
+/// Returns the last element in a grapheme and wraps it in an `Option(String)`.
+/// If the `String` is empty, it returns `None`. Otherwise, it returns
+/// `Some(String)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > last("")
+/// None
+/// ```
+///
+/// ```gleam
+/// > last("icecream")
+/// Some("m")
+/// ```
+///
+pub fn last(s: String) -> Option(String) {
+  case length(s) {
+    0 -> None
+    _ -> Some(slice(s, length(s) - 1, 1))
+  }
+}

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -763,26 +763,26 @@ pub fn first(s: String) -> Result(String, Nil) {
   }
 }
 
-/// Returns the last element in a grapheme and wraps it in an `Option(String)`.
-/// If the `String` is empty, it returns `None`. Otherwise, it returns
-/// `Some(String)`.
+/// Returns the last grapheme cluster in a given `String` and wraps it in a
+/// `Result(String, Nil)`. If the `String` is empty, it returns `Error(Nil)`.
+/// Otherwise, it returns `Ok(String)`.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > last("")
-/// None
+/// Error(Nil)
 /// ```
 ///
 /// ```gleam
 /// > last("icecream")
-/// Some("m")
+/// Ok("m")
 /// ```
 ///
-pub fn last(s: String) -> Option(String) {
-  case length(s) {
-    0 -> None
-    _ -> Some(slice(s, -1, 1))
+pub fn last(s: String) -> Result(String, Nil) {
+  case pop_grapheme(s) {
+    Ok(#(_, rest)) -> Ok(slice(rest, -1, 1))
+    Error(e) -> Error(e)
   }
 }
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -739,3 +739,26 @@ pub fn to_option(s: String) -> Option(String) {
     _ -> Some(s)
   }
 }
+
+/// Returns the first element in a grapheme and wraps it in an `Option(String)`.
+/// If the `String` is empty, it returns `None`. Otherwise, it returns
+/// `Some(String)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > first("")
+/// None
+/// ```
+///
+/// ```gleam
+/// > first("icecream")
+/// Some("i")
+/// ```
+///
+pub fn first(s: String) -> Option(String) {
+  case length(s) {
+    0 -> None
+    _ -> Some(slice(s, 0, 1))
+  }
+}

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -785,3 +785,24 @@ pub fn last(s: String) -> Option(String) {
     _ -> Some(slice(s, length(s) - 1, 1))
   }
 }
+
+/// Creates a new `String` with the first grapheme in the input `String`
+/// converted to uppercase and the remaining graphemes to lowercase.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > capitalize("mamouna")
+/// "Mamouna"
+/// ```
+///
+pub fn capitalize(s: String) -> String {
+  let first =
+    slice(s, 0, 1)
+    |> uppercase
+  let rest =
+    slice(s, 1, length(s))
+    |> lowercase
+
+  append(to: first, suffix: rest)
+}

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -377,6 +377,10 @@ pub fn first_test() {
   "⭐️ Gleam"
   |> string.first
   |> should.equal(Ok("⭐️"))
+
+  "a"
+  |> string.first
+  |> should.equal(Ok("a"))
 }
 
 pub fn last_test() {
@@ -395,6 +399,10 @@ pub fn last_test() {
   "եոգլի"
   |> string.last
   |> should.equal(Ok("ի"))
+
+  "a"
+  |> string.last
+  |> should.equal(Ok("a"))
 }
 
 pub fn capitalize_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -373,6 +373,10 @@ pub fn first_test() {
   "gleam"
   |> string.first
   |> should.equal(Some("g"))
+
+  "⭐️ Gleam"
+  |> string.first
+  |> should.equal(Some("⭐️"))
 }
 
 pub fn last_test() {
@@ -387,6 +391,10 @@ pub fn last_test() {
   "gleam "
   |> string.last
   |> should.equal(Some(" "))
+
+  "եոգլի"
+  |> string.last
+  |> should.equal(Some("ի"))
 }
 
 pub fn capitalize_test() {
@@ -417,4 +425,8 @@ pub fn capitalize_test() {
   " gLeAm1"
   |> string.capitalize
   |> should.equal(" gleam1")
+
+  "る"
+  |> string.capitalize
+  |> should.equal("る")
 }

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -388,3 +388,33 @@ pub fn last_test() {
   |> string.last
   |> should.equal(Some(" "))
 }
+
+pub fn capitalize_test() {
+  ""
+  |> string.capitalize
+  |> should.equal("")
+
+  "gleam"
+  |> string.capitalize
+  |> should.equal("Gleam")
+
+  "GLEAM"
+  |> string.capitalize
+  |> should.equal("Gleam")
+
+  "g l e a m"
+  |> string.capitalize
+  |> should.equal("G l e a m")
+
+  "1GLEAM"
+  |> string.capitalize
+  |> should.equal("1gleam")
+
+  "_gLeAm1"
+  |> string.capitalize
+  |> should.equal("_gleam1")
+
+  " gLeAm1"
+  |> string.capitalize
+  |> should.equal(" gleam1")
+}

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -374,3 +374,17 @@ pub fn first_test() {
   |> string.first
   |> should.equal(Some("g"))
 }
+
+pub fn last_test() {
+  ""
+  |> string.last
+  |> should.equal(None)
+
+  "gleam"
+  |> string.last
+  |> should.equal(Some("m"))
+
+  "gleam "
+  |> string.last
+  |> should.equal(Some(" "))
+}

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -382,19 +382,19 @@ pub fn first_test() {
 pub fn last_test() {
   ""
   |> string.last
-  |> should.equal(None)
+  |> should.be_error
 
   "gleam"
   |> string.last
-  |> should.equal(Some("m"))
+  |> should.equal(Ok("m"))
 
   "gleam "
   |> string.last
-  |> should.equal(Some(" "))
+  |> should.equal(Ok(" "))
 
   "եոգլի"
   |> string.last
-  |> should.equal(Some("ի"))
+  |> should.equal(Ok("ի"))
 }
 
 pub fn capitalize_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -368,15 +368,15 @@ pub fn to_option_test() {
 pub fn first_test() {
   ""
   |> string.first
-  |> should.equal(None)
+  |> should.be_error
 
   "gleam"
   |> string.first
-  |> should.equal(Some("g"))
+  |> should.equal(Ok("g"))
 
   "⭐️ Gleam"
   |> string.first
-  |> should.equal(Some("⭐️"))
+  |> should.equal(Ok("⭐️"))
 }
 
 pub fn last_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -364,3 +364,13 @@ pub fn to_option_test() {
   |> string.to_option
   |> should.equal(Some("ok"))
 }
+
+pub fn first_test() {
+  ""
+  |> string.first
+  |> should.equal(None)
+
+  "gleam"
+  |> string.first
+  |> should.equal(Some("g"))
+}


### PR DESCRIPTION
As a part of my Gleam learning process, I've been reading through the standard library, and I noticed that it is currently missing a few `String` functions that are provided by Elixir (or at least so it seems to my untrained eye). I've used the documentation [here](https://hexdocs.pm/elixir/String.html#functions) as a reference for the implementations.

Please, let me know if these functions are not deemed useful, or if I've overlooked anything.

