### PR TITLE
Unpublish do_to_graphemes

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -714,7 +714,7 @@ pub fn to_graphemes(string: String) -> List(String) {
   |> list.reverse
 }
 
-pub fn do_to_graphemes(string: String, acc: List(String)) -> List(String) {
+fn do_to_graphemes(string: String, acc: List(String)) -> List(String) {
   case pop_grapheme(string) {
     Ok(#(grapheme, rest)) -> do_to_graphemes(rest, [grapheme, ..acc])
     _ -> acc


### PR DESCRIPTION
This was introduced to benefit tail call optimization #338, but I don't think the intention was to allow users to use this function (all other `do_*` functions are private).

It also shows up in the [API docs](https://hexdocs.pm/gleam_stdlib/gleam/string.html#do_to_graphemes).