### PR TITLE
improve list.flatten speed in most cases

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -530,18 +530,19 @@ pub fn prepend(to list: List(a), item: a) -> List(a) {
   [item, ..list]
 }
 
-fn prepend_list_reverse(list prefix: List(a), to suffix: List(a)) -> List(a) {
+// Reverses a list and prepends it to another list
+fn reverse_and_prepend(list prefix: List(a), to suffix: List(a)) -> List(a) {
   case prefix {
     [] -> suffix
-    [head, ..tail] -> prepend_list_reverse(tail, [head, ..suffix])
+    [head, ..tail] -> reverse_and_prepend(list: tail, to: [head, ..suffix])
   }
 }
 
 fn do_flatten(lists: List(List(a)), acc: List(a)) -> List(a) {
   case lists {
     [] -> reverse(acc)
-    [a_list, ..rest_lists] ->
-      do_flatten(rest_lists, prepend_list_reverse(a_list, acc))
+    [list, ..further_lists] ->
+      do_flatten(further_lists, reverse_and_prepend(list: list, to: acc))
   }
 }
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -530,17 +530,24 @@ pub fn prepend(to list: List(a), item: a) -> List(a) {
   [item, ..list]
 }
 
+fn prepend_list_reverse(list prefix: List(a), to suffix: List(a)) -> List(a) {
+  case prefix {
+    [] -> suffix
+    [head, ..tail] -> prepend_list_reverse(tail, [head, ..suffix])
+  }
+}
+
 fn do_flatten(lists: List(List(a)), acc: List(a)) -> List(a) {
   case lists {
-    [] -> acc
-    [l, ..rest] -> do_flatten(rest, append(acc, l))
+    [] -> reverse(acc)
+    [a_list, ..rest_lists] ->
+      do_flatten(rest_lists, prepend_list_reverse(a_list, acc))
   }
 }
 
 /// Flattens a list of lists into a single list.
 ///
-/// This function runs in linear time, and it traverses and copies all the
-/// inner lists.
+/// This function traverses all elements twice.
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
When reviewing my changes to `list.permutations` @schurhammer notices that `list.flatten` should lose the `append`. He suggested a reveres prepend for each list of lists.

AFAIU current implementation:

- walk the whole list to append
- walk the whole list + 1 to append next
- walk the whole list + 2 to append
- ...
- walk the whole list + n to append

How this PR works:

- Say we have `[[1,2], [3,4], [5,6]]`
- we take `[1,2]` and reverse prepend it into the accumulator `[]` to get `[2,1]`
- then take `[3, 4]` and reverse preprend it into `[2,1]` to get `[4,3,2,1]`
- and then `[5, 6]` and reverse and prepend to get `[6,5,4,3,2,1]`
- in the end the result`[6,5,4,3,2,1]` needs to be reversed again.
- In conclusion we have to walk each element once to reverse-prepend and then another time to reverse the result.

I have run this benchmark:

```gleam
if erlang {
  import glychee/benchmark
  import gleam/list

  pub fn main() {
    benchmark.run(
      [
        benchmark.Function(
          label: "list.flatten()",
          callable: fn(test_data) { fn() { list.flatten(test_data) } },
        ),
        benchmark.Function(
          label: "list.flatten_2()",
          callable: fn(test_data) { fn() { list.flatten_2(test_data) } },
        ),
      ],
      [
        benchmark.Data(
          label: "tiny in tiny",
          data: list.range(1, 10)
          |> list.repeat(10),
        ),
        benchmark.Data(
          label: "tiny in medium",
          data: list.range(1, 10)
          |> list.repeat(1_000),
        ),
        benchmark.Data(
          label: "medium in tiny",
          data: list.range(1, 1_000)
          |> list.repeat(10),
        ),
        benchmark.Data(
          label: "short in short",
          data: list.range(1, 100)
          |> list.repeat(100),
        ),
        benchmark.Data(
          label: "large in short",
          data: list.range(1, 10_000)
          |> list.repeat(100),
        ),
        benchmark.Data(
          label: "short in large",
          data: list.range(1, 100)
          |> list.repeat(10_000),
        ),
        benchmark.Data(
          label: "medium in medium",
          data: list.range(1, 1_000)
          |> list.repeat(1_000),
        ),
      ],
    )
  }
}
```

With these results, note that large in large never finished after half an hour:

```shell
❯ gleam clean && \
gleam build && \
erl -pa ./build/dev/erlang/*/ebin -noshell -eval 'gleam@@main:run(benchmark)'
Downloading packages
 Downloaded 4 packages in 0.02s
  Compiling deep_merge
  Compiling statistex
  Compiling benchee
  Compiling glychee
  Compiling gleam_stdlib
   Compiled in 6.06s


================================================================================
==== data set: tiny in tiny
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()        1.20 M        0.84 μs  ±3713.04%        0.70 μs        1.09 μs
list.flatten()          0.87 M        1.15 μs  ±2233.83%        1.09 μs        1.49 μs

Comparison:
list.flatten_2()        1.20 M
list.flatten()          0.87 M - 1.38x slower +0.32 μs

Memory usage statistics:

Name                Memory usage
list.flatten_2()         2.78 KB
list.flatten()           4.91 KB - 1.76x memory usage +2.13 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name             Reduction count
list.flatten_2()             176
list.flatten()                98 - 0.56x reduction count -78

**All measurements for reduction count were the same**


================================================================================
==== data set: tiny in medium
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()       12.35 K      0.0810 ms    ±29.51%      0.0791 ms       0.167 ms
list.flatten()        0.0654 K       15.29 ms    ±15.65%       14.00 ms       23.11 ms

Comparison:
list.flatten_2()       12.35 K
list.flatten()        0.0654 K - 188.81x slower +15.21 ms

Memory usage statistics:

Name                Memory usage
list.flatten_2()         0.27 MB
list.flatten()          64.34 MB - 235.31x memory usage +64.07 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name             Reduction count
list.flatten_2()         18.08 K
list.flatten()          356.07 K - 19.70x reduction count +337.99 K

**All measurements for reduction count were the same**


================================================================================
==== data set: medium in tiny
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()       12.15 K       82.27 μs    ±28.70%       81.91 μs      175.64 μs
list.flatten()          6.93 K      144.28 μs    ±29.14%      132.74 μs      281.61 μs

Comparison:
list.flatten_2()       12.15 K
list.flatten()          6.93 K - 1.75x slower +62.00 μs

Memory usage statistics:

Name                Memory usage
list.flatten_2()       223.98 KB
list.flatten()         513.34 KB - 2.29x memory usage +289.36 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name             Reduction count
list.flatten_2()         15.52 K
list.flatten()            6.26 K - 0.40x reduction count -9.26000 K

**All measurements for reduction count were the same**


================================================================================
==== data set: short in short
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()       11.88 K      0.0842 ms    ±33.35%      0.0800 ms       0.197 ms
list.flatten()          0.68 K        1.47 ms    ±10.00%        1.44 ms        1.95 ms

Comparison:
list.flatten_2()       11.88 K
list.flatten()          0.68 K - 17.52x slower +1.39 ms

Memory usage statistics:

Name                Memory usage
list.flatten_2()         0.22 MB
list.flatten()           6.44 MB - 29.42x memory usage +6.22 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name             Reduction count
list.flatten_2()         15.70 K
list.flatten()           38.97 K - 2.48x reduction count +23.27 K

**All measurements for reduction count were the same**


================================================================================
==== data set: large in short
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()         30.84       32.43 ms    ±21.43%       32.13 ms       52.14 ms
list.flatten()            1.89      529.83 ms     ±1.95%      528.77 ms      548.18 ms

Comparison:
list.flatten_2()         30.84
list.flatten()            1.89 - 16.34x slower +497.40 ms

Memory usage statistics:

Name                Memory usage
list.flatten_2()        28.06 MB
list.flatten()         602.23 MB - 21.46x memory usage +574.18 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                     average  deviation         median         99th %
list.flatten_2()          1.13 M     ±0.51%         1.14 M         1.15 M
list.flatten()            1.70 M     ±0.69%         1.70 M         1.72 M

Comparison:
list.flatten_2()          1.14 M
list.flatten()            1.70 M - 1.50x reduction count +0.57 M


================================================================================
==== data set: short in large
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()         39.96       0.0250 s    ±25.55%       0.0245 s       0.0433 s
list.flatten()          0.0195        51.35 s     ±0.00%        51.35 s        51.35 s

Comparison:
list.flatten_2()         39.96
list.flatten()          0.0195 - 2051.66x slower +51.32 s

Memory usage statistics:

Name                Memory usage
list.flatten_2()       0.0277 GB
list.flatten()          56.95 GB - 2052.85x memory usage +56.92 GB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                     average  deviation         median         99th %
list.flatten_2()          1.18 M     ±0.69%         1.18 M         1.20 M
list.flatten()          167.81 M     ±0.00%       167.81 M       167.81 M

Comparison:
list.flatten_2()          1.18 M
list.flatten()          167.81 M - 142.31x reduction count +166.63 M


================================================================================
==== data set: medium in medium
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.flatten() ...
Benchmarking list.flatten_2() ...

Name                       ips        average  deviation         median         99th %
list.flatten_2()         29.10       0.0344 s    ±18.56%       0.0320 s       0.0501 s
list.flatten()            0.20         4.98 s     ±0.44%         4.98 s         4.99 s

Comparison:
list.flatten_2()         29.10
list.flatten()            0.20 - 144.86x slower +4.94 s

Memory usage statistics:

Name                Memory usage
list.flatten_2()       0.0281 GB
list.flatten()           5.71 GB - 203.54x memory usage +5.68 GB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                     average  deviation         median         99th %
list.flatten_2()          1.15 M     ±0.63%         1.15 M         1.16 M
list.flatten()           16.91 M     ±0.00%        16.91 M        16.91 M

Comparison:
list.flatten_2()          1.15 M
list.flatten()           16.91 M - 14.70x reduction count +15.76 M
```

If you want to run the benchmarks, for verification, you can clone this branch https://github.com/inoas/gleam-stdlib/tree/benchmark-flatten-vs-flatten-2