### PR TITLE
Rename list.length and queue.length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - The performance of `list.flatten` has been greatly improved.
 - The `string_builder` module gains the `join` function.
 - The `list` module gains the `shuffle` function.
+- Renamed `list.length` and `queue.length` to `list.count` and `queue.count`,
+  because these functions signify that the length has to be counted and is,
+  not just available as a property.
 
 ## v0.24.0 - 2022-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `string.split` will now return a list of graphemes if split on an empty
   string (`""`).
 - Renamed `list.length` and `queue.length` to `list.count` and `queue.count`,
-  because these functions signify that the length has to be counted and is,
+  because these function names signify that the length has to be counted and is,
   not just available as a property.
 
 ## v0.24.0 - 2022-10-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@
 - `string.split` will now return a list of graphemes if split on an empty
   string (`""`).
 - Renamed `list.length` and `queue.length` to `list.count` and `queue.count`,
-  because these function names signify that the length has to be counted and is,
-  not just available as a property.
+  because these function names signify that the length has to be counted and
+	is, not just available as a property.
 
 ## v0.24.0 - 2022-10-15
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -38,8 +38,8 @@ pub type LengthMismatch {
 /// This function has to traverse the list to determine the number of elements,
 /// so it runs in linear time.
 ///
-/// This function is natively implemented by the virtual machine and is highly
-/// optimised.
+/// For Erlang, this function is natively implemented by the virtual machine
+/// and is highly optimised.
 ///
 /// ## Examples
 ///

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -44,33 +44,39 @@ pub type LengthMismatch {
 /// ## Examples
 ///
 /// ```gleam
-/// > length([])
+/// > count([])
 /// 0
 ///
-/// > length([1])
+/// > count([1])
 /// 1
 ///
-/// > length([1, 2])
+/// > count([1, 2])
 /// 2
 /// ```
 ///
+pub fn count(list: List(a)) -> Int {
+  do_count(list)
+}
+
+/// Deprecated: Use list.count
+///
 pub fn length(of list: List(a)) -> Int {
-  do_length(list)
+  count(list)
 }
 
 if erlang {
-  external fn do_length(List(a)) -> Int =
+  external fn do_count(List(a)) -> Int =
     "erlang" "length"
 }
 
 if javascript {
-  fn do_length(list: List(a)) -> Int {
-    do_length_acc(list, 0)
+  fn do_count(list: List(a)) -> Int {
+    do_count_acc(list, 0)
   }
 
-  fn do_length_acc(list: List(a), count: Int) -> Int {
+  fn do_count_acc(list: List(a), count: Int) -> Int {
     case list {
-      [_, ..list] -> do_length_acc(list, count + 1)
+      [_, ..list] -> do_count_acc(list, count + 1)
       _ -> count
     }
   }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -61,7 +61,7 @@ pub fn count(list: List(a)) -> Int {
 /// Deprecated: Use `list.count` instead.
 ///
 pub fn length(of list: List(a)) -> Int {
-  count(list)
+  do_count(list)
 }
 
 if erlang {

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -58,7 +58,7 @@ pub fn count(list: List(a)) -> Int {
   do_count(list)
 }
 
-/// Deprecated: Use list.count
+/// Deprecated: Use `list.count` instead.
 ///
 pub fn length(of list: List(a)) -> Int {
   count(list)

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -99,7 +99,7 @@ pub fn count(queue: Queue(a)) -> Int {
   list.count(queue.in) + list.count(queue.out)
 }
 
-/// Deprecated: Use queue.count
+/// Deprecated: Use `queue.count` instead
 ///
 pub fn length(queue: Queue(a)) -> Int {
   count(queue)

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -99,7 +99,7 @@ pub fn count(queue: Queue(a)) -> Int {
   list.count(queue.in) + list.count(queue.out)
 }
 
-/// Deprecated: Use `queue.count` instead
+/// Deprecated: Use `queue.count` instead.
 ///
 pub fn length(queue: Queue(a)) -> Int {
   count(queue)

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -85,18 +85,24 @@ pub fn is_empty(queue: Queue(a)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > length(from_list([]))
+/// > count(from_list([]))
 /// 0
 ///
-/// > length(from_list([1]))
+/// > count(from_list([1]))
 /// 1
 ///
-/// > length(from_list([1, 2]))
+/// > count(from_list([1, 2]))
 /// 2
 /// ```
 ///
+pub fn count(queue: Queue(a)) -> Int {
+  list.count(queue.in) + list.count(queue.out)
+}
+
+/// Deprecated: Use queue.count
+///
 pub fn length(queue: Queue(a)) -> Int {
-  list.length(queue.in) + list.length(queue.out)
+  count(queue)
 }
 
 /// Pushes an element onto the back of the queue.

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -4,7 +4,7 @@
 //// URIs or encoding query strings). The functions in this module are implemented
 //// according to [RFC 3986](https://tools.ietf.org/html/rfc3986).
 ////
-//// Query encoding (Form encoding) is defined in the 
+//// Query encoding (Form encoding) is defined in the
 //// [W3C specification](https://www.w3.org/TR/html52/sec-forms.html#urlencoded-form-data).
 
 import gleam/int
@@ -404,7 +404,7 @@ pub fn origin(uri: Uri) -> Result(String, Nil) {
 }
 
 fn drop_last(elements: List(a)) -> List(a) {
-  list.take(from: elements, up_to: list.length(elements) - 1)
+  list.take(from: elements, up_to: list.count(elements) - 1)
 }
 
 fn join_segments(segments: List(String)) -> String {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -16,22 +16,22 @@ if javascript {
   const recursion_test_cycles = 40_000
 }
 
-pub fn length_test() {
-  list.length([])
+pub fn count_test() {
+  list.count([])
   |> should.equal(0)
 
-  list.length([1])
+  list.count([1])
   |> should.equal(1)
 
-  list.length([1, 1])
+  list.count([1, 1])
   |> should.equal(2)
 
-  list.length([1, 1, 1])
+  list.count([1, 1, 1])
   |> should.equal(3)
 
   // TCO test
   list.range(0, recursion_test_cycles)
-  |> list.length()
+  |> list.count()
 }
 
 pub fn reverse_test() {

--- a/test/gleam/queue_test.gleam
+++ b/test/gleam/queue_test.gleam
@@ -34,11 +34,11 @@ pub fn is_empty_test() {
   |> should.be_false
 }
 
-pub fn length_test() {
+pub fn count_test() {
   let test = fn(input) {
     queue.from_list(input)
-    |> queue.length
-    |> should.equal(list.length(input))
+    |> queue.count
+    |> should.equal(list.count(input))
   }
 
   test([])


### PR DESCRIPTION
Intention: signify that an (expensive) operation has to happen instead of length which appears like a property.