### PR TITLE
Let `decode_list` succeed with arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fixed a bug where decoding a `List` from a `Dynamic` `Array` would fail.
+
 ## v0.22.1 - 2022-06-27
 
 - Fixed a bug where `big_string.concat` could crash.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -576,6 +576,9 @@ export function tuple_get(data, index) {
 }
 
 export function decode_list(data) {
+  if (Array.isArray(data)) {
+    return new Ok(List.fromArray(data));
+  }
   return List.isList(data) ? new Ok(data) : decoder_error("List", data);
 }
 

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -756,6 +756,20 @@ pub fn shallow_list_test() {
   |> should.equal(Error([DecodeError(expected: "List", found: "Int", path: [])]))
 }
 
+if javascript {
+  pub fn array_on_js_is_also_list_test() {
+    #()
+    |> dynamic.from
+    |> dynamic.shallow_list
+    |> should.equal(Ok([]))
+
+    #(1, 2)
+    |> dynamic.from
+    |> dynamic.list(of: dynamic.int)
+    |> should.equal(Ok([1, 2]))
+  }
+}
+
 pub fn result_test() {
   Ok(1)
   |> dynamic.from


### PR DESCRIPTION
Previously would fail, as JS arrays are recognized by `gleam/dynamic` as tuples.