### PR TITLE
Add operator functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.24.1 - unreleased
 
+- The `bool` module gains the `and` and `or` functions.
+- The `float` module gains the `add`, `subtract` and `multiply` functions.
+- The `int` module gains the `add`, `subtract` and `multiply` functions.
 - Fixed a bug where `list.permutations` would not correctly permutate lists
   with non-unique item values.
 - For `regexp.compile` unicode character properties are now used when

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -8,7 +8,7 @@
 
 import gleam/order.{Order}
 
-/// Returns the and of two bools.
+/// Returns the and of two bools, but it evaluates both arguments.
 ///
 /// It's the function equivalent of the `&&` operator. 
 /// This function is useful in higher order functions or pipes.
@@ -29,7 +29,7 @@ pub fn and(a: Bool, b: Bool) -> Bool {
   a && b
 }
 
-/// Returns the or of two bools.
+/// Returns the or of two bools, but it evaluates both arguments.
 ///
 /// It's the function equivalent of the `||` operator. 
 /// This function is useful in higher order functions or pipes.

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -28,7 +28,7 @@ import gleam/order.{Order}
 /// > False |> and(True, _)
 /// False
 /// ```
-pub fn and(a: Bool, b: Bool) {
+pub fn and(a: Bool, b: Bool) -> Bool {
   a && b
 }
 
@@ -52,7 +52,7 @@ pub fn and(a: Bool, b: Bool) {
 /// > False |> or(True, _)
 /// True
 /// ```
-pub fn or(a: Bool, b: Bool) {
+pub fn or(a: Bool, b: Bool) -> Bool {
   a || b
 }
 

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -22,10 +22,7 @@ import gleam/order.{Order}
 /// > and(False, True)
 /// False
 ///
-/// > True |> and(_, True)
-/// True
-///
-/// > False |> and(True, _)
+/// > False |> and(True)
 /// False
 /// ```
 pub fn and(a: Bool, b: Bool) -> Bool {
@@ -46,10 +43,7 @@ pub fn and(a: Bool, b: Bool) -> Bool {
 /// > or(False, True)
 /// True
 ///
-/// > False |> or(_, False)
-/// False
-///
-/// > False |> or(True, _)
+/// > False |> or(True)
 /// True
 /// ```
 pub fn or(a: Bool, b: Bool) -> Bool {

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -8,6 +8,54 @@
 
 import gleam/order.{Order}
 
+/// Returns the and of two bools.
+///
+/// It's the function equivalent of the `&&` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > and(True, True)
+/// True
+///
+/// > and(False, True)
+/// False
+///
+/// > True |> and(_, True)
+/// True
+///
+/// > False |> and(True, _)
+/// False
+/// ```
+pub fn and(a: Bool, b: Bool) {
+  a && b
+}
+
+/// Returns the or of two bools.
+///
+/// It's the function equivalent of the `||` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > or(True, True)
+/// True
+///
+/// > or(False, True)
+/// True
+///
+/// > False |> or(_, False)
+/// False
+///
+/// > False |> or(True, _)
+/// True
+/// ```
+pub fn or(a: Bool, b: Bool) {
+  a || b
+}
+
 /// Returns the opposite bool value.
 ///
 /// This is the same as the `!` or `not` operators in some other languages.

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -479,7 +479,7 @@ pub fn multiply(a: Float, b: Float) -> Float {
   a *. b
 }
 
-/// Subtracts a float subtrahend from a float minuend.gleam/base
+/// Subtracts one float from another.
 ///
 /// It's the function equivalent of the `-.` operator. 
 /// This function is useful in higher order functions or pipes.

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -436,3 +436,75 @@ pub fn divide(a: Float, by b: Float) -> Result(Float, Nil) {
     b -> Ok(a /. b)
   }
 }
+
+/// Adds two floats together.
+///
+/// It's the function equivalent of the `+.` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > add(1.0, 2.0)
+/// 3.0
+///
+/// > list.fold([1.0, 2.0, 3.0], 0.0, add)
+/// 6.0
+///
+/// > 3.0 |> add(2.0)
+/// 5.0
+/// ```
+pub fn add(a: Float, b: Float) -> Float {
+  a +. b
+}
+
+/// Multiplies two floats together.
+///
+/// It's the function equivalent of the `*.` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > multiply(2.0, 4.0)
+/// 8.0
+///
+/// > list.fold([2.0, 3.0, 4.0], 1.0, multiply)
+/// 24.0
+///
+/// > 3.0 |> multiply(2.0)
+/// 6.0
+/// ```
+pub fn multiply(a: Float, b: Float) -> Float {
+  a *. b
+}
+
+/// Subtracts a float subtrahend from a float minuend.gleam/base
+///
+/// It's the function equivalent of the `-.` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > subtract(3.0, 1.0)
+/// 2.0
+///
+/// > list.fold([1.0, 2.0, 3.0], 10.0, subtract)
+/// 4.0
+///
+/// > 3.0 |> subtract(_, 2.0)
+/// 1.0
+///
+/// > 3.0 |> subtract(2.0, _)
+/// -1.0
+///
+/// > 3.0 |> subtract(subtrahend: 2.0)
+/// 1.0
+///
+/// > 3.0 |> subtract(minuend: 2.0)
+/// -1.0
+/// ```
+pub fn subtract(minuend a: Float, subtrahend b: Float) -> Float {
+  a -. b
+}

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -498,13 +498,7 @@ pub fn multiply(a: Float, b: Float) -> Float {
 ///
 /// > 3.0 |> subtract(2.0, _)
 /// -1.0
-///
-/// > 3.0 |> subtract(subtrahend: 2.0)
-/// 1.0
-///
-/// > 3.0 |> subtract(minuend: 2.0)
-/// -1.0
 /// ```
-pub fn subtract(minuend a: Float, subtrahend b: Float) -> Float {
+pub fn subtract(a: Float, b: Float) -> Float {
   a -. b
 }

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -695,7 +695,7 @@ pub fn multiply(a: Int, b: Int) -> Int {
   a * b
 }
 
-/// Subtracts an integer subtrahend from an integer minuend.
+/// Subtracts one int from another.
 ///
 /// It's the function equivalent of the `-` operator. 
 /// This function is useful in higher order functions or pipes.
@@ -709,7 +709,7 @@ pub fn multiply(a: Int, b: Int) -> Int {
 /// > list.fold([1, 2, 3], 10, subtract)
 /// 4
 ///
-/// > 3 |> subtract(_, 2)
+/// > 3 |> subtract(2)
 /// 1
 ///
 /// > 3 |> subtract(2, _)

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -652,3 +652,75 @@ pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
       }
   }
 }
+
+/// Adds two integers together.
+///
+/// It's the function equivalent of the `+` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > add(1, 2)
+/// 3
+///
+/// > list.fold([1, 2, 3], 0, add)
+/// 6
+///
+/// > 3 |> add(2)
+/// 5
+/// ```
+pub fn add(a: Int, b: Int) -> Int {
+  a + b
+}
+
+/// Multiplies two integers together.
+///
+/// It's the function equivalent of the `*` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > multiply(2, 4)
+/// 8
+///
+/// > list.fold([2, 3, 4], 1, multiply)
+/// 24
+///
+/// > 3 |> multiply(2)
+/// 6
+/// ```
+pub fn multiply(a: Int, b: Int) -> Int {
+  a * b
+}
+
+/// Subtracts an integer subtrahend from an integer minuend.
+///
+/// It's the function equivalent of the `-` operator. 
+/// This function is useful in higher order functions or pipes.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > subtract(3, 1)
+/// 2.0
+///
+/// > list.fold([1, 2, 3], 10, subtract)
+/// 4
+///
+/// > 3 |> subtract(_, 2)
+/// 1
+///
+/// > 3 |> subtract(2, _)
+/// -1
+///
+/// > 3 |> subtract(subtrahend: 2)
+/// 1
+///
+/// > 3 |> subtract(minuend: 2)
+/// -1
+/// ```
+pub fn subtract(minuend a: Int, subtrahend b: Int) -> Int {
+  a - b
+}

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -714,13 +714,7 @@ pub fn multiply(a: Int, b: Int) -> Int {
 ///
 /// > 3 |> subtract(2, _)
 /// -1
-///
-/// > 3 |> subtract(subtrahend: 2)
-/// 1
-///
-/// > 3 |> subtract(minuend: 2)
-/// -1
 /// ```
-pub fn subtract(minuend a: Int, subtrahend b: Int) -> Int {
+pub fn subtract(a: Int, b: Int) -> Int {
   a - b
 }

--- a/test/gleam/bool_test.gleam
+++ b/test/gleam/bool_test.gleam
@@ -2,6 +2,34 @@ import gleam/bool
 import gleam/order
 import gleam/should
 
+pub fn and_test() {
+  bool.and(True, True)
+  |> should.be_true
+
+  bool.and(False, True)
+  |> should.be_false
+
+  True |> bool.and(_, True)
+  |> should.be_true
+
+  False |> bool.and(True, _)
+  |> should.be_false
+}
+
+pub fn or_test() {
+  bool.or(True, True)
+  |> should.be_true
+
+  bool.or(False, True)
+  |> should.be_true
+
+  True |> bool.or(_, False)
+  |> should.be_true
+
+  False |> bool.or(True, _)
+  |> should.be_true
+}
+
 pub fn negate_test() {
   bool.negate(True)
   |> should.be_false

--- a/test/gleam/bool_test.gleam
+++ b/test/gleam/bool_test.gleam
@@ -9,10 +9,12 @@ pub fn and_test() {
   bool.and(False, True)
   |> should.be_false
 
-  True |> bool.and(_, True)
+  True
+  |> bool.and(True)
   |> should.be_true
 
-  False |> bool.and(True, _)
+  False
+  |> bool.and(True, _)
   |> should.be_false
 }
 
@@ -23,10 +25,12 @@ pub fn or_test() {
   bool.or(False, True)
   |> should.be_true
 
-  True |> bool.or(_, False)
+  True
+  |> bool.or(False)
   |> should.be_true
 
-  False |> bool.or(True, _)
+  False
+  |> bool.or(True, _)
   |> should.be_true
 }
 

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -398,7 +398,8 @@ pub fn add_test() {
   list.fold([1.0, 2.0, 3.0], 0.0, float.add)
   |> should.equal(6.0)
 
-  3.0 |> float.add(2.0)
+  3.0
+  |> float.add(2.0)
   |> should.equal(5.0)
 }
 
@@ -409,7 +410,8 @@ pub fn multiply_test() {
   list.fold([2.0, 3.0, 4.0], 1.0, float.multiply)
   |> should.equal(24.0)
 
-  3.0 |> float.multiply(2.0)
+  3.0
+  |> float.multiply(2.0)
   |> should.equal(6.0)
 }
 
@@ -420,15 +422,19 @@ pub fn subtract_test() {
   list.fold([1.0, 2.0, 3.0], 10.0, float.subtract)
   |> should.equal(4.0)
 
-  3.0 |> float.subtract(_, 2.0)
+  3.0
+  |> float.subtract(2.0)
   |> should.equal(1.0)
 
-  3.0 |> float.subtract(2.0, _)
+  3.0
+  |> float.subtract(2.0, _)
   |> should.equal(-1.0)
 
-  3.0 |> float.subtract(subtrahend: 2.0)
+  3.0
+  |> float.subtract(subtrahend: 2.0)
   |> should.equal(1.0)
 
-  3.0 |> float.subtract(minuend: 2.0)
+  3.0
+  |> float.subtract(minuend: 2.0)
   |> should.equal(-1.0)
 }

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -390,3 +390,45 @@ pub fn divide_test() {
   float.divide(1.0, by: 0.0)
   |> should.equal(Error(Nil))
 }
+
+pub fn add_test() {
+  float.add(1.0, 2.0)
+  |> should.equal(3.0)
+
+  list.fold([1.0, 2.0, 3.0], 0.0, float.add)
+  |> should.equal(6.0)
+
+  3.0 |> float.add(2.0)
+  |> should.equal(5.0)
+}
+
+pub fn multiply_test() {
+  float.multiply(2.0, 4.0)
+  |> should.equal(8.0)
+
+  list.fold([2.0, 3.0, 4.0], 1.0, float.multiply)
+  |> should.equal(24.0)
+
+  3.0 |> float.multiply(2.0)
+  |> should.equal(6.0)
+}
+
+pub fn subtract_test() {
+  float.subtract(3.0, 1.0)
+  |> should.equal(2.0)
+
+  list.fold([1.0, 2.0, 3.0], 10.0, float.subtract)
+  |> should.equal(4.0)
+
+  3.0 |> float.subtract(_, 2.0)
+  |> should.equal(1.0)
+
+  3.0 |> float.subtract(2.0, _)
+  |> should.equal(-1.0)
+
+  3.0 |> float.subtract(subtrahend: 2.0)
+  |> should.equal(1.0)
+
+  3.0 |> float.subtract(minuend: 2.0)
+  |> should.equal(-1.0)
+}

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -420,12 +420,4 @@ pub fn subtract_test() {
   3.0
   |> float.subtract(2.0, _)
   |> should.equal(-1.0)
-
-  3.0
-  |> float.subtract(subtrahend: 2.0)
-  |> should.equal(1.0)
-
-  3.0
-  |> float.subtract(minuend: 2.0)
-  |> should.equal(-1.0)
 }

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -395,9 +395,6 @@ pub fn add_test() {
   float.add(1.0, 2.0)
   |> should.equal(3.0)
 
-  list.fold([1.0, 2.0, 3.0], 0.0, float.add)
-  |> should.equal(6.0)
-
   3.0
   |> float.add(2.0)
   |> should.equal(5.0)
@@ -407,9 +404,6 @@ pub fn multiply_test() {
   float.multiply(2.0, 4.0)
   |> should.equal(8.0)
 
-  list.fold([2.0, 3.0, 4.0], 1.0, float.multiply)
-  |> should.equal(24.0)
-
   3.0
   |> float.multiply(2.0)
   |> should.equal(6.0)
@@ -418,9 +412,6 @@ pub fn multiply_test() {
 pub fn subtract_test() {
   float.subtract(3.0, 1.0)
   |> should.equal(2.0)
-
-  list.fold([1.0, 2.0, 3.0], 10.0, float.subtract)
-  |> should.equal(4.0)
 
   3.0
   |> float.subtract(2.0)

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -500,3 +500,45 @@ pub fn floor_divide_test() {
   int.floor_divide(-99, by: 2)
   |> should.equal(Ok(-50))
 }
+
+pub fn add_test() {
+  int.add(1, 2)
+  |> should.equal(3)
+
+  list.fold([1, 2, 3], 0, int.add)
+  |> should.equal(6)
+
+  3 |> int.add(2)
+  |> should.equal(5)
+}
+
+pub fn multiply_test() {
+  int.multiply(2, 4)
+  |> should.equal(8)
+
+  list.fold([2, 3, 4], 1, int.multiply)
+  |> should.equal(24)
+
+  3 |> int.multiply(2)
+  |> should.equal(6)
+}
+
+pub fn subtract_test() {
+  int.subtract(3, 1)
+  |> should.equal(2)
+
+  list.fold([1, 2, 3], 10, int.subtract)
+  |> should.equal(4)
+
+  3 |> int.subtract(_, 2)
+  |> should.equal(1)
+
+  3 |> int.subtract(2, _)
+  |> should.equal(-1)
+
+  3 |> int.subtract(subtrahend: 2)
+  |> should.equal(1)
+
+  3 |> int.subtract(minuend: 2)
+  |> should.equal(-1)
+}

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -508,7 +508,8 @@ pub fn add_test() {
   list.fold([1, 2, 3], 0, int.add)
   |> should.equal(6)
 
-  3 |> int.add(2)
+  3
+  |> int.add(2)
   |> should.equal(5)
 }
 
@@ -519,7 +520,8 @@ pub fn multiply_test() {
   list.fold([2, 3, 4], 1, int.multiply)
   |> should.equal(24)
 
-  3 |> int.multiply(2)
+  3
+  |> int.multiply(2)
   |> should.equal(6)
 }
 
@@ -530,15 +532,19 @@ pub fn subtract_test() {
   list.fold([1, 2, 3], 10, int.subtract)
   |> should.equal(4)
 
-  3 |> int.subtract(_, 2)
+  3
+  |> int.subtract(2)
   |> should.equal(1)
 
-  3 |> int.subtract(2, _)
+  3
+  |> int.subtract(2, _)
   |> should.equal(-1)
 
-  3 |> int.subtract(subtrahend: 2)
+  3
+  |> int.subtract(subtrahend: 2)
   |> should.equal(1)
 
-  3 |> int.subtract(minuend: 2)
+  3
+  |> int.subtract(minuend: 2)
   |> should.equal(-1)
 }

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -505,9 +505,6 @@ pub fn add_test() {
   int.add(1, 2)
   |> should.equal(3)
 
-  list.fold([1, 2, 3], 0, int.add)
-  |> should.equal(6)
-
   3
   |> int.add(2)
   |> should.equal(5)
@@ -517,9 +514,6 @@ pub fn multiply_test() {
   int.multiply(2, 4)
   |> should.equal(8)
 
-  list.fold([2, 3, 4], 1, int.multiply)
-  |> should.equal(24)
-
   3
   |> int.multiply(2)
   |> should.equal(6)
@@ -528,9 +522,6 @@ pub fn multiply_test() {
 pub fn subtract_test() {
   int.subtract(3, 1)
   |> should.equal(2)
-
-  list.fold([1, 2, 3], 10, int.subtract)
-  |> should.equal(4)
 
   3
   |> int.subtract(2)

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -530,12 +530,4 @@ pub fn subtract_test() {
   3
   |> int.subtract(2, _)
   |> should.equal(-1)
-
-  3
-  |> int.subtract(subtrahend: 2)
-  |> should.equal(1)
-
-  3
-  |> int.subtract(minuend: 2)
-  |> should.equal(-1)
 }


### PR DESCRIPTION
Allows using operators as functions. Useful in higher order functions or pipes.
See: #366