### PR TITLE
Regex use ucp flag because they use unicode flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed a bug where `regex.scan` would not work correctly on utf8.
 - The performance of `list.flatten` has been greatly improved.
 - The `string_builder` module gains the `join` function.
-- The `list` module gains the  `shuffle` function.
+- The `list` module gains the `shuffle` function.
 
 ## v0.24.0 - 2022-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   the same order that they appear in the input.
 - Added functions `function.apply1` through `function.apply3` which help working
   with functions in pipelines.
+- `regexp.compile` now allows usage of `\B`, `\b`, `\D`, `\d`, `\S`, `\s`, `\W`
+   and `\w` in conjunction with utf8.
 
 ## v0.24.0 - 2022-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - The performance of `list.flatten` has been greatly improved.
 - The `string_builder` module gains the `join` function.
 - For `regexp.compile` unicode character properties are now used when
-  resolving `\B`, `\b`, `\D`, `\d`, `\S`, `\s`, `\W` and `\w` on target Erlang.
+  resolving `\B`, `\b`, `\D`, `\d`, `\S`, `\s`, `\W`, and `\w` on target
+  Erlang.
 
 ## v0.24.0 - 2022-10-15
 

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -184,6 +184,7 @@ compile_regex(String, Options) ->
     {options, Caseless, Multiline} = Options,
     OptionsList = [
         unicode,
+        ucp,
         Caseless andalso caseless,
         Multiline andalso multiline
     ],

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -26,6 +26,13 @@ pub fn compile_test() {
 
   regex.check(re, "abc\n123")
   |> should.be_true
+
+  // For Erlang: This test only succeds only, if the unicode AND the ucp flag
+  // are enabled
+  assert Ok(re) = regex.compile("\\s", options)
+  // Em Space = U+2003 = " " (used below)
+  regex.check(re, " ")
+  |> should.be_true
 }
 
 pub fn check_test() {

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -27,10 +27,9 @@ pub fn compile_test() {
   regex.check(re, "abc\n123")
   |> should.be_true
 
-  // For Erlang: This test only succeds only, if the unicode AND the ucp flag
-  // are enabled
+  // For Erlang: This test will only passes if unicode and ucp flags are set
   assert Ok(re) = regex.compile("\\s", options)
-  // Em Space = U+2003 = " " (used below)
+  // Em space == U+2003 == " " == used below
   regex.check(re, " ")
   |> should.be_true
 }


### PR DESCRIPTION
Closes: https://github.com/gleam-lang/stdlib/issues/356