### PR TITLE
Proof of concept: Allow printing to stdout during tests

### DIFF
--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -2,8 +2,14 @@ import gleam/option.{None, Some}
 import gleam/order
 import gleam/should
 import gleam/string
+import gleam_stdlib_test
 
 pub fn length_test() {
+  // Demo
+  gleam_stdlib_test.stdout("Hello World!")
+  gleam_stdlib_test.stdout(42)
+  gleam_stdlib_test.stdout(False)
+
   string.length("ß↑e̊")
   |> should.equal(3)
 

--- a/test/gleam_stdlib_test.gleam
+++ b/test/gleam_stdlib_test.gleam
@@ -1,9 +1,31 @@
 if erlang {
+  import gleam/string
+
   pub external fn main() -> Nil =
     "gleam_stdlib_test_ffi" "main"
+
+  pub fn stdout(value) {
+    value
+    |> string.inspect
+    |> fn(s) { string.concat(["\n", s]) }
+    |> to_stdout
+  }
+
+  pub external fn to_stdout(string) -> Nil =
+    "gleam_stdlib_test_ffi" "to_stdout"
 }
 
 if javascript {
+  import gleam/string
+  import gleam/io
+
   pub external fn main() -> Nil =
     "./gleam_stdlib_test_ffi.mjs" "main"
+
+  pub fn stdout(value) {
+    value
+    |> string.inspect
+    |> fn(s) { string.concat(["\n", s]) }
+    |> io.println
+  }
 }

--- a/test/gleam_stdlib_test_ffi.erl
+++ b/test/gleam_stdlib_test_ffi.erl
@@ -2,9 +2,10 @@
 
 -export([
     main/0, should_equal/2, should_not_equal/2, should_be_ok/1,
-    should_be_error/1
+    should_be_error/1, to_stdout/1
 ]).
 
+% -define(NODEBUG, true). % Defining NODEBUG disables EUnit debugging
 -include_lib("eunit/include/eunit.hrl").
 
 main() ->
@@ -26,15 +27,18 @@ filepath_to_module(Path0) ->
     Path5 = list_to_binary(Path4),
     binary_to_atom(Path5).
 
-should_equal(Actual, Expected) -> 
+should_equal(Actual, Expected) ->
     ?assertEqual(Expected, Actual),
     nil.
-should_not_equal(Actual, Expected) -> 
+should_not_equal(Actual, Expected) ->
     ?assertNotEqual(Expected, Actual),
     nil.
-should_be_ok(A) -> 
+should_be_ok(A) ->
     ?assertMatch({ok, _}, A),
     nil.
-should_be_error(A) -> 
+should_be_error(A) ->
     ?assertMatch({error, _}, A),
     nil.
+
+to_stdout(String) when is_binary(String) ->
+	?debugMsg(String).


### PR DESCRIPTION
```
❯ gleam test --target javascript; gleam test --target erlang
  Compiling gleam_stdlib
   Compiled in 0.55s
    Running gleam_stdlib_test.main
Running tests...
..............
"Hello World!"

42

False
...................................................................................................................................................................................................................................................................................................................................................................................

385 tests
385 passes
0 failures
  Compiling gleam_stdlib
   Compiled in 1.43s
    Running gleam_stdlib_test.main
.............................................................................................................................................................................................................................................................................................................build/dev/erlang/gleam_stdlib/build/gleam_stdlib_test_ffi.erl:44:<0.83.0>: 
"Hello World!"
build/dev/erlang/gleam_stdlib/build/gleam_stdlib_test_ffi.erl:44:<0.83.0>: 
42
build/dev/erlang/gleam_stdlib/build/gleam_stdlib_test_ffi.erl:44:<0.83.0>: 
False
.....................................................................................
Finished in 1.226 seconds
386 tests, 0 failures
```