### PR TITLE
`list.insertion_sort_tailrec` and `list.insertion_sort`

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1032,6 +1032,47 @@ pub fn sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
   do_sort(list, compare, length(list))
 }
 
+/// Sorts from smallest to largest based upon the ordering specified by a given
+/// function.
+///
+fn insert_into_sorted(
+  item: a,
+  sorted_list: List(a),
+  compare: fn(a, a) -> Order,
+) -> List(a) {
+  case sorted_list {
+    [] -> [item]
+    [head, ..tail] ->
+      case compare(item, head) {
+        order.Eq | order.Lt -> prepend(sorted_list, item)
+        _ ->
+          insert_into_sorted(item, tail, compare)
+          |> prepend(head)
+      }
+  }
+}
+
+/// Sorts from smallest to largest based upon the ordering specified by a given
+/// function. Applies the insertion sort algorithm.
+/// See <https://en.wikipedia.org/wiki/Insertion_sort> for details.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > import gleam/int
+/// > list.insertion_sort([4, 3, 6, 5, 4, 1, 2], by: int.compare)
+/// [1, 2, 3, 4, 4, 5, 6]
+/// ```
+///
+pub fn insertion_sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
+  case list {
+    [] -> []
+    [one_item] -> [one_item]
+    [head, ..tail] ->
+      insert_into_sorted(head, insertion_sort(tail, compare), compare)
+  }
+}
+
 /// Creates a list of ints ranging from a given start and finish.
 ///
 /// ## Examples

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1079,15 +1079,15 @@ pub fn insertion_sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
 /// Processes as such for inserting `4` into `[1, 2, 3, 5]`:
 ///
 /// ```gleam
-/// > do_insert_into_sorted_list_list_tailrec(4, [1, 2, 3, 5], [])
-/// > do_insert_into_sorted_list_list_tailrec(4, [2, 3, 5], [1])
-/// > do_insert_into_sorted_list_list_tailrec(4, [3, 5], [2, 1])
-/// > do_insert_into_sorted_list_list_tailrec(4, [5], [3, 2, 1])
+/// > do_insert_into_sorted_list_tailrec(4, [1, 2, 3, 5], [])
+/// > do_insert_into_sorted_list_tailrec(4, [2, 3, 5], [1])
+/// > do_insert_into_sorted_list_tailrec(4, [3, 5], [2, 1])
+/// > do_insert_into_sorted_list_tailrec(4, [5], [3, 2, 1])
 /// > [3, 2, 1] |> reverse() |> append(4, ..[5])
 /// [1, 2, 3, 4, 5]
 /// ```
 ///
