### PR TITLE
Add `int.{remainder, modulo}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - `string.slice` is now tail recursive and will no longer exceed the stack size
   on large inputs on target JavaScript.
-- Added `int.remainder` and `int.modulo` functions which allow safe modulo
-  operations the way common languages support them.
+- Added `int.remainder` and `int.modulo` functions which allow safe remainder
+  and modulo operations the way common languages support them.
 
 ## v0.23.0 - 2022-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## v0.24.0 - unreleased
 
-- `string.slice` is now tail recursive and will no longer blog the stack on
-  large inputs when running on JavaScript.
+- `string.slice` is now tail recursive and will no longer exceed the stack size
+  on large inputs on target JavaScript.
+- Added `int.remainder` and `int.modulo` functions which allow safe modulo
+  operations the way common languages support them.
 
 ## v0.23.0 - 2022-09-15
 

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -502,6 +502,8 @@ pub fn random(boundary_a: Int, boundary_b: Int) -> Int {
   |> float.round()
 }
 
+/// Performs a truncated integer division.
+///
 /// Returns division of the inputs as a `Result`.
 ///
 /// ## Examples
@@ -512,6 +514,12 @@ pub fn random(boundary_a: Int, boundary_b: Int) -> Int {
 ///
 /// > divide(1, 0)
 /// Error(Nil)
+///
+/// > divide(5, 2)
+/// Ok(2)
+///
+/// > divide(-99, 2)
+/// Ok(-49)
 /// ```
 ///
 pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -504,7 +504,8 @@ pub fn random(boundary_a: Int, boundary_b: Int) -> Int {
 
 /// Performs a truncated integer division.
 ///
-/// Returns division of the inputs as a `Result`.
+/// Returns division of the inputs as a `Result`: If the given divisor equals
+/// `0`, this function returns an `Error`.
 ///
 /// ## Examples
 ///
@@ -535,8 +536,8 @@ pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// C, C#, C++, Go, Java, JavaScript, Kotlin, Nim, PHP, Rust,
 /// Scala, Swift, Crystal as well as Erlang's and Elixir's rem operator.
 ///
-/// In addition if the given divisor equals `0`, this function returns an
-/// `Error`.
+/// Returns division of the inputs as a `Result`: If the given divisor equals
+/// `0`, this function returns an `Error`.
 ///
 /// ## Examples
 ///
@@ -575,8 +576,8 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// This functions mimicks modulo operation on following languages:
 /// Haskell, Lua, Python, Ruby, as well as Elixir's Integer.mod().
 ///
-/// In addition if the given divisor equals `0`, this function returns an
-/// `Error`.
+/// Returns division of the inputs as a `Result`: If the given divisor equals
+/// `0`, this function returns an `Error`.
 ///
 /// ## Examples
 ///

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -514,9 +514,94 @@ pub fn random(boundary_a: Int, boundary_b: Int) -> Int {
 /// Error(Nil)
 /// ```
 ///
-pub fn divide(a: Int, by b: Int) -> Result(Int, Nil) {
-  case b {
+pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
+  case divisor {
     0 -> Error(Nil)
-    b -> Ok(a / b)
+    divisor -> Ok(dividend / divisor)
+  }
+}
+
+/// Returns division remainder of the inputs as a `Result`.
+///
+/// This functions mimicks modulo operation of following languages:
+/// C, C#, C++, Go, Java, JavaScript, Kotlin, Nim, PHP, Rust,
+/// Scala, Swift, Crystal as well as Erlang's and Elixir's rem operator.
+///
+/// In addition if the given divisor equals 0, this function returns an Error.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > int.remainder(3, 2)
+/// Ok(1)
+///
+/// > int.remainder(1, 0)
+/// Error(Nil)
+///
+/// > int.remainder(10, -1)
+/// Ok(0)
+///
+/// > int.remainder(13, by: 3)
+/// Ok(1)
+///
+/// > int.remainder(-13, by: 3)
+/// Ok(-1)
+///
+/// > int.remainder(13, by: -3)
+/// Ok(1)
+///
+/// > int.remainder(-13, by: -3)
+/// Ok(-1)
+/// ```
+///
+pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
+  case divisor {
+    0 -> Error(Nil)
+    divisor -> Ok(dividend % divisor)
+  }
+}
+
+/// Computes the modulo remainder of an integer division.
+///
+/// This functions mimicks modulo operation on following languages:
+/// Haskell, Lua, Python, Ruby, as well as Elixir's Integer.mod().
+///
+/// In addition if the given divisor equals 0, this function returns an Error.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > int.modulo(3, 2)
+/// Ok(1)
+///
+/// > int.modulo(1, 0)
+/// Error(Nil)
+///
+/// > int.modulo(10, -1)
+/// Ok(0)
+///
+/// > int.modulo(13, by: 3)
+/// Ok(1)
+///
+/// > int.modulo(-13, by: 3)
+/// Ok(2)
+///
+/// > int.modulo(13, by: -3)
+/// Ok(-2)
+///
+/// > int.modulo(-13, by: -3)
+/// Ok(-1)
+/// ```
+///
+pub fn modulo(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
+  case divisor {
+    0 -> Error(Nil)
+    _ -> {
+      let remainder = dividend % divisor
+      case remainder * divisor < 0 {
+        True -> Ok(remainder + divisor)
+        False -> Ok(remainder)
+      }
+    }
   }
 }

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -529,13 +529,14 @@ pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
   }
 }
 
