### PR TITLE
fix io.debug to behave the same on Erlang and JavaScript. Add io.debug_raw

### DIFF
--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -48,7 +48,7 @@ if javascript {
     "../gleam_stdlib.mjs" "log"
 }
 
-/// Prints a value to standard output using Erlang syntax.
+/// Prints a value to standard output (stdout) yielding Gleam syntax.
 ///
 /// The value is returned after being printed so it can be used in pipelines.
 ///
@@ -73,24 +73,39 @@ if javascript {
 /// ```
 ///
 pub fn debug(term: anything) -> anything {
-  debug_print(term)
+  do_debug(term)
   term
 }
 
 if erlang {
-  fn debug_print(term: anything) -> DoNotLeak {
-    erlang_fwrite("~tp\n", [term])
-  }
+  external fn do_debug(term: anything) -> Nil =
+    "buggy_ffi" "debug"
 }
 
 if javascript {
-  external fn debug_print(anything) -> Nil =
+  external fn do_debug(anything) -> Nil =
     "../gleam_stdlib.mjs" "debug"
 }
 
+/// Prints a value to standard output (stdout) yielding Erlang or JavaScript syntax.
+///
+pub fn debug_raw(term: anything) -> anything {
+  do_debug_raw(term)
+  term
+}
+
 if erlang {
+  fn do_debug_raw(term: anything) -> DoNotLeak {
+    erlang_fwrite("~tp\n", [term])
+  }
+
   external type DoNotLeak
 
   external fn erlang_fwrite(String, List(a)) -> DoNotLeak =
     "io" "fwrite"
+}
+
+if javascript {
+  external fn do_debug_raw(anything) -> Nil =
+    "../gleam_stdlib.mjs" "debug_raw"
 }

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -79,11 +79,11 @@ pub fn debug(term: anything) -> anything {
 
 if erlang {
   external fn do_debug(term: anything) -> Nil =
-    "buggy_ffi" "debug"
+    "gleam_stdlib" "debug"
 }
 
 if javascript {
-  external fn do_debug(anything) -> Nil =
+  external fn do_debug(term: anything) -> Nil =
     "../gleam_stdlib.mjs" "debug"
 }
 
@@ -106,6 +106,6 @@ if erlang {
 }
 
 if javascript {
-  external fn do_debug_raw(anything) -> Nil =
+  external fn do_debug_raw(term: anything) -> Nil =
     "../gleam_stdlib.mjs" "debug_raw"
 }

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -824,17 +824,19 @@ pub fn capitalise(s: String) -> String {
   }
 }
 
-pub fn inspect(value: a) -> String {
-  do_inspect(value)
+/// Creates a String representative of gleam values.
+///
+pub fn inspect(term: anything) -> String {
+  do_inspect(term)
   |> string_builder.to_string
 }
 
 if javascript {
-  external fn do_inspect(value: a) -> string_builder.StringBuilder =
+  external fn do_inspect(term: anything) -> string_builder.StringBuilder =
     "../gleam.mjs" "inspect"
 }
 
 if erlang {
-  external fn do_inspect(value: a) -> string_builder.StringBuilder =
+  external fn do_inspect(term: anything) -> string_builder.StringBuilder =
     "gleam_stdlib" "inspect"
 }

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -10,7 +10,7 @@
          percent_encode/1, percent_decode/1, regex_check/2, regex_split/2,
          base_decode64/1, parse_query/1, bit_string_concat/1, size_of_tuple/1,
          decode_tuple/1, tuple_get/2, classify_dynamic/1, print/1, println/1,
-         inspect/1]).
+         inspect/1, debug/1]).
 
 %% Taken from OTP's uri_string module
 -define(DEC2HEX(X),
@@ -375,3 +375,7 @@ inspect(Any) when is_function(Any) ->
     ["//fn(", Args, ") { ... }"];
 inspect(Any) ->
     ["//erl(", io_lib:format("~p", [Any]), ")"].
+
+debug(Any) ->
+    println(inspect(Any)),
+    nil.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -201,6 +201,10 @@ export function debug(term) {
   console.log(inspect(term));
 }
 
+export function debug_raw(term) {
+  console.log(term);
+}
+
 export function crash(message) {
   throw new globalThis.Error(message);
 }


### PR DESCRIPTION
Status Quo: `io.debug()` prints Gleam syntax on target JavaScript but Erlang syntax on target Erlang.

This PR:

- Unifies `io.debug()` to output Gleam syntax.
- Adds `io.debug_raw()` which keeps the previous Erlang implementation of `io.debug()` and adds a JavaScript implementation that returns the underlying data/types.