-fn do_insert_into_sorted_list_list_tailrec(
+fn do_insert_into_sorted_list_tailrec(
   item: a,
   sorted_list: List(a),
   smaller_than_item_acc: List(a),
@@ -1105,7 +1105,7 @@ fn do_insert_into_sorted_list_list_tailrec(
           |> reverse
           |> append([item, ..sorted_list])
         _ ->
-          do_insert_into_sorted_list_list_tailrec(
+          do_insert_into_sorted_list_tailrec(
             item,
             sorted_list_tail,
             [sorted_list_head, ..smaller_than_item_acc],
@@ -1126,7 +1126,7 @@ fn do_insertion_sort_tailrec(
     [chaotic_list_head, ..chaotic_list_tail] ->
       do_insertion_sort_tailrec(
         chaotic_list_tail,
-        do_insert_into_sorted_list_list_tailrec(
+        do_insert_into_sorted_list_tailrec(
           chaotic_list_head,
           sorted_list,
           [],

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1032,10 +1032,9 @@ pub fn sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
   do_sort(list, compare, length(list))
 }
 
-/// Sorts from smallest to largest based upon the ordering specified by a given
-/// function.
+/// Inserts an element into a sorted list at its correct ordering index.
 ///
-fn insert_into_sorted(
+fn do_insert_into_sorted_list(
   item: a,
   sorted_list: List(a),
   compare: fn(a, a) -> Order,
@@ -1044,9 +1043,9 @@ fn insert_into_sorted(
     [] -> [item]
     [head, ..tail] ->
       case compare(item, head) {
-        order.Eq | order.Lt -> prepend(sorted_list, item)
+        order.Lt | order.Eq -> prepend(sorted_list, item)
         _ ->
-          insert_into_sorted(item, tail, compare)
+          do_insert_into_sorted_list(item, tail, compare)
           |> prepend(head)
       }
   }
@@ -1069,8 +1068,92 @@ pub fn insertion_sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
     [] -> []
     [one_item] -> [one_item]
     [head, ..tail] ->
-      insert_into_sorted(head, insertion_sort(tail, compare), compare)
+      do_insert_into_sorted_list(head, insertion_sort(tail, compare), compare)
   }
+}
+
+/// Inserts an element into a sorted list at its correct ordering index.
+///
+/// This is the tail recurwsive variant of do_insert_into_sorted_list.
+///
+/// Processes as such for inserting `4` into `[1, 2, 3, 5]`:
+///
+/// ```gleam
+/// > do_insert_into_sorted_list_list_tailrec(4, [1, 2, 3, 5], [])
+/// > do_insert_into_sorted_list_list_tailrec(4, [2, 3, 5], [1])
+/// > do_insert_into_sorted_list_list_tailrec(4, [3, 5], [2, 1])
+/// > do_insert_into_sorted_list_list_tailrec(4, [5], [3, 2, 1])
+/// > [3, 2, 1] |> reverse() |> append(4, ..[5])
+/// [1, 2, 3, 4, 5]
+/// ```
+///
+fn do_insert_into_sorted_list_list_tailrec(
+  item: a,
+  sorted_list: List(a),
+  smaller_than_item_acc: List(a),
+  compare_fn: fn(a, a) -> Order,
+) -> List(a) {
+  case sorted_list {
+    [] ->
+      smaller_than_item_acc
+      |> reverse
+      |> append([item, ..sorted_list])
+    [sorted_list_head, ..sorted_list_tail] ->
+      case compare_fn(item, sorted_list_head) {
+        order.Lt | order.Eq ->
+          smaller_than_item_acc
+          |> reverse
+          |> append([item, ..sorted_list])
+        _ ->
+          do_insert_into_sorted_list_list_tailrec(
+            item,
+            sorted_list_tail,
+            [sorted_list_head, ..smaller_than_item_acc],
+            compare_fn,
+          )
+      }
+  }
+}
+
+/// This is the private insertion_sort implementation containing an accumulator
+fn do_insertion_sort_tailrec(
+  chaotic_list: List(a),
+  sorted_list: List(a),
+  compare_fn: fn(a, a) -> Order,
+) -> List(a) {
+  case chaotic_list {
+    [] -> sorted_list
+    [chaotic_list_head, ..chaotic_list_tail] ->
+      do_insertion_sort_tailrec(
+        chaotic_list_tail,
+        do_insert_into_sorted_list_list_tailrec(
+          chaotic_list_head,
+          sorted_list,
+          [],
+          compare_fn,
+        ),
+        compare_fn,
+      )
+  }
+}
+
+/// Sorts from smallest to largest based upon the ordering specified by a given
+/// function. Applies the insertion sort algorithm.
+/// See <https://en.wikipedia.org/wiki/Insertion_sort> for details.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > import gleam/int
+/// > list.insertion_sort_tailrec([4, 3, 6, 5, 4, 1, 2], by: int.compare)
+/// [1, 2, 3, 4, 4, 5, 6]
+/// ```
+///
+pub fn insertion_sort_tailrec(
+  list: List(a),
+  by compare_fn: fn(a, a) -> Order,
+) -> List(a) {
+  do_insertion_sort_tailrec(list, [], compare_fn)
 }
 
 /// Creates a list of ints ranging from a given start and finish.

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -483,6 +483,29 @@ pub fn insertion_sort_test() {
   |> should.equal([])
 }
 
+pub fn insertion_sort_tailrec_test() {
+  [4, 3, 6, 5, 4]
+  |> list.insertion_sort_tailrec(int.compare)
+  |> should.equal([3, 4, 4, 5, 6])
+
+  [4, 3, 6, 5, 4, 1]
+  |> list.insertion_sort_tailrec(int.compare)
+  |> should.equal([1, 3, 4, 4, 5, 6])
+
+  [4.1, 3.1, 6.1, 5.1, 4.1]
+  |> list.insertion_sort_tailrec(float.compare)
+  |> should.equal([3.1, 4.1, 4.1, 5.1, 6.1])
+
+  []
+  |> list.insertion_sort_tailrec(int.compare)
+  |> should.equal([])
+
+  list.range(0, 100_000)
+  |> list.reverse
+  |> list.insertion_sort_tailrec(int.compare)
+}
+
+/// TCO test
 pub fn index_map_test() {
   list.index_map([3, 4, 5], fn(i, x) { #(i, x) })
   |> should.equal([#(0, 3), #(1, 4), #(2, 5)])

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -465,6 +465,24 @@ pub fn sort_test() {
   |> should.equal([])
 }
 
+pub fn insertion_sort_test() {
+  [4, 3, 6, 5, 4]
+  |> list.insertion_sort(int.compare)
+  |> should.equal([3, 4, 4, 5, 6])
+
+  [4, 3, 6, 5, 4, 1]
+  |> list.insertion_sort(int.compare)
+  |> should.equal([1, 3, 4, 4, 5, 6])
+
+  [4.1, 3.1, 6.1, 5.1, 4.1]
+  |> list.insertion_sort(float.compare)
+  |> should.equal([3.1, 4.1, 4.1, 5.1, 6.1])
+
+  []
+  |> list.insertion_sort(int.compare)
+  |> should.equal([])
+}
+
 pub fn index_map_test() {
   list.index_map([3, 4, 5], fn(i, x) { #(i, x) })
   |> should.equal([#(0, 3), #(1, 4), #(2, 5)])


### PR DESCRIPTION
After benchmarking I guess we will remove `list.insertion_sort`.

This PR includes a test for JS that sorts a list with `100_000` items and does not blow the stack.