-/// Returns division remainder of the inputs as a `Result`.
+/// Computes the remainder of an integer division of inputs as a `Result`.
 ///
 /// This functions mimicks modulo operation of following languages:
 /// C, C#, C++, Go, Java, JavaScript, Kotlin, Nim, PHP, Rust,
 /// Scala, Swift, Crystal as well as Erlang's and Elixir's rem operator.
 ///
-/// In addition if the given divisor equals 0, this function returns an Error.
+/// In addition if the given divisor equals `0`, this function returns an
+/// `Error`.
 ///
 /// ## Examples
 ///
@@ -569,12 +570,13 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
   }
 }
 
-/// Computes the modulo remainder of an integer division.
+/// Computes the modulo of an integer division of inputs as a `Result`.
 ///
 /// This functions mimicks modulo operation on following languages:
 /// Haskell, Lua, Python, Ruby, as well as Elixir's Integer.mod().
 ///
-/// In addition if the given divisor equals 0, this function returns an Error.
+/// In addition if the given divisor equals `0`, this function returns an
+/// `Error`.
 ///
 /// ## Examples
 ///

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -19,7 +19,10 @@ if javascript {
 /// See [the Erlang map module](https://erlang.org/doc/man/maps.html) for more
 /// information.
 ///
-pub external type Map(key, value)
+pub external type Map(
+  key,
+  value,
+)
 
 /// Determines the number of key-value pairs in the map.
 /// This function runs in constant time and does not need to iterate the map.

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -424,6 +424,12 @@ pub fn divide_test() {
 
   int.divide(1, by: 0)
   |> should.equal(Error(Nil))
+
+  int.divide(5, by: 2)
+  |> should.equal(Ok(2))
+
+  int.divide(-99, by: 2)
+  |> should.equal(Ok(-49))
 }
 
 pub fn remainder_test() {

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -273,7 +273,7 @@ pub fn power_test() {
 
   // int.power(-1, 0.5) is equivalent to int.square_root(-1) and should
   // return an error as an imaginary number would otherwise have to be
-  // returned 
+  // returned
   int.power(-1, 0.5)
   |> should.equal(Error(Nil))
 
@@ -286,7 +286,7 @@ pub fn power_test() {
   int.power(0, -1.0)
   |> should.equal(Error(Nil))
 
-  // Check that a negative base and exponent is fine as long as the 
+  // Check that a negative base and exponent is fine as long as the
   // exponent is not fractional
   int.power(-2, -1.0)
   |> should.equal(Ok(-0.5))
@@ -415,11 +415,59 @@ pub fn random_test() {
 pub fn divide_test() {
   int.divide(1, 1)
   |> should.equal(Ok(1))
+
   int.divide(1, 0)
   |> should.equal(Error(Nil))
 
   int.divide(0, by: 1)
   |> should.equal(Ok(0))
+
   int.divide(1, by: 0)
   |> should.equal(Error(Nil))
+}
+
+pub fn remainder_test() {
+  int.remainder(3, 2)
+  |> should.equal(Ok(1))
+
+  int.remainder(1, 0)
+  |> should.equal(Error(Nil))
+
+  int.remainder(10, -1)
+  |> should.equal(Ok(0))
+
+  int.remainder(13, by: 3)
+  |> should.equal(Ok(1))
+
+  int.remainder(-13, by: 3)
+  |> should.equal(Ok(-1))
+
+  int.remainder(13, by: -3)
+  |> should.equal(Ok(1))
+
+  int.remainder(-13, by: -3)
+  |> should.equal(Ok(-1))
+}
+
+pub fn modulo_test() {
+  int.modulo(3, 2)
+  |> should.equal(Ok(1))
+
+  int.modulo(1, 0)
+  |> should.equal(Error(Nil))
+
+  int.modulo(10, -1)
+  |> should.equal(Ok(0))
+
+  int.modulo(13, by: 3)
+  |> should.equal(Ok(1))
+
+  int.modulo(-13, by: 3)
+  |> should.equal(Ok(2))
+
+  int.modulo(13, by: -3)
+  |> should.equal(Ok(-2))
+
+  int.modulo(-13, by: -3)
+  |> should.equal(Ok(-1))
 }


### PR DESCRIPTION
As a side effect we have noticed the 0-safe stdlib functions were missing when @tynanbe discovered this bug https://github.com/gleam-lang/gleam/issues/1784

We were unsure if modulo and remainder are the same until I did some digging: <https://torstencurdt.com/tech/posts/modulo-of-negative-numbers/>

IMHO, we should make sure to call `%` ***remainder operator*** in gleam compiler code and any current and future gleam docs as it maps to C/Erlang behavior where it is also called remainder (and not modulo AFAIK).

I have also ported Elixir's `Integer.modulo` because that behavior for integer modulo/remainder division is also common in many languages (see link above).