### PR TITLE
Implement `join` for `string_builder` module

### DIFF
--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -1,3 +1,5 @@
+import gleam/list
+
 /// `StringBuilder` is a type used for efficiently building strings.
 ///
 /// When we append one string to another the strings must be copied to a
@@ -159,6 +161,12 @@ if erlang {
 if javascript {
   external fn do_byte_size(StringBuilder) -> Int =
     "../gleam_stdlib.mjs" "length"
+}
+
+pub fn join(builders: List(StringBuilder), with sep: String) -> StringBuilder {
+  builders
+  |> list.intersperse(from_string(sep))
+  |> concat
 }
 
 /// Converts a builder to a new builder where the contents have been

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -163,6 +163,8 @@ if javascript {
     "../gleam_stdlib.mjs" "length"
 }
 
+/// Joins the given builders into a new builder separated with the given string
+///
 pub fn join(builders: List(StringBuilder), with sep: String) -> StringBuilder {
   builders
   |> list.intersperse(from_string(sep))

--- a/test/gleam/string_builder_test.gleam
+++ b/test/gleam/string_builder_test.gleam
@@ -134,3 +134,14 @@ pub fn new_test() {
   |> string_builder.to_string
   |> should.equal("")
 }
+
+pub fn join_test() {
+  [
+    string_builder.from_string("Gleam"),
+    string_builder.from_string("Elixir"),
+    string_builder.from_string("Erlang"),
+  ]
+  |> string_builder.join(", ")
+  |> string_builder.to_string
+  |> should.equal("Gleam, Elixir, Erlang")
+}


### PR DESCRIPTION
Addresses #361 and implements the `join` method for `string_builder`.