### PR TITLE
Feature: add zip_with to list and iterator

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -902,6 +902,44 @@ pub fn strict_zip(
   }
 }
 
+fn do_zip_with(xs: List(a), ys: List(b), fun: fn(a, b) -> c, acc: List(c)) -> List(c) {
+  case xs, ys {
+    [x, ..xs], [y, ..ys] -> do_zip_with(xs, ys, fun, [fun(x, y), ..acc])
+    _, _ -> reverse(acc)
+  }
+}
+
+/// Takes two lists and a binary operation
+/// and returns a single list with the results of
+/// applying the operation to each element 
+/// at the same position in both lists.
+///
+/// If one of the lists is longer than the other, the remaining elements from
+/// the longer list are not used.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > zip_with([], [], fn (a, b) { a + b })
+/// []
+///
+/// > zip_with([1, 2, 3], [4, 5, 6], fn (a, b) { a + b })
+/// [5, 7, 9]
+///
+/// > zip_with([1, 2, 3], [4, 5, 6], fn (a, b) { #(a, b) })
+/// [#(1, 4), #(2, 5), #(3, 9)]
+///
+/// > zip_with([1, 2], [4], fn (a, b) { a + b })
+/// [5]
+///
+/// > zip_with([5], [1, 2], fn (a, b) { a + b })
+/// [6]
+/// ```
+///
+pub fn zip_with(xs: List(a), ys: List(b), fun: fn(a, b) -> c) -> List(c) {
+  do_zip_with(xs, ys, fun, [])
+}
+
 fn do_unzip(input, xs, ys) {
   case input {
     [] -> #(reverse(xs), reverse(ys))

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -305,6 +305,13 @@ pub fn zip_test() {
   |> should.equal([#("a", 20), #("b", 21), #("c", 22)])
 }
 
+pub fn zip_with_test() {
+  iterator.from_list([1, 2, 3])
+  |> iterator.zip_with(iterator.range(5, 7), fn (a, b) { a + b })
+  |> iterator.to_list
+  |> should.equal([6, 8, 10])
+}
+
 pub fn chunk_test() {
   iterator.from_list([1, 2, 2, 3, 4, 4, 6, 7, 7])
   |> iterator.chunk(by: fn(n) { n % 2 })

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -484,6 +484,39 @@ pub fn zip_test() {
   list.zip(recursion_test_cycles_list, recursion_test_cycles_list)
 }
 
+pub fn zip_with_test() {
+  list.zip_with([], [], fn (a, b) { a + b })
+  |> should.equal([])
+
+  list.zip_with([], [1, 2, 3], fn (a, b) { a + b })
+  |> should.equal([])
+
+  list.zip_with([1, 2], [], fn (a, b) { a + b })
+  |> should.equal([])
+
+  list.zip_with([1, 2, 3], [4, 5, 6], fn (a, b) { a + b })
+  |> should.equal([5, 7, 9])
+
+  list.zip_with([1, 2], [4, 5, 6], fn (a, b) { a + b })
+  |> should.equal([5, 7])
+
+  list.zip_with([5, 6, 7], [1, 2], fn (a, b) { a + b })
+  |> should.equal([6, 8])
+
+  list.zip_with([1, 2, 3], [4, 5, 6], fn (a, b) { #(a, b) })
+  |> should.equal([#(1, 4), #(2, 5), #(3, 6)])
+
+  list.zip_with([1, 2], [4], fn (a, b) { a + b })
+  |> should.equal([5])
+
+    list.zip_with([5], [1, 2], fn (a, b) { a + b })
+  |> should.equal([6])
+
+  // TCO test
+  let recursion_test_cycles_list = list.range(0, recursion_test_cycles)
+  list.zip_with(recursion_test_cycles_list, recursion_test_cycles_list, fn (a, b) { a + b })
+}
+
 pub fn strict_zip_test() {
   list.strict_zip([], [1, 2, 3])
   |> should.equal(Error(list.LengthMismatch))


### PR DESCRIPTION
This PR proposes to add a `zip_with` to the list and iterator modules.
"Zip with" is a function to combine the elements of two lists or iterators into a single list or iterator using a binary operation.

```gleam
> list.zip_with([1, 2, 3], [4, 5, 6], fn (a, b) { a + b })
[5, 7, 9]

> iterator.from_list([1, 2, 3]) |> iterator.zip_with(range(5, 7), fn (a, b) { a + b })  |> iterator.to_list
[6, 8, 10]
```
I've stayed close to the existing `zip` implementations of each module.

Note that the existing `zip` could be expressed using `zip_with` by zipping over two sequences using a pair-construction operator.
```gleam
> list.zip_with([1, 2, 3], [4, 5, 6], fn (a, b) { #(a, b) })
[#(1, 4), #(2, 5), #(3, 9)]
```

Prior art includes:
- [Haskell](https://hackage.haskell.org/package/base-4.17.0.0/docs/Prelude.html#v:zipWith)
- [Erlang](https://www.erlang.org/doc/man/lists.html#zipwith-3)
- [lodash (JS Library)](https://lodash.com/docs/#zipWith)
- [ramdajs (JS Library)](https://ramdajs.com/docs/#zipWith)

In Python it is possible with [map](https://docs.python.org/3/library/functions.html#map) with an extra argument.
In C++ it is possible with [std::transform](https://en.cppreference.com/w/cpp/algorithm/transform) (comparable to our `map`) with an extra argument.
In C# / LINQ it is possible with [Zip](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.zip?view=net-7.0) with an extra argument.
In APL it is possible with [each (¨)](https://aplwiki.com/wiki/Each).

Before going further:
- Do we want this in the stdlib? 
- Should they be separate functions or part of map or zip?

To discuss (separate issue, perhaps):
- Should we make the zip APIs more consistent across modules (`xs`, `ys` vs `left`, `right`)? If yes, which is to be favored?
- Should we add labelled arguments to these APIs?