### PR TITLE
runtime-module for unix_timestamp and locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The `string` module gains the `first`, `last`, and `capitalise` functions.
 - Fixed a bug where `string.reverse` would break utf8 strings on target JavaScript.
 - Fixed a bug where `string.slice` would break utf8 strings on target JavaScript.
+- The new `runtime` module gains `unix_timestamp` and `locale` functions.
 
 ## v0.21.0 - 2022-04-24
 

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -41,12 +41,12 @@ pub type Options {
 /// ```gleam
 /// > let options = Options(case_insensitive: False, multi_line: True)
 /// > assert Ok(re) = compile("^[0-9]", with: options)
-/// > match(re, "abc\n123")
+/// > check(re, "abc\n123")
 /// True
 ///
 /// > let options = Options(case_insensitive: True, multi_line: False)
 /// > assert Ok(re) = compile("[A-Z]", with: options)
-/// > match(re, "abc123")
+/// > check(re, "abc123")
 /// True
 /// ```
 ///
@@ -73,10 +73,10 @@ if javascript {
 ///
 /// ```gleam
 /// > assert Ok(re) = from_string("[0-9]")
-/// > match(re, "abc123")
+/// > check(re, "abc123")
 /// True
 ///
-/// > match(re, "abcxyz")
+/// > check(re, "abcxyz")
 /// False
 ///
 /// > from_string("[0-9")

--- a/src/gleam/runtime.gleam
+++ b/src/gleam/runtime.gleam
@@ -1,0 +1,44 @@
+import gleam/string
+
+/// Fetches the unix timestamp from the runtime
+///
+pub fn unix_timestamp() -> Int {
+  do_unix_timestamp()
+}
+
+if javascript {
+  external fn do_unix_timestamp() -> Int =
+    "../gleam_stdlib.mjs" "unix_timestamp"
+}
+
+if erlang {
+  external fn do_unix_timestamp() -> Int =
+    "gleam_stdlib" "unix_timestamp"
+}
+
+/// Fetches the locale from the runtime.
+///
+/// Returns a Tuple of normalized Strings containing:
+/// 1. ISO-639 language code in lowercase
+/// 2. ISO-3166 country code in uppercase
+///
+pub fn locale() -> #(String, String) {
+  let runtime_locale = do_locale()
+  let language_code =
+    string.slice(from: runtime_locale, at_index: 0, length: 2)
+    |> string.lowercase
+  let country_code =
+    string.slice(from: runtime_locale, at_index: 0, length: 2)
+    |> string.uppercase
+  #(language_code, country_code)
+}
+
+if javascript {
+  external fn do_locale() -> String =
+    "../gleam_stdlib.mjs" "locale"
+}
+
+if erlang {
+  external fn do_locale() -> String =
+    "gleam_stdlib" "locale"
+}

--- a/src/gleam/runtime.gleam
+++ b/src/gleam/runtime.gleam
@@ -21,25 +21,25 @@ if erlang {
 /// Returns a Tuple of normalized Strings containing:
 /// 1. ISO-639 language code in lowercase
 /// 2. ISO-3166 country code in uppercase
-/// 3. System string
+/// 3. System locale String
 ///
 pub fn get_locale() -> #(String, String, String) {
   let runtime_locale = do_get_locale()
   let language_code =
-    string.slice(from: runtime_locale, at_index: 0, length: 2)
+    string.slice(from: runtime_locale.0, at_index: 0, length: 2)
     |> string.lowercase
   let country_code =
-    string.slice(from: runtime_locale, at_index: 0, length: 2)
+    string.slice(from: runtime_locale.0, at_index: 0, length: 2)
     |> string.uppercase
-  #(language_code, country_code, runtime_locale)
+  #(language_code, country_code, runtime_locale.1)
 }
 
 if javascript {
-  external fn do_get_locale() -> String =
+  external fn do_get_locale() -> #(String, String) =
     "../gleam_stdlib.mjs" "get_locale"
 }
 
 if erlang {
-  external fn do_get_locale() -> String =
+  external fn do_get_locale() -> #(String, String) =
     "gleam_stdlib" "get_locale"
 }

--- a/src/gleam/runtime.gleam
+++ b/src/gleam/runtime.gleam
@@ -22,8 +22,8 @@ if erlang {
 /// 1. ISO-639 language code in lowercase
 /// 2. ISO-3166 country code in uppercase
 ///
-pub fn locale() -> #(String, String) {
-  let runtime_locale = do_locale()
+pub fn get_locale() -> #(String, String) {
+  let runtime_locale = do_get_locale()
   let language_code =
     string.slice(from: runtime_locale, at_index: 0, length: 2)
     |> string.lowercase
@@ -34,11 +34,11 @@ pub fn locale() -> #(String, String) {
 }
 
 if javascript {
-  external fn do_locale() -> String =
-    "../gleam_stdlib.mjs" "locale"
+  external fn do_get_locale() -> String =
+    "../gleam_stdlib.mjs" "get_locale"
 }
 
 if erlang {
-  external fn do_locale() -> String =
-    "gleam_stdlib" "locale"
+  external fn do_get_locale() -> String =
+    "gleam_stdlib" "get_locale"
 }

--- a/src/gleam/runtime.gleam
+++ b/src/gleam/runtime.gleam
@@ -21,8 +21,9 @@ if erlang {
 /// Returns a Tuple of normalized Strings containing:
 /// 1. ISO-639 language code in lowercase
 /// 2. ISO-3166 country code in uppercase
+/// 3. System string
 ///
-pub fn get_locale() -> #(String, String) {
+pub fn get_locale() -> #(String, String, String) {
   let runtime_locale = do_get_locale()
   let language_code =
     string.slice(from: runtime_locale, at_index: 0, length: 2)
@@ -30,7 +31,7 @@ pub fn get_locale() -> #(String, String) {
   let country_code =
     string.slice(from: runtime_locale, at_index: 0, length: 2)
     |> string.uppercase
-  #(language_code, country_code)
+  #(language_code, country_code, runtime_locale)
 }
 
 if javascript {

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -387,7 +387,7 @@ get_locale() ->
         os:getenv("LC_ALL", os:getenv("LANG", "C"))
     ),
     case string:uppercase(string:slice(Locale, 0, 2)) of
-        "C" -> {"en_US", Locale};
-        "C." -> {"en_US", Locale};
+        "C" -> {"en_GB", Locale};
+        "C." -> {"en_GB", Locale};
         _ -> {string:slice(Locale, 0, 5), Locale}
     end.

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -380,13 +380,14 @@ unix_timestamp() ->
     {MegaSecs, Secs, _MicroSecs} = erlang:timestamp(),
     MegaSecs * 1000000 + Secs.
 
-% Returns an locale in the form of:
-% "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
+% Returns locale information
 get_locale() ->
-    string:slice(
-        os:getenv(
-            "LANGUAGE",
-            os:getenv("LC_ALL", os:getenv("LANG", "C"))
-        ),
-        0, 5
-    ).
+	Locale = os:getenv(
+		"LANGUAGE",
+		os:getenv("LC_ALL", os:getenv("LANG", "C"))
+	),
+	case string:uppercase(string:slice(Locale, 0, 2)) of
+		"C" -> {"en_US", Locale};
+		"C." -> {"en_US", Locale};
+		_ -> {string:slice(Locale, 0, 5), Locale}
+   	end.

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -10,7 +10,7 @@
          percent_encode/1, percent_decode/1, regex_check/2, regex_split/2,
          base_decode64/1, parse_query/1, bit_string_concat/1, size_of_tuple/1,
          decode_tuple/1, tuple_get/2, classify_dynamic/1, print/1, println/1,
-         inspect/1, unix_timestamp/0, locale/0]).
+         inspect/1, unix_timestamp/0, get_locale/0]).
 
 %% Taken from OTP's uri_string module
 -define(DEC2HEX(X),
@@ -382,7 +382,7 @@ unix_timestamp() ->
 
 % Returns an locale in the form of:
 % "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
-locale() ->
+get_locale() ->
     string:slice(
         os:getenv(
             "LANGUAGE",

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -10,7 +10,7 @@
          percent_encode/1, percent_decode/1, regex_check/2, regex_split/2,
          base_decode64/1, parse_query/1, bit_string_concat/1, size_of_tuple/1,
          decode_tuple/1, tuple_get/2, classify_dynamic/1, print/1, println/1,
-         inspect/1]).
+         inspect/1, unix_timestamp/0, locale/0]).
 
 %% Taken from OTP's uri_string module
 -define(DEC2HEX(X),
@@ -375,3 +375,18 @@ inspect(Any) when is_function(Any) ->
     ["//fn(", Args, ") { ... }"];
 inspect(Any) ->
     ["//erl(", io_lib:format("~p", [Any]), ")"].
+
+unix_timestamp() ->
+    {MegaSecs, Secs, _MicroSecs} = erlang:timestamp(),
+    MegaSecs * 1000000 + Secs.
+
+% Returns an locale in the form of:
+% "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
+locale() ->
+    string:slice(
+        os:getenv(
+            "LANGUAGE",
+            os:getenv("LC_ALL", os:getenv("LANG", "C"))
+        ),
+        0, 5
+    ).

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -382,12 +382,12 @@ unix_timestamp() ->
 
 % Returns locale information
 get_locale() ->
-	Locale = os:getenv(
-		"LANGUAGE",
-		os:getenv("LC_ALL", os:getenv("LANG", "C"))
-	),
-	case string:uppercase(string:slice(Locale, 0, 2)) of
-		"C" -> {"en_US", Locale};
-		"C." -> {"en_US", Locale};
-		_ -> {string:slice(Locale, 0, 5), Locale}
-   	end.
+    Locale = os:getenv(
+        "LANGUAGE",
+        os:getenv("LC_ALL", os:getenv("LANG", "C"))
+    ),
+    case string:uppercase(string:slice(Locale, 0, 2)) of
+        "C" -> {"en_US", Locale};
+        "C." -> {"en_US", Locale};
+        _ -> {string:slice(Locale, 0, 5), Locale}
+    end.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -608,8 +608,12 @@ export function unix_timestamp() {
 // Returns an locale in the form of:
 // "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
 export function get_locale() {
-  if (typeof navigator !== "undefined") {
-    return navigator.language.substring(0, 5);
-  }
-  return Intl.DateTimeFormat().resolvedOptions().locale.substring(0, 5);
+	let locale = (() => {
+		if (typeof navigator !== "undefined") {
+			return navigator.language.substring(0, 5);
+		} else {
+			return Intl.DateTimeFormat().resolvedOptions().locale.substring(0, 5);
+		}
+	})();
+	return [locale, locale];
 }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -607,7 +607,7 @@ export function unix_timestamp() {
 
 // Returns an locale in the form of:
 // "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
-export function locale() {
+export function get_locale() {
   if (typeof navigator !== "undefined") {
     return navigator.language.substring(0, 5);
   }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -608,7 +608,7 @@ export function unix_timestamp() {
 // Returns an locale in the form of:
 // "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
 export function get_locale() {
-	let locale = system_locale = (() => {
+	let locale = (() => {
 		if (typeof navigator !== "undefined") {
 			return navigator.language.substring(0, 5);
 		} else {
@@ -616,5 +616,6 @@ export function get_locale() {
 		}
 	})();
 	// If the given JavaScript runtime ever returns encodings such as "en_US.UTF-8", this should be in `system_locale`.
+	let system_locale = locale;
 	return [locale, system_locale];
 }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -599,3 +599,17 @@ export function decode_field(value, name) {
     return error();
   }
 }
+
+// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#get_the_number_of_seconds_since_the_ecmascript_epoch
+export function unix_timestamp() {
+  return Math.floor(Date.now() / 1000);
+}
+
+// Returns an locale in the form of:
+// "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
+export function locale() {
+  if (typeof navigator !== "undefined") {
+    return navigator.language.substring(0, 5);
+  }
+  return Intl.DateTimeFormat().resolvedOptions().locale.substring(0, 5);
+}

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -608,12 +608,13 @@ export function unix_timestamp() {
 // Returns an locale in the form of:
 // "ab_CD", "ab-CD", "ab_cd", or "ab-cd".
 export function get_locale() {
-	let locale = (() => {
+	let locale = system_locale = (() => {
 		if (typeof navigator !== "undefined") {
 			return navigator.language.substring(0, 5);
 		} else {
 			return Intl.DateTimeFormat().resolvedOptions().locale.substring(0, 5);
 		}
 	})();
-	return [locale, locale];
+	// If NodeJS ever return encoding such as "en_US.UTF-8", this should be in systemlocale
+	return [locale, system_locale];
 }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -615,6 +615,6 @@ export function get_locale() {
 			return Intl.DateTimeFormat().resolvedOptions().locale.substring(0, 5);
 		}
 	})();
-	// If NodeJS ever return encoding such as "en_US.UTF-8", this should be in systemlocale
+	// If the given JavaScript runtime ever returns encodings such as "en_US.UTF-8", this should be in `system_locale`.
 	return [locale, system_locale];
 }

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -2,8 +2,6 @@ import gleam/should
 import gleam/runtime
 import gleam/int
 import gleam/regex
-import gleam/string
-import gleam/io
 
 pub fn unix_timestamp_test() {
   let unix_timestamp = runtime.unix_timestamp()
@@ -23,12 +21,6 @@ pub fn unix_timestamp_test() {
 
 pub fn get_locale_test() {
   let locale = runtime.get_locale()
-
-  // string.inspect(locale)
-  // |> should.equal("no-match-1")
-  //
-  locale.2
-  |> should.equal("no-match")
 
   // Implementation must return a lower case language code
   let language = locale.0

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -1,0 +1,38 @@
+import gleam/should
+import gleam/runtime
+import gleam/int
+import gleam/regex
+
+pub fn do_unix_timestamp_test() {
+  let unix_timestamp = runtime.unix_timestamp()
+
+  // Implementation must return an integer
+  assert Ok(re) = regex.from_string("[0-9]+")
+  unix_timestamp
+  |> int.to_string
+  |> regex.check(re, _)
+  |> should.be_true
+
+  // Implementation must return a positive integer
+  unix_timestamp
+  |> fn(x) { x >= 0 }
+  |> should.be_true
+}
+
+pub fn do_locale_test() {
+  let locale = runtime.locale()
+
+  // Implementation must return a lower case language code
+  let language = locale.0
+  assert Ok(re) = regex.from_string("[a-z]{2,2}")
+  language
+  |> regex.check(re, _)
+  |> should.be_true
+
+  // Implementation must return an upper case country code
+  let country = locale.1
+  assert Ok(re) = regex.from_string("[A-Z]{2,2}")
+  country
+  |> regex.check(re, _)
+  |> should.be_true
+}

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -25,7 +25,7 @@ pub fn get_locale_test() {
   let locale = runtime.get_locale()
 
   string.inspect(locale)
-  |> io.debug()
+  |> should.equal("no-match")
 
   // Implementation must return a lower case language code
   let language = locale.0

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -27,10 +27,10 @@ pub fn get_locale_test() {
   // string.inspect(locale)
   // |> should.equal("no-match-1")
   //
-  string.inspect(locale.0)
+  locale.0
   |> should.equal("no-match-2")
 
-  string.inspect(locale.1)
+  locale.1
   |> should.equal("no-match-3")
 
   // Implementation must return a lower case language code

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -25,7 +25,13 @@ pub fn get_locale_test() {
   let locale = runtime.get_locale()
 
   string.inspect(locale)
-  |> should.equal("no-match")
+  |> should.equal("no-match-1")
+
+  string.inspect(locale.0)
+  |> should.equal("no-match-2")
+
+  string.inspect(locale.1)
+  |> should.equal("no-match-3")
 
   // Implementation must return a lower case language code
   let language = locale.0

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -3,7 +3,7 @@ import gleam/runtime
 import gleam/int
 import gleam/regex
 
-pub fn do_unix_timestamp_test() {
+pub fn unix_timestamp_test() {
   let unix_timestamp = runtime.unix_timestamp()
 
   // Implementation must return an integer
@@ -19,8 +19,8 @@ pub fn do_unix_timestamp_test() {
   |> should.be_true
 }
 
-pub fn do_locale_test() {
-  let locale = runtime.locale()
+pub fn get_locale_test() {
+  let locale = runtime.get_locale()
 
   // Implementation must return a lower case language code
   let language = locale.0

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -2,6 +2,8 @@ import gleam/should
 import gleam/runtime
 import gleam/int
 import gleam/regex
+import gleam/string
+import gleam/io
 
 pub fn unix_timestamp_test() {
   let unix_timestamp = runtime.unix_timestamp()
@@ -21,6 +23,9 @@ pub fn unix_timestamp_test() {
 
 pub fn get_locale_test() {
   let locale = runtime.get_locale()
+
+  string.inspect(locale)
+  |> io.debug()
 
   // Implementation must return a lower case language code
   let language = locale.0

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -27,11 +27,8 @@ pub fn get_locale_test() {
   // string.inspect(locale)
   // |> should.equal("no-match-1")
   //
-  locale.0
-  |> should.equal("no-match-2")
-
-  locale.1
-  |> should.equal("no-match-3")
+  locale.2
+  |> should.equal("no-match")
 
   // Implementation must return a lower case language code
   let language = locale.0

--- a/test/gleam/runtime_test.gleam
+++ b/test/gleam/runtime_test.gleam
@@ -24,9 +24,9 @@ pub fn unix_timestamp_test() {
 pub fn get_locale_test() {
   let locale = runtime.get_locale()
 
-  string.inspect(locale)
-  |> should.equal("no-match-1")
-
+  // string.inspect(locale)
+  // |> should.equal("no-match-1")
+  //
   string.inspect(locale.0)
   |> should.equal("no-match-2")
 


### PR DESCRIPTION
also fixes docblocks in regex.gleam