### PR TITLE
fix inspect on improper lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.9.0
         with:
           otp-version: "23.2"
-          gleam-version: "0.20.0-rc1"
+          gleam-version: "0.22.1"
       - uses: actions/setup-node@v2
         with:
           node-version: "16.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed `string.inspect` and `io.debug` crashing on improper Erlang lists.
+- Fixed `string.inspect` and `io.debug` crashing on improper Erlang lists (#333).
 
 ## v0.22.3 - 2022-08-09
 
@@ -49,7 +49,7 @@
 - The `int` module gains the `random` function.
 - The JavaScript target implementation of the `string.replace` received a bug
   fix.
-- The `list` module gains a `prepend` function. (#284)
+- The `list` module gains a `prepend` function (#284).
 
 ## v0.20.0 - 2022-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `string.inspect` and `io.debug` crashing on improper Erlang lists.
+
 ## v0.22.3 - 2022-08-09
 
 - Removed a duplicate import.
@@ -12,7 +16,7 @@
   ranges when compiled to JavaScript.
 - Fixed a bug where the `list` module's `contains`, `any`, and `all` could
   exhaust the stack when compiling to JavaScript.
-- `list.range` and `iterator.range` return values are now inclusive of both start and end bounds. 
+- `list.range` and `iterator.range` return values are now inclusive of both start and end bounds.
 
 ## v0.22.1 - 2022-06-27
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -813,14 +813,7 @@ pub fn tuple6(
   fn(value) {
     try _ = assert_is_tuple(value, 6)
     let #(a, b, c, d, e, f) = unsafe_coerce(value)
-    case
-      decode1(a),
-      decode2(b),
-      decode3(c),
-      decode4(d),
-      decode5(e),
-      decode6(f)
-    {
+    case decode1(a), decode2(b), decode3(c), decode4(d), decode5(e), decode6(f) {
       Ok(a), Ok(b), Ok(c), Ok(d), Ok(e), Ok(f) -> Ok(#(a, b, c, d, e, f))
       a, b, c, d, e, f ->
         tuple_errors(a, "0")

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -1,4 +1,4 @@
-import gleam/int
+	import gleam/int
 import gleam/list
 import gleam/map
 import gleam/map.{Map}

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -1,4 +1,4 @@
-	import gleam/int
+import gleam/int
 import gleam/list
 import gleam/map
 import gleam/map.{Map}

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -349,7 +349,7 @@ inspect(Binary) when is_binary(Binary) ->
             ["<<", lists:join(", ", Segments), ">>"]
     end;
 inspect(List) when is_list(List) ->
-    Elements = lists:join(<<", ">>, lists:map(fun inspect/1, List)),
+    Elements = lists:join(<<", ">>, do_map_listish(fun inspect/1, List)),
     ["[", Elements, "]"];
 inspect(Any) when is_tuple(Any) % Record constructors
   andalso is_atom(element(1, Any))
@@ -374,6 +374,14 @@ inspect(Any) when is_function(Any) ->
     ["//fn(", Args, ") { ... }"];
 inspect(Any) ->
     ["//erl(", io_lib:format("~p", [Any]), ")"].
+
+do_map_listish(_Fn, [])  ->
+	[];
+do_map_listish(Fn, List) when is_list(List) ->
+	[Head | Tail] = List,
+	[Fn(Head) | do_map_listish(Fn, Tail)];
+do_map_listish(Fn, Tail) when not is_list(Tail) ->
+	[Fn(Tail)].
 
 float_to_string(Float) when is_float(Float) ->
     erlang:iolist_to_binary(io_lib_format:fwrite_g(Float)).

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -376,12 +376,12 @@ inspect(Any) ->
     ["//erl(", io_lib:format("~p", [Any]), ")"].
 
 do_map_listish(_Fn, [])  ->
-	[];
+    [];
 do_map_listish(Fn, List) when is_list(List) ->
-	[Head | Tail] = List,
-	[Fn(Head) | do_map_listish(Fn, Tail)];
+    [Head | Tail] = List,
+    [Fn(Head) | do_map_listish(Fn, Tail)];
 do_map_listish(Fn, Tail) when not is_list(Tail) ->
-	[Fn(Tail)].
+    [Fn(Tail)].
 
 float_to_string(Float) when is_float(Float) ->
     erlang:iolist_to_binary(io_lib_format:fwrite_g(Float)).


### PR DESCRIPTION
closes #332
and thus closes https://github.com/gleam-lang/gleam/issues/1721

Let me know if you prefer to have a general function that just converts listish (list+improper list) to list - that fn could be reused, but then mapping in this case takes two recursion passes.

~~I am also not sure if my solution is TCO compatible.~~