### PR TITLE
Format docblocks

### DIFF
--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -18,10 +18,14 @@ import gleam/order.{Order}
 /// ```gleam
 /// > and(True, True)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > and(False, True)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > False |> and(True)
 /// False
 /// ```
@@ -40,10 +44,14 @@ pub fn and(a: Bool, b: Bool) -> Bool {
 /// ```gleam
 /// > or(True, True)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > or(False, True)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > False |> or(True)
 /// True
 /// ```
@@ -61,7 +69,9 @@ pub fn or(a: Bool, b: Bool) -> Bool {
 /// ```gleam
 /// > negate(True)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > negate(False)
 /// True
 /// ```
@@ -80,13 +90,19 @@ pub fn negate(bool: Bool) -> Bool {
 /// ```gleam
 /// > nor(False, False)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > nor(False, True)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > nor(True, False)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > nor(True, True)
 /// False
 /// ```
@@ -107,13 +123,19 @@ pub fn nor(a: Bool, b: Bool) -> Bool {
 /// ```gleam
 /// > nand(False, False)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > nand(False, True)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > nand(True, False)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > nand(True, True)
 /// False
 /// ```
@@ -134,13 +156,19 @@ pub fn nand(a: Bool, b: Bool) -> Bool {
 /// ```gleam
 /// > exclusive_or(False, False)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > exclusive_or(False, True)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > exclusive_or(True, False)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > exclusive_or(True, True)
 /// False
 /// ```
@@ -161,13 +189,19 @@ pub fn exclusive_or(a: Bool, b: Bool) -> Bool {
 /// ```gleam
 /// > exclusive_nor(False, False)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > exclusive_nor(False, True)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > exclusive_nor(True, False)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > exclusive_nor(True, True)
 /// True
 /// ```
@@ -207,10 +241,14 @@ pub fn compare(a: Bool, with b: Bool) -> Order {
 /// ```gleam
 /// > max(True, False)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > max(False, True)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > max(False, False)
 /// False
 /// ```
@@ -229,7 +267,9 @@ pub fn max(a: Bool, b: Bool) -> Bool {
 /// ```gleam
 /// > min(True, False)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > min(False, True)
 /// False
 ///
@@ -270,7 +310,9 @@ pub fn to_int(bool: Bool) -> Int {
 /// ```gleam
 /// > to_string(True)
 /// "True"
+/// ```
 ///
+/// ```gleam
 /// > to_string(False)
 /// "False"
 /// ```

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -10,9 +10,9 @@ import gleam/order.{Order}
 
 /// Returns the and of two bools, but it evaluates both arguments.
 ///
-/// It's the function equivalent of the `&&` operator. 
+/// It's the function equivalent of the `&&` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -25,15 +25,16 @@ import gleam/order.{Order}
 /// > False |> and(True)
 /// False
 /// ```
+///
 pub fn and(a: Bool, b: Bool) -> Bool {
   a && b
 }
 
 /// Returns the or of two bools, but it evaluates both arguments.
 ///
-/// It's the function equivalent of the `||` operator. 
+/// It's the function equivalent of the `||` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -46,6 +47,7 @@ pub fn and(a: Bool, b: Bool) -> Bool {
 /// > False |> or(True)
 /// True
 /// ```
+///
 pub fn or(a: Bool, b: Bool) -> Bool {
   a || b
 }

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -962,9 +962,7 @@ pub fn decode2(
 /// > from(#(1, 2.0, "3"))
 /// > |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
 /// Ok(MyRecord(1, 2.0, "3"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", ""))
 /// > |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
 /// Error([
@@ -1002,9 +1000,7 @@ pub fn decode3(
 /// >   element(3, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", "", ""))
 /// > |> decode4(
 /// >   MyRecord,
@@ -1055,9 +1051,7 @@ pub fn decode4(
 /// >   element(4, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", "", "", ""))
 /// > |> decode5(
 /// >   MyRecord,
@@ -1112,9 +1106,7 @@ pub fn decode5(
 /// >   element(5, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", "", "", "", ""))
 /// > |> decode6(
 /// >   MyRecord,
@@ -1174,9 +1166,7 @@ pub fn decode6(
 /// >   element(6, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", "", "", "", "", ""))
 /// > |> decode7(
 /// >   MyRecord,
@@ -1240,9 +1230,7 @@ pub fn decode7(
 /// >   element(7, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", "", "", "", "", "", ""))
 /// > |> decode7(
 /// >   MyRecord,
@@ -1310,9 +1298,7 @@ pub fn decode8(
 /// >   element(8, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
-/// ```
 ///
-/// ```gleam
 /// > from(#("", "", "", "", "", "", "", "", ""))
 /// > |> decode7(
 /// >   MyRecord,

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -12,9 +12,11 @@ if erlang {
 /// `Dynamic` data is data that we don't know the type of yet.
 /// We likely get data like this from interop with Erlang, or from
 /// IO with the outside world.
+///
 pub external type Dynamic
 
 /// Error returned when unexpected data is encountered
+///
 pub type DecodeError {
   DecodeError(expected: String, found: String, path: List(String))
 }
@@ -80,7 +82,9 @@ pub fn dynamic(value: Dynamic) -> Result(Dynamic, List(DecodeError)) {
 /// ```gleam
 /// > bit_string(from("Hello")) == bit_string.from_string("Hello")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > bit_string(from(123))
 /// Error([DecodeError(expected: "BitString", found: "Int", path: [])])
 /// ```
@@ -107,7 +111,9 @@ if javascript {
 /// ```gleam
 /// > string(from("Hello"))
 /// Ok("Hello")
+/// ```
 ///
+/// ```gleam
 /// > string(from(123))
 /// Error([DecodeError(expected: "String", found: "Int", path: [])])
 /// ```
@@ -171,7 +177,9 @@ if javascript {
 /// ```gleam
 /// > int(from(123))
 /// Ok(123)
+/// ```
 ///
+/// ```gleam
 /// > int(from("Hello"))
 /// Error([DecodeError(expected: "Int", found: "String", path: [])])
 /// ```
@@ -198,7 +206,9 @@ if javascript {
 /// ```gleam
 /// > float(from(2.0))
 /// Ok(2.0)
+/// ```
 ///
+/// ```gleam
 /// > float(from(123))
 /// Error([DecodeError(expected: "Float", found: "Int", path: [])])
 /// ```
@@ -225,7 +235,9 @@ if javascript {
 /// ```gleam
 /// > bool(from(True))
 /// Ok(True)
+/// ```
 ///
+/// ```gleam
 /// > bool(from(123))
 /// Error([DecodeError(expected: "bool", found: "Int", path: [])])
 /// ```
@@ -255,7 +267,9 @@ if javascript {
 /// ```gleam
 /// > shallow_list(from(["a", "b", "c"]))
 /// Ok([from("a"), from("b"), from("c")])
+/// ```
 ///
+/// ```gleam
 /// > shallow_list(1)
 /// Error([DecodeError(expected: "Int", found: "Int", path: [])])
 /// ```
@@ -296,11 +310,15 @@ if javascript {
 /// > from(Ok(1))
 /// > |> result(ok: int, error: string)
 /// Ok(Ok(1))
+/// ```
 ///
+/// ```gleam
 /// > from(Error("boom"))
 /// > |> result(ok: int, error: string)
 /// Ok(Error("boom"))
+/// ```
 ///
+/// ```gleam
 /// > from(123)
 /// > |> result(ok: int, error: string)
 /// Error([DecodeError(expected: "2 element tuple", found: "Int", path: [])])
@@ -346,11 +364,15 @@ pub fn result(
 /// > from(["a", "b", "c"])
 /// > |> list(of: string)
 /// Ok(["a", "b", "c"])
+/// ```
 ///
+/// ```gleam
 /// > from([1, 2, 3])
 /// > |> list(of: string)
 /// Error([DecodeError(expected: "String", found: "Int", path: [])])
+/// ```
 ///
+/// ```gleam
 /// > from("ok")
 /// > |> list(of: string)
 /// Error([DecodeError(expected: "List", found: "String", path: [])])
@@ -376,23 +398,33 @@ pub fn list(
 /// > from("Hello")
 /// > |> optional(string)
 /// Ok(Some("Hello"))
+/// ```
 ///
+/// ```gleam
 /// > from("Hello")
 /// > |> optional(string)
 /// Ok(Some("Hello"))
+/// ```
 ///
+/// ```gleam
 /// > from(atom.from_string("null"))
 /// > |> optional(string)
 /// Ok(None)
+/// ```
 ///
+/// ```gleam
 /// > from(atom.from_string("nil"))
 /// > |> optional(string)
 /// Ok(None)
+/// ```
 ///
+/// ```gleam
 /// > from(atom.from_string("undefined"))
 /// > |> optional(string)
 /// Ok(None)
+/// ```
 ///
+/// ```gleam
 /// > from(123)
 /// > |> optional(string)
 /// Error([DecodeError(expected: "BitString", found: "Int", path: [])])
@@ -430,7 +462,9 @@ if javascript {
 /// > from(map.new("Hello", "World"))
 /// > |> field(named: "Hello", of: string)
 /// Ok("World")
+/// ```
 ///
+/// ```gleam
 /// > from(123)
 /// > |> field("Hello", string)
 /// Error([DecodeError(expected: "Map", found: "Int", path: [])])
@@ -606,17 +640,23 @@ fn push_path(error: DecodeError, name: t) -> DecodeError {
 /// > from(#(1, 2))
 /// > |> tuple2(int, int)
 /// Ok(#(1, 2))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2.0))
 /// > |> tuple2(int, float)
 /// Ok(#(1, 2.0))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2, 3))
 /// > |> tuple2(int, float)
 /// Error([
 ///   DecodeError(expected: "2 element tuple", found: "3 element tuple", path: []),
 /// ])
+/// ```
 ///
+/// ```gleam
 /// > from("")
 /// > |> tuple2(int, float)
 /// Error([DecodeError(expected: "2 element tuple", found: "String", path: [])])
@@ -648,17 +688,23 @@ pub fn tuple2(
 /// > from(#(1, 2, 3))
 /// > |> tuple3(int, int, int)
 /// Ok(#(1, 2, 3))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2.0, "3"))
 /// > |> tuple3(int, float, string)
 /// Ok(#(1, 2.0, "3"))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2))
 /// > |> tuple3(int, float, string)
 /// Error([
 ///   DecodeError(expected: "3 element tuple", found: "2 element tuple", path: [])),
 /// ])
+/// ```
 ///
+/// ```gleam
 /// > from("")
 /// > |> tuple3(int, float, string)
 /// Error([
@@ -694,7 +740,9 @@ pub fn tuple3(
 /// > from(#(1, 2, 3, 4))
 /// > |> tuple4(int, int, int, int)
 /// Ok(#(1, 2, 3, 4))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2.0, "3", 4))
 /// > |> tuple4(int, float, string, int)
 /// Ok(#(1, 2.0, "3", 4))
@@ -704,7 +752,9 @@ pub fn tuple3(
 /// Error([
 ///   DecodeError(expected: "4 element tuple", found: "2 element tuple", path: []),
 /// ])
+/// ```
 ///
+/// ```gleam
 /// > from("")
 /// > |> tuple4(int, float, string, int)
 /// Error([
@@ -742,11 +792,15 @@ pub fn tuple4(
 /// > from(#(1, 2, 3, 4, 5))
 /// > |> tuple5(int, int, int, int, int)
 /// Ok(#(1, 2, 3, 4, 5))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2.0, "3", 4, 5))
 /// > |> tuple5(int, float, string, int, int)
 /// Ok(#(1, 2.0, "3", 4, 5))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2))
 /// > |> tuple5(int, float, string, int, int)
 /// Error([
@@ -790,11 +844,15 @@ pub fn tuple5(
 /// > from(#(1, 2, 3, 4, 5, 6))
 /// > |> tuple6(int, int, int, int, int, int)
 /// Ok(#(1, 2, 3, 4, 5, 6))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2.0, "3", 4, 5, 6))
 /// > |> tuple6(int, float, string, int, int)
 /// Ok(#(1, 2.0, "3", 4, 5, 6))
+/// ```
 ///
+/// ```gleam
 /// > from(#(1, 2))
 /// > |> tuple6(int, float, string, int, int, int)
 /// Error([
@@ -840,13 +898,16 @@ pub fn tuple6(
 ///
 /// ```gleam
 /// > import gleam/map
-///
 /// > map.new() |> from |> map(string, int)
 /// Ok(map.new())
+/// ```
 ///
+/// ```gleam
 /// > from(1) |> map(string, int)
 /// Error(DecodeError(expected: "Map", found: "Int", path: []))
+/// ```
 ///
+/// ```gleam
 /// > from("") |> map(string, int)
 /// Error(DecodeError(expected: "Map", found: "String", path: []))
 /// ```
@@ -897,10 +958,14 @@ if javascript {
 /// > ])
 /// > bool_or_string(from("ok"))
 /// Ok("ok")
+/// ```
 ///
+/// ```gleam
 /// > bool_or_string(from(True))
 /// Ok("a bool")
+/// ```
 ///
+/// ```gleam
 /// > bool_or_string(from(1))
 /// Error(DecodeError(expected: "unknown", found: "unknown", path: []))
 /// ```
@@ -962,7 +1027,9 @@ pub fn decode2(
 /// > from(#(1, 2.0, "3"))
 /// > |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
 /// Ok(MyRecord(1, 2.0, "3"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", ""))
 /// > |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
 /// Error([
@@ -1000,7 +1067,9 @@ pub fn decode3(
 /// >   element(3, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", "", ""))
 /// > |> decode4(
 /// >   MyRecord,
@@ -1051,7 +1120,9 @@ pub fn decode4(
 /// >   element(4, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", "", "", ""))
 /// > |> decode5(
 /// >   MyRecord,
@@ -1106,7 +1177,9 @@ pub fn decode5(
 /// >   element(5, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", "", "", "", ""))
 /// > |> decode6(
 /// >   MyRecord,
@@ -1166,7 +1239,9 @@ pub fn decode6(
 /// >   element(6, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", "", "", "", "", ""))
 /// > |> decode7(
 /// >   MyRecord,
@@ -1230,7 +1305,9 @@ pub fn decode7(
 /// >   element(7, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", "", "", "", "", "", ""))
 /// > |> decode7(
 /// >   MyRecord,
@@ -1298,7 +1375,9 @@ pub fn decode8(
 /// >   element(8, string),
 /// > )
 /// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
+/// ```
 ///
+/// ```gleam
 /// > from(#("", "", "", "", "", "", "", "", ""))
 /// > |> decode7(
 /// >   MyRecord,

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -52,7 +52,7 @@ if javascript {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > clamp(1.2, min: 1.4, max: 1.6)
 /// 1.4
 /// ```
@@ -66,6 +66,7 @@ pub fn clamp(x: Float, min min_bound: Float, max max_bound: Float) -> Float {
 /// Compares two `Float`s, returning an order.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > compare(2.0, 2.3)
 /// Lt
@@ -282,10 +283,10 @@ pub fn absolute_value(x: Float) -> Float {
 pub fn power(base: Float, of exponent: Float) -> Result(Float, Nil) {
   let fractional: Bool = ceiling(exponent) -. exponent >. 0.
   // In the following check:
-  // 1. If the base is negative and the exponent is fractional then 
+  // 1. If the base is negative and the exponent is fractional then
   //    return an error as it will otherwise be an imaginary number
   // 2. If the base is 0 and the exponent is negative then the expression
-  //    is equivalent to the exponent divided by 0 and an error should be 
+  //    is equivalent to the exponent divided by 0 and an error should be
   //    returned
   case base <. 0. && fractional || base == 0. && exponent <. 0. {
     True -> Error(Nil)
@@ -376,8 +377,8 @@ fn do_product(numbers: List(Float), initial: Float) -> Float {
   }
 }
 
-/// Returns 0.0 if boundary_a and boundary_b are equal,
-/// otherwise returns a Float x where: lower_boundary =< x < upper_boundary.
+/// Returns `0.0` if `boundary_a` and `boundary_b` are equal,
+/// otherwise returns a `Float x` where `lower_boundary =< x < upper_boundary`.
 ///
 /// ## Examples
 ///
@@ -439,9 +440,9 @@ pub fn divide(a: Float, by b: Float) -> Result(Float, Nil) {
 
 /// Adds two floats together.
 ///
-/// It's the function equivalent of the `+.` operator. 
+/// It's the function equivalent of the `+.` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -454,15 +455,16 @@ pub fn divide(a: Float, by b: Float) -> Result(Float, Nil) {
 /// > 3.0 |> add(2.0)
 /// 5.0
 /// ```
+///
 pub fn add(a: Float, b: Float) -> Float {
   a +. b
 }
 
 /// Multiplies two floats together.
 ///
-/// It's the function equivalent of the `*.` operator. 
+/// It's the function equivalent of the `*.` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -475,15 +477,16 @@ pub fn add(a: Float, b: Float) -> Float {
 /// > 3.0 |> multiply(2.0)
 /// 6.0
 /// ```
+///
 pub fn multiply(a: Float, b: Float) -> Float {
   a *. b
 }
 
 /// Subtracts one float from another.
 ///
-/// It's the function equivalent of the `-.` operator. 
+/// It's the function equivalent of the `-.` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -499,6 +502,7 @@ pub fn multiply(a: Float, b: Float) -> Float {
 /// > 3.0 |> subtract(2.0, _)
 /// -1.0
 /// ```
+///
 pub fn subtract(a: Float, b: Float) -> Float {
   a -. b
 }

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -4,6 +4,7 @@ import gleam/order.{Order}
 /// possible.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > parse("2.3")
 /// Ok(2.3)
@@ -29,6 +30,7 @@ if javascript {
 /// Returns the string representation of the provided `Float`.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > to_string(2.3)
 /// "2.3"
@@ -88,6 +90,7 @@ pub fn compare(a: Float, with b: Float) -> Order {
 /// e.g. 5.3 - 5.0 is not exactly 0.3 in a float
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > loosely_compare(5.0, with: 5.3, tolerating: 0.5)
 /// Eq

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -1,14 +1,16 @@
 import gleam/order.{Order}
 
-/// Attempts to parse a string as a `Float`, returning `Error(Nil)` if it was not
-/// possible.
+/// Attempts to parse a string as a `Float`, returning `Error(Nil)` if it was
+/// not possible.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > parse("2.3")
 /// Ok(2.3)
+/// ```
 ///
+/// ```gleam
 /// > parse("ABC")
 /// Error(Nil)
 /// ```
@@ -193,7 +195,9 @@ if javascript {
 /// ```gleam
 /// > round(2.3)
 /// 2
+/// ```
 ///
+/// ```gleam
 /// > round(2.5)
 /// 3
 /// ```
@@ -249,7 +253,9 @@ if javascript {
 /// ```gleam
 /// > absolute_value(-12.5)
 /// 12.5
+/// ```
 ///
+/// ```gleam
 /// > absolute_value(10.2)
 /// 10.2
 /// ```
@@ -269,16 +275,24 @@ pub fn absolute_value(x: Float) -> Float {
 /// ```gleam
 /// > power(2.0, -1.0)
 /// Ok(0.5)
+/// ```
 ///
+/// ```gleam
 /// > power(2.0, 2.0)
 /// Ok(4.0)
+/// ```
 ///
+/// ```gleam
 /// > power(8.0, 1.5)
 /// Ok(22.627416997969522)
+/// ```
 ///
+/// ```gleam
 /// > 4.0 |> power(of: 2.0)
 /// Ok(16.0)
+/// ```
 ///
+/// ```gleam
 /// > power(-1.0, 0.5)
 /// Error(Nil)
 /// ```
@@ -314,7 +328,9 @@ if javascript {
 /// ```gleam
 /// > square_root(4.0)
 /// Ok(2.0)
+/// ```
 ///
+/// ```gleam
 /// > square_root(-16.0)
 /// Error(Nil)
 /// ```
@@ -328,8 +344,8 @@ pub fn square_root(x: Float) -> Result(Float, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > negate(1.)
-/// -1.
+/// > negate(1.0)
+/// -1.0
 /// ```
 ///
 pub fn negate(x: Float) -> Float {
@@ -429,7 +445,9 @@ if javascript {
 /// ```gleam
 /// > divide(0.0, 1.0)
 /// Ok(1.0)
+/// ```
 ///
+/// ```gleam
 /// > divide(1.0, 0.0)
 /// Error(Nil)
 /// ```
@@ -451,10 +469,15 @@ pub fn divide(a: Float, by b: Float) -> Result(Float, Nil) {
 /// ```gleam
 /// > add(1.0, 2.0)
 /// 3.0
+/// ```
 ///
+/// ```gleam
+/// > import gleam/list
 /// > list.fold([1.0, 2.0, 3.0], 0.0, add)
 /// 6.0
+/// ```
 ///
+/// ```gleam
 /// > 3.0 |> add(2.0)
 /// 5.0
 /// ```
@@ -473,10 +496,15 @@ pub fn add(a: Float, b: Float) -> Float {
 /// ```gleam
 /// > multiply(2.0, 4.0)
 /// 8.0
+/// ```
 ///
+/// ```gleam
+/// import gleam/list
 /// > list.fold([2.0, 3.0, 4.0], 1.0, multiply)
 /// 24.0
+/// ```
 ///
+/// ```gleam
 /// > 3.0 |> multiply(2.0)
 /// 6.0
 /// ```
@@ -495,13 +523,20 @@ pub fn multiply(a: Float, b: Float) -> Float {
 /// ```gleam
 /// > subtract(3.0, 1.0)
 /// 2.0
+/// ```
 ///
+/// ```gleam
+/// > import gleam/list
 /// > list.fold([1.0, 2.0, 3.0], 10.0, subtract)
 /// 4.0
+/// ```
 ///
+/// ```gleam
 /// > 3.0 |> subtract(_, 2.0)
 /// 1.0
+/// ```
 ///
+/// ```gleam
 /// > 3.0 |> subtract(2.0, _)
 /// -1.0
 /// ```

--- a/src/gleam/function.gleam
+++ b/src/gleam/function.gleam
@@ -6,7 +6,7 @@ pub fn compose(fun1: fn(a) -> b, fun2: fn(b) -> c) -> fn(a) -> c {
 }
 
 /// Takes a function with arity two
-/// and returns a curried equivalent.
+/// and returns a curried equivalent:
 /// `fn(a, b) -> c` becomes `fn(a) -> fn(b) -> c`.
 ///
 pub fn curry2(fun: fn(a, b) -> value) {
@@ -14,7 +14,7 @@ pub fn curry2(fun: fn(a, b) -> value) {
 }
 
 /// Takes a function with arity three
-/// and returns a curried equivalent.
+/// and returns a curried equivalent:
 /// `fn(a, b, c) -> d` becomes `fn(a) -> fn(b) -> fn(c) -> d`.
 ///
 pub fn curry3(fun: fn(a, b, c) -> value) {
@@ -81,15 +81,14 @@ pub fn tap(arg: a, effect: fn(a) -> b) -> a {
 /// ## Example
 ///
 /// ```gleam
-/// fn get_doubler() {
-///   fn(x: int) { x * 2 }
+/// let doubler = fn() {
+///   fn(x: Int) { x * 2 }
 /// }
 ///
-/// fn use_apply() {
-///   get_doubler()
-///   |> function.apply1(2)
-///   |> should.equal(4)
-/// }
+/// doubler()
+/// |> function.apply1(2)
+/// |> should.equal(4)
+/// ```
 ///
 pub fn apply1(fun: fn(a) -> value, arg1: a) -> value {
   fun(arg1)
@@ -98,8 +97,8 @@ pub fn apply1(fun: fn(a) -> value, arg1: a) -> value {
 /// Takes a function with arity two and two arguments,
 /// calls that function with the arguments
 /// and returns the function return value.
-/// 
-/// See `apply1` for more details
+///
+/// See `apply1` for more details.
 ///
 pub fn apply2(fun: fn(a, b) -> value, arg1: a, arg2: b) -> value {
   fun(arg1, arg2)
@@ -108,8 +107,8 @@ pub fn apply2(fun: fn(a, b) -> value, arg1: a, arg2: b) -> value {
 /// Takes a function with arity three and three arguments,
 /// calls that function with the arguments
 /// and returns the function return value.
-/// 
-/// See `apply1` for more details
+///
+/// See `apply1` for more details.
 ///
 pub fn apply3(fun: fn(a, b, c) -> value, arg1: a, arg2: b, arg3: c) -> value {
   fun(arg1, arg2, arg3)

--- a/src/gleam/function.gleam
+++ b/src/gleam/function.gleam
@@ -81,13 +81,13 @@ pub fn tap(arg: a, effect: fn(a) -> b) -> a {
 /// ## Example
 ///
 /// ```gleam
-/// let doubler = fn() {
-///   fn(x: Int) { x * 2 }
-/// }
-///
-/// doubler()
-/// |> function.apply1(2)
-/// |> should.equal(4)
+/// > let doubler = fn() {
+/// >  fn(x: Int) { x * 2 }
+/// > }
+/// >
+/// > doubler()
+/// > |> apply1(2)
+/// 4
 /// ```
 ///
 pub fn apply1(fun: fn(a) -> value, arg1: a) -> value {

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -588,37 +588,37 @@ pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > int.remainder(3, 2)
+/// > remainder(3, 2)
 /// Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > int.remainder(1, 0)
+/// > remainder(1, 0)
 /// Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > int.remainder(10, -1)
+/// > remainder(10, -1)
 /// Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > int.remainder(13, by: 3)
+/// > remainder(13, by: 3)
 /// Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > int.remainder(-13, by: 3)
+/// > remainder(-13, by: 3)
 /// Ok(-1)
 /// ```
 ///
 /// ```gleam
-/// > int.remainder(13, by: -3)
+/// > remainder(13, by: -3)
 /// Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > int.remainder(-13, by: -3)
+/// > remainder(-13, by: -3)
 /// Ok(-1)
 /// ```
 ///
@@ -640,37 +640,37 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > int.modulo(3, 2)
+/// > modulo(3, 2)
 /// Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > int.modulo(1, 0)
+/// > modulo(1, 0)
 /// Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > int.modulo(10, -1)
+/// > modulo(10, -1)
 /// Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > int.modulo(13, by: 3)
+/// > modulo(13, by: 3)
 /// Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > int.modulo(-13, by: 3)
+/// > modulo(-13, by: 3)
 /// Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > int.modulo(13, by: -3)
+/// > modulo(13, by: -3)
 /// Ok(-2)
 /// ```
 ///
 /// ```gleam
-/// > int.modulo(-13, by: -3)
+/// > modulo(-13, by: -3)
 /// Ok(-1)
 /// ```
 ///

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -8,7 +8,9 @@ import gleam/order.{Order}
 /// ```gleam
 /// > absolute_value(-12)
 /// 12
+/// ```
 ///
+/// ```gleam
 /// > absolute_value(10)
 /// 10
 /// ```
@@ -28,16 +30,24 @@ pub fn absolute_value(x: Int) -> Int {
 /// ```gleam
 /// > power(2, -1.0)
 /// Ok(0.5)
+/// ```
 ///
+/// ```gleam
 /// > power(2, 2.0)
 /// Ok(4.0)
+/// ```
 ///
+/// ```gleam
 /// > power(8, 1.5)
 /// Ok(22.627416997969522)
+/// ```
 ///
+/// ```gleam
 /// > 4 |> power(of: 2.0)
 /// Ok(16.0)
+/// ```
 ///
+/// ```gleam
 /// > power(-1, 0.5)
 /// Error(Nil)
 /// ```
@@ -55,7 +65,9 @@ pub fn power(base: Int, of exponent: Float) -> Result(Float, Nil) {
 /// ```gleam
 /// > square_root(4)
 /// Ok(2.0)
+/// ```
 ///
+/// ```gleam
 /// > square_root(-16)
 /// Error(Nil)
 /// ```
@@ -73,7 +85,9 @@ pub fn square_root(x: Int) -> Result(Float, Nil) {
 /// ```gleam
 /// > parse("2")
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > parse("ABC")
 /// Error(Nil)
 /// ```
@@ -130,16 +144,24 @@ pub type InvalidBase {
 /// ```gleam
 /// > to_base_string(2, 2)
 /// Ok("10")
+/// ```
 ///
+/// ```gleam
 /// > to_base_string(48, 16)
 /// Ok("30")
+/// ```
 ///
+/// ```gleam
 /// > to_base_string(48, 36)
 /// Ok("1C")
+/// ```
 ///
+/// ```gleam
 /// > to_base_string(48, 1)
 /// Error(InvalidBase)
+/// ```
 ///
+/// ```gleam
 /// > to_base_string(48, 37)
 /// Error(InvalidBase)
 /// ```
@@ -219,13 +241,17 @@ pub fn to_base36(x: Int) -> String {
 ///
 /// ```gleam
 /// > to_float(5)
-/// 5.
+/// 5.0
+/// ```
 ///
+/// ```gleam
 /// > to_float(0)
-/// 0.
+/// 0.0
+/// ```
 ///
+/// ```gleam
 /// > to_float(-3)
-/// -3.
+/// -3.0
 /// ```
 ///
 pub fn to_float(x: Int) -> Float {
@@ -264,10 +290,14 @@ pub fn clamp(x: Int, min min_bound: Int, max max_bound: Int) -> Int {
 /// ```gleam
 /// > compare(2, 3)
 /// Lt
+/// ```
 ///
+/// ```gleam
 /// > compare(4, 3)
 /// Gt
+/// ```
 ///
+/// ```gleam
 /// > compare(3, 3)
 /// Eq
 /// ```
@@ -322,7 +352,9 @@ pub fn max(a: Int, b: Int) -> Int {
 /// ```gleam
 /// > is_even(2)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > is_even(3)
 /// False
 /// ```
@@ -338,7 +370,9 @@ pub fn is_even(x: Int) -> Bool {
 /// ```gleam
 /// > is_odd(3)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > is_odd(2)
 /// False
 /// ```
@@ -411,7 +445,9 @@ fn do_product(numbers: List(Int), initial: Int) -> Int {
 /// ```gleam
 /// > digits(234, 10)
 /// Ok([2,3,4])
+/// ```
 ///
+/// ```gleam
 /// > digits(234, 1)
 /// Error(InvalidBase)
 /// ```
@@ -438,10 +474,14 @@ fn do_digits(x: Int, base: Int, acc: List(Int)) -> List(Int) {
 /// ```gleam
 /// > undigits([2,3,4], 10)
 /// Ok(234)
+/// ```
 ///
+/// ```gleam
 /// > undigits([2,3,4], 1)
 /// Error(InvalidBase)
+/// ```
 ///
+/// ```gleam
 /// > undigits([2,3,4], 2)
 /// Error(InvalidBase)
 /// ```
@@ -512,13 +552,19 @@ pub fn random(boundary_a: Int, boundary_b: Int) -> Int {
 /// ```gleam
 /// > divide(0, 1)
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > divide(1, 0)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > divide(5, 2)
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > divide(-99, 2)
 /// Ok(-49)
 /// ```
@@ -544,22 +590,34 @@ pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ```gleam
 /// > int.remainder(3, 2)
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > int.remainder(1, 0)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > int.remainder(10, -1)
 /// Ok(0)
+/// ```
 ///
+/// ```gleam
 /// > int.remainder(13, by: 3)
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > int.remainder(-13, by: 3)
 /// Ok(-1)
+/// ```
 ///
+/// ```gleam
 /// > int.remainder(13, by: -3)
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > int.remainder(-13, by: -3)
 /// Ok(-1)
 /// ```
@@ -584,22 +642,34 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ```gleam
 /// > int.modulo(3, 2)
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > int.modulo(1, 0)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > int.modulo(10, -1)
 /// Ok(0)
+/// ```
 ///
+/// ```gleam
 /// > int.modulo(13, by: 3)
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > int.modulo(-13, by: 3)
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > int.modulo(13, by: -3)
 /// Ok(-2)
+/// ```
 ///
+/// ```gleam
 /// > int.modulo(-13, by: -3)
 /// Ok(-1)
 /// ```
@@ -631,13 +701,19 @@ pub fn modulo(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ```gleam
 /// > floor_divide(1, 0)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > floor_divide(5, 2)
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > floor_divide(6, -4)
 /// Ok(-2)
+/// ```
 ///
+/// ```gleam
 /// > floor_divide(-99, 2)
 /// Ok(-50)
 /// ```
@@ -663,10 +739,15 @@ pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ```gleam
 /// > add(1, 2)
 /// 3
+/// ```
 ///
+/// ```gleam
+/// import gleam/list
 /// > list.fold([1, 2, 3], 0, add)
 /// 6
+/// ```
 ///
+/// ```gleam
 /// > 3 |> add(2)
 /// 5
 /// ```
@@ -685,10 +766,15 @@ pub fn add(a: Int, b: Int) -> Int {
 /// ```gleam
 /// > multiply(2, 4)
 /// 8
+/// ```
 ///
+/// ```gleam
+/// import gleam/list
 /// > list.fold([2, 3, 4], 1, multiply)
 /// 24
+/// ```
 ///
+/// ```gleam
 /// > 3 |> multiply(2)
 /// 6
 /// ```
@@ -707,13 +793,20 @@ pub fn multiply(a: Int, b: Int) -> Int {
 /// ```gleam
 /// > subtract(3, 1)
 /// 2.0
+/// ```
 ///
+/// ```gleam
+/// import gleam/list
 /// > list.fold([1, 2, 3], 10, subtract)
 /// 4
+/// ```
 ///
+/// ```gleam
 /// > 3 |> subtract(2)
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > 3 |> subtract(2, _)
 /// -1
 /// ```

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -217,7 +217,7 @@ pub fn to_base36(x: Int) -> String {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > to_float(5)
 /// 5.
 ///
@@ -246,7 +246,7 @@ if javascript {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > clamp(40, min: 50, max: 60)
 /// 50
 /// ```
@@ -465,8 +465,8 @@ fn do_undigits(
   }
 }
 
-/// Returns 0 if boundary_a and boundary_b are equal,
-/// otherwise returns an Int x where: lower_boundary =< x < upper_boundary.
+/// Returns `0` if `boundary_a` and `boundary_b` are equal,
+/// otherwise returns an `Int x` where `lower_boundary =< x < upper_boundary`.
 ///
 /// ## Examples
 ///
@@ -655,9 +655,9 @@ pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 
 /// Adds two integers together.
 ///
-/// It's the function equivalent of the `+` operator. 
+/// It's the function equivalent of the `+` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -670,15 +670,16 @@ pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// > 3 |> add(2)
 /// 5
 /// ```
+///
 pub fn add(a: Int, b: Int) -> Int {
   a + b
 }
 
 /// Multiplies two integers together.
 ///
-/// It's the function equivalent of the `*` operator. 
+/// It's the function equivalent of the `*` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -691,15 +692,16 @@ pub fn add(a: Int, b: Int) -> Int {
 /// > 3 |> multiply(2)
 /// 6
 /// ```
+///
 pub fn multiply(a: Int, b: Int) -> Int {
   a * b
 }
 
 /// Subtracts one int from another.
 ///
-/// It's the function equivalent of the `-` operator. 
+/// It's the function equivalent of the `-` operator.
 /// This function is useful in higher order functions or pipes.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -715,6 +717,7 @@ pub fn multiply(a: Int, b: Int) -> Int {
 /// > 3 |> subtract(2, _)
 /// -1
 /// ```
+///
 pub fn subtract(a: Int, b: Int) -> Int {
   a - b
 }

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -60,11 +60,15 @@ if javascript {
 /// > io.debug("Hi mum")
 /// // -> <<"Hi mum">>
 /// "Hi mum"
+/// ```
 ///
+/// ```gleam
 /// > io.debug(Ok(1))
 /// // -> {ok, 1}
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > import list
 /// > [1, 2]
 /// > |> list.map(fn(x) { x + 1 })

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -6,7 +6,7 @@ import gleam/string
 ///
 /// ## Example
 ///
-/// ```
+/// ```gleam
 /// > io.print("Hi mum")
 /// // -> Hi mum
 /// Nil

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -57,13 +57,13 @@ if javascript {
 /// ## Example
 ///
 /// ```gleam
-/// > io.debug("Hi mum")
+/// > debug("Hi mum")
 /// // -> <<"Hi mum">>
 /// "Hi mum"
 /// ```
 ///
 /// ```gleam
-/// > io.debug(Ok(1))
+/// > debug(Ok(1))
 /// // -> {ok, 1}
 /// Ok(1)
 /// ```
@@ -72,7 +72,7 @@ if javascript {
 /// > import list
 /// > [1, 2]
 /// > |> list.map(fn(x) { x + 1 })
-/// > |> io.debug
+/// > |> debug
 /// > |> list.map(fn(x) { x * 2 })
 /// // -> [2, 3]
 /// [4, 6]

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -197,10 +197,7 @@ pub fn to_list(iterator: Iterator(element)) -> List(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Next(head, tail) =
-/// >   [1, 2, 3, 4]
-/// >   |> from_list
-/// >   |> step
+/// > assert Next(head, tail) = [1, 2, 3, 4] |> from_list |> step
 /// > head
 /// 1
 ///
@@ -1134,6 +1131,7 @@ fn do_fold_until(
 ///
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > let f = fn(acc, e) {
 /// >   case e {

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1129,7 +1129,6 @@ fn do_fold_until(
 /// If called on an iterator of infinite length then this function will only ever
 /// return if the function returns `list.Stop`.
 ///
-///
 /// ## Examples
 ///
 /// ```gleam
@@ -1170,7 +1169,6 @@ fn do_try_fold(
 }
 
 /// A variant of fold that might fail.
-///
 ///
 /// The folding function should return `Result(accumulator, error)`.
 /// If the returned value is `Ok(accumulator)` try_fold will try the next value in the iterator.

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -109,7 +109,8 @@ pub fn repeat(x: element) -> Iterator(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> to_list
+/// > from_list([1, 2, 3, 4])
+/// > |> to_list
 /// [1, 2, 3, 4]
 /// ```
 ///
@@ -179,7 +180,10 @@ pub fn run(iterator: Iterator(e)) -> Nil {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3] |> from_list |> map(fn(x) { x * 2 }) |> to_list
+/// > [1, 2, 3]
+/// > |> from_list
+/// > |> map(fn(x) { x * 2 })
+/// > |> to_list
 /// [2, 4, 6]
 /// ```
 ///
@@ -197,13 +201,19 @@ pub fn to_list(iterator: Iterator(element)) -> List(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Next(head, tail) = [1, 2, 3, 4] |> from_list |> step
+/// > assert Next(head, tail) = [1, 2, 3, 4]
+/// >   |> from_list
+/// >   |> step
 /// > head
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > tail |> to_list
 /// [2, 3, 4]
+/// ```
 ///
+/// ```gleam
 /// > empty() |> step
 /// Done
 /// ```
@@ -235,10 +245,18 @@ fn do_take(continuation: fn() -> Action(e), desired: Int) -> fn() -> Action(e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5] |> from_list |> take(up_to: 3) |> to_list
+/// > [1, 2, 3, 4, 5]
+/// > |> from_list
+/// > |> take(up_to: 3)
+/// > |> to_list
 /// [1, 2, 3]
+/// ```
 ///
-/// > [1, 2] |> from_list |> take(up_to: 3) |> to_list
+/// ```gleam
+/// > [1, 2]
+/// > |> from_list
+/// > |> take(up_to: 3)
+/// > |> to_list
 /// [1, 2]
 /// ```
 ///
@@ -271,10 +289,18 @@ fn do_drop(continuation: fn() -> Action(e), desired: Int) -> Action(e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5] |> from_list |> drop(up_to: 3) |> to_list
+/// > [1, 2, 3, 4, 5]
+/// > |> from_list
+/// > |> drop(up_to: 3)
+/// > |> to_list
 /// [4, 5]
+/// ```
 ///
-/// > [1, 2] |> from_list |> drop(up_to: 3) |> to_list
+/// ```gleam
+/// > [1, 2]
+/// > |> from_list
+/// > |> drop(up_to: 3)
+/// > |> to_list
 /// []
 /// ```
 ///
@@ -303,7 +329,10 @@ fn do_map(continuation: fn() -> Action(a), f: fn(a) -> b) -> fn() -> Action(b) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3] |> from_list |> map(fn(x) { x * 2 }) |> to_list
+/// > [1, 2, 3]
+/// > |> from_list
+/// > |> map(fn(x) { x * 2 })
+/// > |> to_list
 /// [2, 4, 6]
 /// ```
 ///
@@ -328,7 +357,10 @@ fn do_append(first: fn() -> Action(a), second: fn() -> Action(a)) -> Action(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2] |> from_list |> append([3, 4] |> from_list) |> to_list
+/// > [1, 2]
+/// > |> from_list
+/// > |> append([3, 4] |> from_list)
+/// > |> to_list
 /// [1, 2, 3, 4]
 /// ```
 ///
@@ -353,7 +385,10 @@ fn do_flatten(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([[1, 2], [3, 4]]) |> map(from_list) |> flatten |> to_list
+/// > from_list([[1, 2], [3, 4]])
+/// > |> map(from_list)
+/// > |> flatten
+/// > |> to_list
 /// [1, 2, 3, 4]
 /// ```
 ///
@@ -374,7 +409,10 @@ pub fn flatten(iterator: Iterator(Iterator(a))) -> Iterator(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2] |> from_list |> flat_map(fn(x) { from_list([x, x + 1]) }) |> to_list
+/// > [1, 2]
+/// > |> from_list
+/// > |> flat_map(fn(x) { from_list([x, x + 1]) })
+/// > |> to_list
 /// [1, 2, 2, 3]
 /// ```
 ///
@@ -413,7 +451,10 @@ fn do_filter(
 ///
 /// ```gleam
 /// > import gleam/int
-/// > [1, 2, 3, 4] |> from_list |> filter(int.is_even) |> to_list
+/// > [1, 2, 3, 4]
+/// > |> from_list
+/// > |> filter(int.is_even)
+/// > |> to_list
 /// [2, 4]
 /// ```
 ///
@@ -430,7 +471,11 @@ pub fn filter(
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2] |> from_list |> cycle |> take(6) |> to_list
+/// > [1, 2]
+/// > |> from_list
+/// > |> cycle
+/// > |> take(6)
+/// > |> to_list
 /// [1, 2, 1, 2, 1, 2]
 /// ```
 ///
@@ -447,10 +492,14 @@ pub fn cycle(iterator: Iterator(a)) -> Iterator(a) {
 /// ```gleam
 /// > range(from: 1, to: 5) |> to_list
 /// [1, 2, 3, 4, 5]
+/// ```
 ///
+/// ```gleam
 /// > range(from: 1, to: -2) |> to_list
 /// [1, 0, -1, -2]
+/// ```
 ///
+/// ```gleam
 /// > range(from: 0, to: 0) |> to_list
 /// [0]
 /// ```
@@ -504,10 +553,14 @@ fn do_find(continuation: fn() -> Action(a), f: fn(a) -> Bool) -> Result(a, Nil) 
 /// ```gleam
 /// > find(from_list([1, 2, 3]), fn(x) { x > 2 })
 /// Ok(3)
+/// ```
 ///
+/// ```gleam
 /// > find(from_list([1, 2, 3]), fn(x) { x > 4 })
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > find(empty(), fn(_) { True })
 /// Error(Nil)
 /// ```
@@ -585,7 +638,9 @@ fn do_take_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 2, 4]) |> take_while(satisfying: fn(x) { x < 3 }) |> to_list
+/// > from_list([1, 2, 3, 2, 4])
+/// > |> take_while(satisfying: fn(x) { x < 3 })
+/// > |> to_list
 /// [1, 2]
 /// ```
 ///
@@ -618,7 +673,9 @@ fn do_drop_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 2, 5]) |> drop_while(satisfying: fn(x) { x < 4 }) |> to_list
+/// > from_list([1, 2, 3, 4, 2, 5])
+/// > |> drop_while(satisfying: fn(x) { x < 4 })
+/// > |> to_list
 /// [4, 2, 5]
 /// ```
 ///
@@ -654,7 +711,9 @@ fn do_scan(
 ///
 /// ```gleam
 /// // Generate a sequence of partial sums
-/// > from_list([1, 2, 3, 4, 5]) |> scan(from: 0, with: fn(acc, el) { acc + el }) |> to_list
+/// > from_list([1, 2, 3, 4, 5])
+/// > |> scan(from: 0, with: fn(acc, el) { acc + el })
+/// > |> to_list
 /// [1, 3, 6, 10, 15]
 /// ```
 ///
@@ -691,7 +750,9 @@ fn do_zip(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list(["a", "b", "c"]) |> zip(range(20, 30)) |> to_list
+/// > from_list(["a", "b", "c"])
+/// > |> zip(range(20, 30))
+/// > |> to_list
 /// [#("a", 20), #("b", 21), #("c", 22)]
 /// ```
 ///
@@ -743,7 +804,9 @@ fn do_chunk(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 2, 3, 4, 4, 6, 7, 7]) |> chunk(by: fn(n) { n % 2 }) |> to_list
+/// > from_list([1, 2, 2, 3, 4, 4, 6, 7, 7])
+/// > |> chunk(by: fn(n) { n % 2 })
+/// > |> to_list
 /// [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
 /// ```
 ///
@@ -812,10 +875,16 @@ fn do_sized_chunk(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 5, 6]) |> sized_chunk(into: 2) |> to_list
+/// > from_list([1, 2, 3, 4, 5, 6])
+/// > |> sized_chunk(into: 2)
+/// > |> to_list
 /// [[1, 2], [3, 4], [5, 6]]
+/// ```
 ///
-/// > from_list([1, 2, 3, 4, 5, 6, 7, 8]) |> sized_chunk(into: 3) |> to_list
+/// ```gleam
+/// > from_list([1, 2, 3, 4, 5, 6, 7, 8])
+/// > |> sized_chunk(into: 3)
+/// > |> to_list
 /// [[1, 2, 3], [4, 5, 6], [7, 8]]
 /// ```
 ///
@@ -847,13 +916,19 @@ fn do_intersperse(
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> intersperse(with: 0) |> to_list
+/// > empty()
+/// > |> intersperse(with: 0)
+/// > |> to_list
 /// []
 ///
-/// > from_list([1]) |> intersperse(with: 0) |> to_list
+/// > from_list([1])
+/// > |> intersperse(with: 0)
+/// > |> to_list
 /// [1]
 ///
-/// > from_list([1, 2, 3, 4, 5]) |> intersperse(with: 0) |> to_list
+/// > from_list([1, 2, 3, 4, 5])
+/// > |> intersperse(with: 0)
+/// > |> to_list
 /// [1, 0, 2, 0, 3, 0, 4, 0, 5]
 /// ```
 ///
@@ -892,10 +967,14 @@ fn do_any(
 /// ```gleam
 /// > empty() |> any(fn(n) { n % 2 == 0 })
 /// False
+/// ```
 ///
+/// ```gleam
 /// > from_list([1, 2, 5, 7, 9]) |> any(fn(n) { n % 2 == 0 })
 /// True
+/// ```
 ///
+/// ```gleam
 /// > from_list([1, 3, 5, 7, 9]) |> any(fn(n) { n % 2 == 0 })
 /// False
 /// ```
@@ -930,10 +1009,14 @@ fn do_all(
 /// ```gleam
 /// > empty() |> all(fn(n) { n % 2 == 0 })
 /// True
+/// ```
 ///
+/// ```gleam
 /// > from_list([2, 4, 6, 8]) |> all(fn(n) { n % 2 == 0 })
 /// True
+/// ```
 ///
+/// ```gleam
 /// > from_list([2, 4, 5, 8]) |> all(fn(n) { n % 2 == 0 })
 /// False
 /// ```
@@ -997,7 +1080,9 @@ pub fn group(
 /// ```gleam
 /// > from_list([]) |> reduce(fn(acc, x) { acc + x })
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > from_list([1, 2, 3, 4, 5]) |> reduce(fn(acc, x) { acc + x })
 /// Ok(15)
 /// ```
@@ -1025,7 +1110,9 @@ pub fn reduce(
 /// ```gleam
 /// > empty() |> last
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > range(1, 10) |> last
 /// Ok(9)
 /// ```
@@ -1094,7 +1181,9 @@ fn do_interleave(
 /// ```gleam
 /// > from_list([1, 2, 3, 4]) |> interleave(from_list([11, 12, 13, 14])) |> to_list
 /// [1, 11, 2, 12, 3, 13, 4, 14]
+/// ```
 ///
+/// ```gleam
 /// > from_list([1, 2, 3, 4]) |> interleave(from_list([100])) |> to_list
 /// [1, 100, 2, 3, 4]
 /// ```
@@ -1132,6 +1221,7 @@ fn do_fold_until(
 /// ## Examples
 ///
 /// ```gleam
+/// > import gleam/list
 /// > let f = fn(acc, e) {
 /// >   case e {
 /// >     _ if e < 4 -> list.Continue(e + acc)
@@ -1141,7 +1231,7 @@ fn do_fold_until(
 /// >
 /// > [1, 2, 3, 4]
 /// > |> from_list
-/// > |> iterator.fold_until(from: acc, with: f)
+/// > |> fold_until(from: acc, with: f)
 /// 6
 /// ```
 ///
@@ -1205,7 +1295,9 @@ pub fn try_fold(
 /// ```gleam
 /// > from_list([1, 2, 3]) |> first
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > empty() |> first
 /// Error(Nil)
 /// ```
@@ -1216,21 +1308,25 @@ pub fn first(from iterator: Iterator(e)) -> Result(e, Nil) {
   }
 }
 
-/// Returns nth element yielded by the given iterator, where 0 means the first element.
+/// Returns nth element yielded by the given iterator, where `0` means the first element.
 ///
 /// If there are not enough elements in the iterator, `Error(Nil)` is returned.
 ///
-/// For any `index` less than 0 this function behaves as if it was set to 0.
+/// For any `index` less than `0` this function behaves as if it was set to `0`.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > from_list([1, 2, 3, 4]) |> at(2)
 /// Ok(3)
+/// ```
 ///
+/// ```gleam
 /// > from_list([1, 2, 3, 4]) |> at(4)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > empty() |> at(0)
 /// Error(Nil)
 /// ```

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -178,7 +178,7 @@ pub fn run(iterator: Iterator(e)) -> Nil {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > [1, 2, 3] |> from_list |> map(fn(x) { x * 2 }) |> to_list
 /// [2, 4, 6]
 /// ```
@@ -655,8 +655,8 @@ fn do_scan(
 ///
 /// ## Examples
 ///
-/// Generate a sequence of partial sums:
 /// ```gleam
+/// // Generate a sequence of partial sums
 /// > from_list([1, 2, 3, 4, 5]) |> scan(from: 0, with: fn(acc, el) { acc + el }) |> to_list
 /// [1, 3, 6, 10, 15]
 /// ```
@@ -1055,8 +1055,10 @@ pub fn empty() -> Iterator(element) {
 ///
 /// ## Examples
 ///
+/// ```gleam
 /// > once(fn() { 1 }) |> to_list
 /// [1]
+/// ```
 ///
 pub fn once(f: fn() -> element) -> Iterator(element) {
   fn() { Continue(f(), stop) }
@@ -1204,7 +1206,7 @@ pub fn try_fold(
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > from_list([1, 2, 3]) |> first
 /// Ok(1)
 ///
@@ -1226,7 +1228,7 @@ pub fn first(from iterator: Iterator(e)) -> Result(e, Nil) {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > from_list([1, 2, 3, 4]) |> at(2)
 /// Ok(3)
 ///

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1734,8 +1734,8 @@ pub fn last(list: List(a)) -> Result(a, Nil) {
 /// > combinations([1, 2, 3], 2)
 /// [[1, 2], [1, 3], [2, 3]]
 ///
-///  > combinations([1, 2, 3, 4], 3)
-///  [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
+/// > combinations([1, 2, 3, 4], 3)
+/// [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
 /// ```
 ///
 pub fn combinations(items: List(a), by n: Int) -> List(List(a)) {

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -296,8 +296,10 @@ fn do_map(list: List(a), fun: fn(a) -> b, acc: List(b)) -> List(b) {
 ///
 /// ## Examples
 ///
+/// ```gleam
 /// > map([2, 4, 6], fn(x) { x * 2 })
 /// [4, 8, 12]
+/// ```
 ///
 pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
   do_map(list, fun, [])
@@ -479,8 +481,10 @@ pub fn take(from list: List(a), up_to n: Int) -> List(a) {
 ///
 /// ## Examples
 ///
+/// ```gleam
 /// > new()
 /// []
+/// ```
 ///
 pub fn new() -> List(a) {
   []
@@ -1713,10 +1717,10 @@ pub fn scan(
 ///
 /// ## Examples
 ///
+/// ```gleam
 /// > last([])
 /// Error(Nil)
 ///
-/// ```gleam
 /// > last([1, 2, 3, 4, 5])
 /// Ok(5)
 /// ```

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -46,10 +46,14 @@ pub type LengthMismatch {
 /// ```gleam
 /// > length([])
 /// 0
+/// ```
 ///
+/// ```gleam
 /// > length([1])
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > length([1, 2])
 /// 2
 /// ```
@@ -90,10 +94,14 @@ if javascript {
 /// ```gleam
 /// > reverse([])
 /// []
+/// ```
 ///
+/// ```gleam
 /// > reverse([1])
 /// [1]
+/// ```
 ///
+/// ```gleam
 /// > reverse([1, 2])
 /// [2, 1]
 /// ```
@@ -129,10 +137,14 @@ if javascript {
 /// ```gleam
 /// > is_empty([])
 /// True
+/// ```
 ///
+/// ```gleam
 /// > is_empty([1])
 /// False
+/// ```
 ///
+/// ```gleam
 /// > is_empty([1, 1])
 /// False
 /// ```
@@ -151,16 +163,24 @@ pub fn is_empty(list: List(a)) -> Bool {
 /// ```gleam
 /// > [] |> contains(any: 0)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > [0] |> contains(any: 0)
 /// True
+/// ```
 ///
+/// ```gleam
 /// > [1] |> contains(any: 0)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > [1, 1] |> contains(any: 0)
 /// False
+/// ```
 ///
+/// ```gleam
 /// > [1, 0] |> contains(any: 0)
 /// True
 /// ```
@@ -180,10 +200,14 @@ pub fn contains(list: List(a), any elem: a) -> Bool {
 /// ```gleam
 /// > first([])
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > first([0])
 /// Ok(0)
+/// ```
 ///
+/// ```gleam
 /// > first([1, 2])
 /// Ok(1)
 /// ```
@@ -205,10 +229,14 @@ pub fn first(list: List(a)) -> Result(a, Nil) {
 /// ```gleam
 /// > rest([])
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > rest([0])
 /// Ok([])
+/// ```
 ///
+/// ```gleam
 /// > rest([1, 2])
 /// Ok([2])
 /// ```
@@ -241,7 +269,9 @@ fn do_filter(list: List(a), fun: fn(a) -> Bool, acc: List(a)) -> List(a) {
 /// ```gleam
 /// > filter([2, 4, 6, 1], fn(x) { x > 2 })
 /// [4, 6]
+/// ```
 ///
+/// ```gleam
 /// > filter([2, 4, 6, 1], fn(x) { x > 6 })
 /// []
 /// ```
@@ -275,7 +305,9 @@ fn do_filter_map(
 /// ```gleam
 /// > filter_map([2, 4, 6, 1], Error)
 /// []
+/// ```
 ///
+/// ```gleam
 /// > filter_map([2, 4, 6, 1], fn(x) { Ok(x + 1) })
 /// [3, 5, 7, 2]
 /// ```
@@ -397,13 +429,19 @@ fn do_try_map(
 /// ```gleam
 /// > try_map([1, 2, 3], fn(x) { Ok(x + 2) })
 /// Ok([3, 4, 5])
+/// ```
 ///
+/// ```gleam
 /// > try_map([1, 2, 3], fn(_) { Error(0) })
 /// Error(0)
+/// ```
 ///
+/// ```gleam
 /// > try_map([[1], [2, 3]], head)
 /// Ok([1, 2])
+/// ```
 ///
+/// ```gleam
 /// > try_map([[1], [], [2]], head)
 /// Error(Nil)
 /// ```
@@ -428,7 +466,9 @@ pub fn try_map(
 /// ```gleam
 /// > drop([1, 2, 3, 4], 2)
 /// [3, 4]
+/// ```
 ///
+/// ```gleam
 /// > drop([1, 2, 3, 4], 9)
 /// []
 /// ```
@@ -468,7 +508,9 @@ fn do_take(list: List(a), n: Int, acc: List(a)) -> List(a) {
 /// ```gleam
 /// > take([1, 2, 3, 4], 2)
 /// [1, 2]
+/// ```
 ///
+/// ```gleam
 /// > take([1, 2, 3, 4], 9)
 /// [1, 2, 3, 4]
 /// ```
@@ -731,10 +773,14 @@ pub fn fold_until(
 /// ```gleam
 /// > find([1, 2, 3], fn(x) { x > 2 })
 /// Ok(3)
+/// ```
 ///
+/// ```gleam
 /// > find([1, 2, 3], fn(x) { x > 4 })
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > find([], fn(_) { True })
 /// Error(Nil)
 /// ```
@@ -763,10 +809,14 @@ pub fn find(
 /// ```gleam
 /// > find_map([[], [2], [3]], head)
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > find_map([[], []], head)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > find_map([], head)
 /// Error(Nil)
 /// ```
@@ -794,10 +844,14 @@ pub fn find_map(
 /// ```gleam
 /// > all([], fn(x) { x > 3 })
 /// True
+/// ```
 ///
+/// ```gleam
 /// > all([4, 5], fn(x) { x > 3 })
 /// True
+/// ```
 ///
+/// ```gleam
 /// > all([4, 3], fn(x) { x > 3 })
 /// False
 /// ```
@@ -822,13 +876,19 @@ pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
 /// ```gleam
 /// > any([], fn(x) { x > 3 })
 /// False
+/// ```
 ///
+/// ```gleam
 /// > any([4, 5], fn(x) { x > 3 })
 /// True
+/// ```
 ///
+/// ```gleam
 /// > any([4, 3], fn(x) { x > 4 })
 /// False
+/// ```
 ///
+/// ```gleam
 /// > any([3, 4], fn(x) { x > 3 })
 /// True
 /// ```
@@ -861,13 +921,19 @@ fn do_zip(xs: List(a), ys: List(b), acc: List(#(a, b))) -> List(#(a, b)) {
 /// ```gleam
 /// > zip([], [])
 /// []
+/// ```
 ///
+/// ```gleam
 /// > zip([1, 2], [3])
 /// [#(1, 3)]
+/// ```
 ///
+/// ```gleam
 /// > zip([1], [3, 4])
 /// [#(1, 3)]
+/// ```
 ///
+/// ```gleam
 /// > zip([1, 2], [3, 4])
 /// [#(1, 3), #(2, 4)]
 /// ```
@@ -885,13 +951,19 @@ pub fn zip(xs: List(a), ys: List(b)) -> List(#(a, b)) {
 /// ```gleam
 /// > strict_zip([], [])
 /// Ok([])
+/// ```
 ///
+/// ```gleam
 /// > strict_zip([1, 2], [3])
 /// Error(LengthMismatch)
+/// ```
 ///
+/// ```gleam
 /// > strict_zip([1], [3, 4])
 /// Error(LengthMismatch)
+/// ```
 ///
+/// ```gleam
 /// > strict_zip([1, 2], [3, 4])
 /// Ok([#(1, 3), #(2, 4)])
 /// ```
@@ -920,7 +992,9 @@ fn do_unzip(input, xs, ys) {
 /// ```gleam
 /// > unzip([#(1, 2), #(3, 4)])
 /// #([1, 3], [2, 4])
+/// ```
 ///
+/// ```gleam
 /// > unzip([])
 /// #([], [])
 /// ```
@@ -945,7 +1019,9 @@ fn do_intersperse(list: List(a), separator: a, acc: List(a)) -> List(a) {
 /// ```gleam
 /// > intersperse([1, 1, 1], 2)
 /// [1, 2, 1, 2, 1]
+/// ```
 ///
+/// ```gleam
 /// > intersperse([], 2)
 /// []
 /// ```
@@ -969,7 +1045,9 @@ pub fn intersperse(list: List(a), with elem: a) -> List(a) {
 /// ```gleam
 /// > at([1, 2, 3], 1)
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > at([1, 2, 3], 5)
 /// Error(Nil)
 /// ```
@@ -1111,10 +1189,14 @@ pub fn sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
 /// ```gleam
 /// > range(0, 0)
 /// [0]
+/// ```
 ///
+/// ```gleam
 /// > range(0, 5)
 /// [0, 1, 2, 3, 4, 5]
+/// ```
 ///
+/// ```gleam
 /// > range(1, -5)
 /// [1, 0, -1, -2, -3, -4, -5]
 /// ```
@@ -1145,7 +1227,9 @@ fn do_repeat(a: a, times: Int, acc: List(a)) -> List(a) {
 /// ```gleam
 /// > repeat("a", times: 0)
 /// []
+/// ```
 ///
+/// ```gleam
 /// > repeat("a", times: 5)
 /// ["a", "a", "a", "a", "a"]
 /// ```
@@ -1175,10 +1259,14 @@ fn do_split(list: List(a), n: Int, taken: List(a)) -> #(List(a), List(a)) {
 /// ```gleam
 /// > split([6, 7, 8, 9], 0)
 /// #([], [6, 7, 8, 9])
+/// ```
 ///
+/// ```gleam
 /// > split([6, 7, 8, 9], 2)
 /// #([6, 7], [8, 9])
+/// ```
 ///
+/// ```gleam
 /// > split([6, 7, 8, 9], 4)
 /// #([6, 7, 8, 9], [])
 /// ```
@@ -1213,7 +1301,9 @@ fn do_split_while(
 /// ```gleam
 /// > split_while([1, 2, 3, 4, 5], fn(x) { x <= 3 })
 /// #([1, 2, 3], [4, 5])
+/// ```
 ///
+/// ```gleam
 /// > split_while([1, 2, 3, 4, 5], fn(x) { x <= 5 })
 /// #([1, 2, 3, 4, 5], [])
 /// ```
@@ -1238,10 +1328,14 @@ pub fn split_while(
 /// ```gleam
 /// > key_find([#("a", 0), #("b", 1)], "a")
 /// Ok(0)
+/// ```
 ///
+/// ```gleam
 /// > key_find([#("a", 0), #("b", 1)], "b")
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > key_find([#("a", 0), #("b", 1)], "c")
 /// Error(Nil)
 /// ```
@@ -1282,10 +1376,14 @@ fn do_pop(haystack, predicate, checked) {
 /// ```gleam
 /// > pop([1, 2, 3], fn(x) { x > 2 })
 /// Ok(#(3, [1, 2]))
+/// ```
 ///
+/// ```gleam
 /// > pop([1, 2, 3], fn(x) { x > 4 })
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > pop([], fn(_) { True })
 /// Error(Nil)
 /// ```
@@ -1318,10 +1416,14 @@ fn do_pop_map(haystack, mapper, checked) {
 /// ```gleam
 /// > pop_map([[], [2], [3]], head)
 /// Ok(#(2, [[], [3]]))
+/// ```
 ///
+/// ```gleam
 /// > pop_map([[], []], head)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > pop_map([], head)
 /// Error(Nil)
 /// ```
@@ -1344,10 +1446,14 @@ pub fn pop_map(
 /// ```gleam
 /// > key_pop([#("a", 0), #("b", 1)], "a")
 /// Ok(#(0, [#("b", 1)]))
+/// ```
 ///
+/// ```gleam
 /// > key_pop([#("a", 0), #("b", 1)], "b")
 /// Ok(#(1, [#("a", 0)]))
+/// ```
 ///
+/// ```gleam
 /// > key_pop([#("a", 0), #("b", 1)], "c")
 /// Error(Nil)
 /// ```
@@ -1378,7 +1484,9 @@ pub fn key_pop(
 /// ```gleam
 /// > key_set([#(5, 0), #(4, 1)], 4, 100)
 /// [#(5, 0), #(4, 100)]
+/// ```
 ///
+/// ```gleam
 /// > key_set([#(5, 0), #(4, 1)], 1, 100)
 /// [#(5, 0), #(4, 1), #(1, 100)]
 /// ```
@@ -1487,7 +1595,9 @@ fn do_window(acc: List(List(a)), l: List(a), n: Int) -> List(List(a)) {
 /// ```gleam
 /// > window([1,2,3,4,5], 3)
 /// [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+/// ```
 ///
+/// ```gleam
 /// > window([1, 2], 4)
 /// []
 /// ```
@@ -1504,7 +1614,9 @@ pub fn window(l: List(a), by n: Int) -> List(List(a)) {
 /// ```gleam
 /// > window_by_2([1,2,3,4])
 /// [#(1, 2), #(2, 3), #(3, 4)]
+/// ```
 ///
+/// ```gleam
 /// > window_by_2([1])
 /// []
 /// ```
@@ -1641,7 +1753,9 @@ fn do_sized_chunk(
 /// ```gleam
 /// > [1, 2, 3, 4, 5, 6] |> sized_chunk(into: 2)
 /// [[1, 2], [3, 4], [5, 6]]
+/// ```
 ///
+/// ```gleam
 /// > [1, 2, 3, 4, 5, 6, 7, 8] |> sized_chunk(into: 3)
 /// [[1, 2, 3], [4, 5, 6], [7, 8]]
 /// ```
@@ -1663,7 +1777,9 @@ pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
 /// ```gleam
 /// > [] |> reduce(fn(acc, x) { acc + x })
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > [1, 2, 3, 4, 5] |> reduce(fn(acc, x) { acc + x })
 /// Ok(15)
 /// ```
@@ -1720,7 +1836,9 @@ pub fn scan(
 /// ```gleam
 /// > last([])
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > last([1, 2, 3, 4, 5])
 /// Ok(5)
 /// ```
@@ -1737,7 +1855,9 @@ pub fn last(list: List(a)) -> Result(a, Nil) {
 /// ```gleam
 /// > combinations([1, 2, 3], 2)
 /// [[1, 2], [1, 3], [2, 3]]
+/// ```
 ///
+/// ```gleam
 /// > combinations([1, 2, 3, 4], 3)
 /// [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
 /// ```
@@ -1859,6 +1979,9 @@ fn do_shuffle_by_pair_indexes(
 
 /// Takes a list, randomly sorts all items and returns the shuffled list.
 ///
+/// This function uses Erlang's `:rand` module or Javascript's
+/// `Math.random()` to calcuate the index shuffling.
+///
 /// ## Example
 ///
 /// ```gleam
@@ -1866,9 +1989,6 @@ fn do_shuffle_by_pair_indexes(
 /// |> list.shuffle()
 /// > [1, 6, 9, 10, 3, 8, 4, 2, 7, 5]
 /// ```
-///
-/// Notice: This function uses Erlang's `:rand` module or Javascript's
-/// `Math.random()` to calcuate the index shuffling.
 ///
 pub fn shuffle(list: List(a)) -> List(a) {
   list

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -682,7 +682,7 @@ fn do_index_fold(
 ///
 /// ```gleam
 /// ["a", "b", "c"]
-/// |> list.index_fold([], fn(acc, item, index) { ... })
+/// |> index_fold([], fn(acc, item, index) { ... })
 /// ```
 ///
 pub fn index_fold(

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -29,7 +29,9 @@ pub external type Map(key, value)
 /// ```gleam
 /// > new() |> size()
 /// 0
+/// ```
 ///
+/// ```gleam
 /// > new() |> insert("key", "value") |> size()
 /// 1
 /// ```
@@ -58,7 +60,9 @@ if javascript {
 /// ```gleam
 /// > new() |> to_list()
 /// []
+/// ```
 ///
+/// ```gleam
 /// > new() |> insert("key", 0) |> to_list()
 /// [#("key", 0)]
 /// ```
@@ -104,7 +108,9 @@ if javascript {
 /// ```gleam
 /// > new() |> insert("a", 0) |> has_key("a")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > new() |> insert("a", 0) |> has_key("b")
 /// False
 /// ```
@@ -150,7 +156,9 @@ if javascript {
 /// ```gleam
 /// > new() |> insert("a", 0) |> get("a")
 /// Ok(0)
+/// ```
 ///
+/// ```gleam
 /// > new() |> insert("a", 0) |> get("b")
 /// Error(Nil)
 /// ```
@@ -179,7 +187,9 @@ if javascript {
 /// ```gleam
 /// > new() |> insert("a", 0) |> to_list
 /// [#("a", 0)]
+/// ```
 ///
+/// ```gleam
 /// > new() |> insert("a", 0) |> insert("a", 5) |> to_list
 /// [#("a", 5)]
 /// ```
@@ -296,7 +306,9 @@ if javascript {
 /// > from_list([#("a", 0), #("b", 1)])
 /// > |> filter(fn(key, value) { value != 0 })
 /// from_list([#("b", 1)])
+/// ```
 ///
+/// ```gleam
 /// > from_list([#("a", 0), #("b", 1)])
 /// > |> filter(fn(key, value) { True })
 /// from_list([#("a", 0), #("b", 1)])
@@ -339,7 +351,9 @@ if javascript {
 /// > from_list([#("a", 0), #("b", 1)])
 /// > |> take(["b"])
 /// from_list([#("b", 1)])
+/// ```
 ///
+/// ```gleam
 /// > from_list([#("a", 0), #("b", 1)])
 /// > |> take(["a", "b", "c"])
 /// from_list([#("a", 0), #("b", 1)])
@@ -409,7 +423,9 @@ if javascript {
 /// ```gleam
 /// > delete([#("a", 0), #("b", 1)], "a")
 /// from_list([#("b", 1)])
+/// ```
 ///
+/// ```gleam
 /// > delete([#("a", 0), #("b", 1)], "c")
 /// from_list([#("a", 0), #("b", 1)])
 /// ```
@@ -436,10 +452,14 @@ if javascript {
 /// ```gleam
 /// > drop([#("a", 0), #("b", 1)], ["a"])
 /// from_list([#("b", 2)])
+/// ```
 ///
+/// ```gleam
 /// > delete([#("a", 0), #("b", 1)], ["c"])
 /// from_list([#("a", 0), #("b", 1)])
+/// ```
 ///
+/// ```gleam
 /// > drop([#("a", 0), #("b", 1)], ["a", "b", "c"])
 /// from_list([])
 /// ```
@@ -466,7 +486,9 @@ pub fn drop(from map: Map(k, v), drop disallowed_keys: List(k)) -> Map(k, v) {
 /// >
 /// > update(map, "a", increment)
 /// from_list([#("a", 1)])
+/// ```
 ///
+/// ```gleam
 /// > update(map, "b", increment)
 /// from_list([#("a", 0), #("b", 0)])
 /// ```
@@ -503,7 +525,9 @@ fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(acc, k, v) -> acc) -> acc 
 /// > let map = from_list([#("a", 1), #("b", 3), #("c", 9)])
 /// > fold(map, 0, fn(accumulator, key, value) { accumulator + value })
 /// 13
+/// ```
 ///
+/// ```gleam
 /// > import gleam/string.{append}
 /// > fold(map, "", fn(accumulator, key, value) { append(accumulator, key) })
 /// "abc"

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -34,7 +34,6 @@ pub external type Map(key, value)
 /// 1
 /// ```
 ///
-///
 pub fn size(map: Map(k, v)) -> Int {
   do_size(map)
 }
@@ -210,7 +209,6 @@ if javascript {
 /// > |> map_values(fn(key, value) { key * value })
 /// [#(3, 9), #(2, 8)]
 /// ```
-///
 ///
 pub fn map_values(in map: Map(k, v), with fun: fn(k, v) -> w) -> Map(k, w) {
   do_map_values(fun, map)

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -20,7 +20,9 @@ pub type Option(a) {
 /// ```gleam
 /// > all([Some(1), Some(2)])
 /// Some([1, 2])
+/// ```
 ///
+/// ```gleam
 /// > all([Some(1), None])
 /// None
 /// ```
@@ -45,7 +47,9 @@ pub fn all(list: List(Option(a))) -> Option(List(a)) {
 /// ```gleam
 /// > is_some(Some(1))
 /// True
+/// ```
 ///
+/// ```gleam
 /// > is_some(None)
 /// False
 /// ```
@@ -61,7 +65,9 @@ pub fn is_some(option: Option(a)) -> Bool {
 /// ```gleam
 /// > is_none(Some(1))
 /// False
+/// ```
 ///
+/// ```gleam
 /// > is_none(None)
 /// True
 /// ```
@@ -77,7 +83,9 @@ pub fn is_none(option: Option(a)) -> Bool {
 /// ```gleam
 /// > to_result(Some(1), "some_error")
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > to_result(None, "some_error")
 /// Error("some_error")
 /// ```
@@ -96,7 +104,9 @@ pub fn to_result(option: Option(a), e) -> Result(a, e) {
 /// ```gleam
 /// > from_result(Ok(1))
 /// Some(1)
+/// ```
 ///
+/// ```gleam
 /// > from_result(Error("some_error"))
 /// None
 /// ```
@@ -115,7 +125,9 @@ pub fn from_result(result: Result(a, e)) -> Option(a) {
 /// ```gleam
 /// > unwrap(Some(1), 0)
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > unwrap(None, 0)
 /// 0
 /// ```
@@ -134,7 +146,9 @@ pub fn unwrap(option: Option(a), or default: a) -> a {
 /// ```gleam
 /// > lazy_unwrap(Some(1), fn() { 0 })
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > lazy_unwrap(None, fn() { 0 })
 /// 0
 /// ```
@@ -157,7 +171,9 @@ pub fn lazy_unwrap(option: Option(a), or default: fn() -> a) -> a {
 /// ```gleam
 /// > map(over: Some(1), with: fn(x) { x + 1 })
 /// Some(2)
+/// ```
 ///
+/// ```gleam
 /// > map(over: None, with: fn(x) { x + 1 })
 /// None
 /// ```
@@ -176,10 +192,14 @@ pub fn map(over option: Option(a), with fun: fn(a) -> b) -> Option(b) {
 /// ```gleam
 /// > flatten(Some(Some(1)))
 /// Some(1)
+/// ```
 ///
+/// ```gleam
 /// > flatten(Some(None))
 /// None
+/// ```
 ///
+/// ```gleam
 /// > flatten(None)
 /// None
 /// ```
@@ -206,13 +226,19 @@ pub fn flatten(option: Option(Option(a))) -> Option(a) {
 /// ```gleam
 /// > then(Some(1), fn(x) { Some(x + 1) })
 /// Some(2)
+/// ```
 ///
+/// ```gleam
 /// > then(Some(1), fn(x) { Some(#("a", x)) })
 /// Some(#("a", 1))
+/// ```
 ///
+/// ```gleam
 /// > then(Some(1), fn(_) { None })
 /// None
+/// ```
 ///
+/// ```gleam
 /// > then(None, fn(x) { Some(x + 1) })
 /// None
 /// ```
@@ -231,13 +257,19 @@ pub fn then(option: Option(a), apply fun: fn(a) -> Option(b)) -> Option(b) {
 /// ```gleam
 /// > or(Some(1), Some(2))
 /// Some(1)
+/// ```
 ///
+/// ```gleam
 /// > or(Some(1), None)
 /// Some(1)
+/// ```
 ///
+/// ```gleam
 /// > or(None, Some(2))
 /// Some(2)
+/// ```
 ///
+/// ```gleam
 /// > or(None, None)
 /// None
 /// ```
@@ -256,13 +288,19 @@ pub fn or(first: Option(a), second: Option(a)) -> Option(a) {
 /// ```gleam
 /// > lazy_or(Some(1), fn() { Some(2) })
 /// Some(1)
+/// ```
 ///
+/// ```gleam
 /// > lazy_or(Some(1), fn() { None })
 /// Some(1)
+/// ```
 ///
+/// ```gleam
 /// > lazy_or(None, fn() { Some(2) })
 /// Some(2)
+/// ```
 ///
+/// ```gleam
 /// > lazy_or(None, fn() { None })
 /// None
 /// ```

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -17,7 +17,7 @@ pub type Option(a) {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > all([Some(1), Some(2)])
 /// Some([1, 2])
 ///
@@ -77,6 +77,7 @@ pub fn is_none(option: Option(a)) -> Bool {
 /// ```gleam
 /// > to_result(Some(1), "some_error")
 /// Ok(1)
+///
 /// > to_result(None, "some_error")
 /// Error("some_error")
 /// ```
@@ -95,6 +96,7 @@ pub fn to_result(option: Option(a), e) -> Result(a, e) {
 /// ```gleam
 /// > from_result(Ok(1))
 /// Some(1)
+///
 /// > from_result(Error("some_error"))
 /// None
 /// ```
@@ -277,7 +279,7 @@ pub fn lazy_or(first: Option(a), second: fn() -> Option(a)) -> Option(a) {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > values([Some(1), None, Some(3)])
 /// [1, 3]
 /// ```

--- a/src/gleam/order.gleam
+++ b/src/gleam/order.gleam
@@ -20,10 +20,14 @@ pub type Order {
 /// ```gleam
 /// > reverse(Lt)
 /// Gt
+/// ```
 ///
+/// ```gleam
 /// > reverse(Eq)
 /// Eq
+/// ```
 ///
+/// ```gleam
 /// > reverse(Lt)
 /// Gt
 /// ```
@@ -43,10 +47,14 @@ pub fn reverse(order: Order) -> Order {
 /// ```gleam
 /// > to_int(Lt)
 /// -1
+/// ```
 ///
+/// ```gleam
 /// > to_int(Eq)
 /// 0
+/// ```
 ///
+/// ```gleam
 /// > to_int(Gt)
 /// 1
 /// ```

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -65,10 +65,14 @@ pub fn to_list(queue: Queue(a)) -> List(a) {
 /// ```gleam
 /// > [] |> from_list |> is_empty
 /// True
+/// ```
 ///
+/// ```gleam
 /// > [1] |> from_list |> is_empty
 /// False
+/// ```
 ///
+/// ```gleam
 /// > [1, 2] |> from_list |> is_empty
 /// False
 /// ```
@@ -87,10 +91,14 @@ pub fn is_empty(queue: Queue(a)) -> Bool {
 /// ```gleam
 /// > length(from_list([]))
 /// 0
+/// ```
 ///
+/// ```gleam
 /// > length(from_list([1]))
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > length(from_list([1, 2]))
 /// 2
 /// ```
@@ -139,12 +147,16 @@ pub fn push_front(onto queue: Queue(a), this item: a) -> Queue(a) {
 /// > |> queue.push_back(1)
 /// > |> queue.pop_back()
 /// Ok(#(1, queue.push_front(queue.new(), 0)))
+/// ```
 ///
+/// ```gleam
 /// > queue.new()
 /// > |> queue.push_front(0)
 /// > |> queue.pop_back()
 /// Ok(#(0, queue.new()))
+/// ```
 ///
+/// ```gleam
 /// > queue.new()
 /// > |> queue.pop_back()
 /// Error(Nil)
@@ -175,12 +187,16 @@ pub fn pop_back(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
 /// > |> queue.push_front(0)
 /// > |> queue.pop_front()
 /// Ok(#(0, queue.push_back(queue.new(), 1)))
+/// ```
 ///
+/// ```gleam
 /// > queue.new()
 /// > |> queue.push_back(0)
 /// > |> queue.pop_front()
 /// Ok(#(0, queue.new()))
+/// ```
 ///
+/// ```gleam
 /// > queue.new()
 /// > |> queue.pop_back()
 /// Error(Nil)
@@ -207,10 +223,14 @@ pub fn pop_front(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
 /// ```gleam
 /// > [] |> from_list |> reverse |> to_list
 /// []
+/// ```
 ///
+/// ```gleam
 /// > [1] |> from_list |> reverse |> to_list
 /// [1]
+/// ```
 ///
+/// ```gleam
 /// > [1, 2] |> from_list |> reverse |> to_list
 /// [2, 1]
 /// ```

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -142,23 +142,23 @@ pub fn push_front(onto queue: Queue(a), this item: a) -> Queue(a) {
 /// # Examples
 ///
 /// ```gleam
-/// > queue.new()
-/// > |> queue.push_back(0)
-/// > |> queue.push_back(1)
-/// > |> queue.pop_back()
-/// Ok(#(1, queue.push_front(queue.new(), 0)))
+/// > new()
+/// > |> push_back(0)
+/// > |> push_back(1)
+/// > |> pop_back()
+/// Ok(#(1, push_front(new(), 0)))
 /// ```
 ///
 /// ```gleam
-/// > queue.new()
-/// > |> queue.push_front(0)
-/// > |> queue.pop_back()
-/// Ok(#(0, queue.new()))
+/// > new()
+/// > |> push_front(0)
+/// > |> pop_back()
+/// Ok(#(0, new()))
 /// ```
 ///
 /// ```gleam
-/// > queue.new()
-/// > |> queue.pop_back()
+/// > new()
+/// > |> pop_back()
 /// Error(Nil)
 /// ```
 ///

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -43,7 +43,9 @@ pub type Options {
 /// > assert Ok(re) = compile("^[0-9]", with: options)
 /// > match(re, "abc\n123")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > let options = Options(case_insensitive: True, multi_line: False)
 /// > assert Ok(re) = compile("[A-Z]", with: options)
 /// > match(re, "abc123")
@@ -75,10 +77,14 @@ if javascript {
 /// > assert Ok(re) = from_string("[0-9]")
 /// > match(re, "abc123")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > match(re, "abcxyz")
 /// False
+/// ```
 ///
+/// ```gleam
 /// > from_string("[0-9")
 /// Error(
 ///   CompileError(
@@ -100,7 +106,9 @@ pub fn from_string(pattern: String) -> Result(Regex, CompileError) {
 /// > assert Ok(re) = from_string("^f.o.?")
 /// > check(with: re, content: "foo")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > check(with: re, content: "boo")
 /// False
 /// ```

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -160,8 +160,8 @@ if javascript {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Ok(re) = regex.from_string("[oi]n a (\\w+)")
-/// > regex.scan(with: re, content: "I am on a boat in a lake.")
+/// > assert Ok(re) = from_string("[oi]n a (\\w+)")
+/// > scan(with: re, content: "I am on a boat in a lake.")
 /// [
 ///   Match(
 ///     content: "on a boat",

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -10,7 +10,9 @@ import gleam/list
 /// ```gleam
 /// > is_ok(Ok(1))
 /// True
+/// ```
 ///
+/// ```gleam
 /// > is_ok(Error(Nil))
 /// False
 /// ```
@@ -29,7 +31,9 @@ pub fn is_ok(result: Result(a, e)) -> Bool {
 /// ```gleam
 /// > is_error(Ok(1))
 /// False
+/// ```
 ///
+/// ```gleam
 /// > is_error(Error(Nil))
 /// True
 /// ```
@@ -52,7 +56,9 @@ pub fn is_error(result: Result(a, e)) -> Bool {
 /// ```gleam
 /// > map(over: Ok(1), with: fn(x) { x + 1 })
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > map(over: Error(1), with: fn(x) { x + 1 })
 /// Error(1)
 /// ```
@@ -75,7 +81,9 @@ pub fn map(over result: Result(a, e), with fun: fn(a) -> b) -> Result(b, e) {
 /// ```gleam
 /// > map_error(over: Error(1), with: fn(x) { x + 1 })
 /// Error(2)
+/// ```
 ///
+/// ```gleam
 /// > map_error(over: Ok(1), with: fn(x) { x + 1 })
 /// Ok(1)
 /// ```
@@ -97,10 +105,14 @@ pub fn map_error(
 /// ```gleam
 /// > flatten(Ok(Ok(1)))
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > flatten(Ok(Error("")))
 /// Error("")
+/// ```
 ///
+/// ```gleam
 /// > flatten(Error(Nil))
 /// Error(Nil)
 /// ```
@@ -127,13 +139,19 @@ pub fn flatten(result: Result(Result(a, e), e)) -> Result(a, e) {
 /// ```gleam
 /// > then(Ok(1), fn(x) { Ok(x + 1) })
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > then(Ok(1), fn(x) { Ok(#("a", x)) })
 /// Ok(#("a", 1))
+/// ```
 ///
+/// ```gleam
 /// > then(Ok(1), fn(_) { Error("Oh no") })
 /// Error("Oh no")
+/// ```
 ///
+/// ```gleam
 /// > then(Error(Nil), fn(x) { Ok(x + 1) })
 /// Error(Nil)
 /// ```
@@ -156,7 +174,9 @@ pub fn then(
 /// ```gleam
 /// > unwrap(Ok(1), 0)
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > unwrap(Error(""), 0)
 /// 0
 /// ```
@@ -176,7 +196,9 @@ pub fn unwrap(result: Result(a, e), or default: a) -> a {
 /// ```gleam
 /// > lazy_unwrap(Ok(1), fn() { 0 })
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > lazy_unwrap(Error(""), fn() { 0 })
 /// 0
 /// ```
@@ -196,7 +218,9 @@ pub fn lazy_unwrap(result: Result(a, e), or default: fn() -> a) -> a {
 /// ```gleam
 /// > unwrap_error(Error(1), 0)
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > unwrap_error(Ok(""), 0)
 /// 0
 /// ```
@@ -216,7 +240,9 @@ pub fn unwrap_error(result: Result(a, e), or default: e) -> e {
 /// ```gleam
 /// > unwrap_both(Error(1))
 /// 1
+/// ```
 ///
+/// ```gleam
 /// > unwrap_both(Ok(2))
 /// 2
 /// ```
@@ -235,7 +261,9 @@ pub fn unwrap_both(result: Result(a, a)) -> a {
 /// ```gleam
 /// > nil_error(Error(1))
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > nil_error(Ok(1))
 /// Ok(1)
 /// ```
@@ -251,13 +279,19 @@ pub fn nil_error(result: Result(a, e)) -> Result(a, Nil) {
 /// ```gleam
 /// > or(Ok(1), Ok(2))
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > or(Ok(1), Error("Error 2"))
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > or(Error("Error 1"), Ok(2))
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > or(Error("Error 1"), Error("Error 2"))
 /// Error("Error 2")
 /// ```
@@ -276,13 +310,19 @@ pub fn or(first: Result(a, e), second: Result(a, e)) -> Result(a, e) {
 /// ```gleam
 /// > lazy_or(Ok(1), fn() { Ok(2) })
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > lazy_or(Ok(1), fn() { Error("Error 2") })
 /// Ok(1)
+/// ```
 ///
+/// ```gleam
 /// > lazy_or(Error("Error 1"), fn() { Ok(2) })
 /// Ok(2)
+/// ```
 ///
+/// ```gleam
 /// > lazy_or(Error("Error 1"), fn() { Error("Error 2") })
 /// Error("Error 2")
 /// ```
@@ -306,7 +346,9 @@ pub fn lazy_or(
 /// ```gleam
 /// > all([Ok(1), Ok(2)])
 /// Ok([1, 2])
+/// ```
 ///
+/// ```gleam
 /// > all([Ok(1), Error("e")])
 /// Error("e")
 /// ```
@@ -322,7 +364,9 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
 /// ```gleam
 /// > replace(Ok(1), Nil)
 /// Ok(Nil)
+/// ```
 ///
+/// ```gleam
 /// > replace(Error(1), Nil)
 /// Error(1)
 /// ```
@@ -341,7 +385,9 @@ pub fn replace(result: Result(a, e), value: b) -> Result(b, e) {
 /// ```gleam
 /// > replace_error(Error(1), Nil)
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > replace_error(Ok(1), Nil)
 /// Ok(1)
 /// ```

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -156,9 +156,7 @@ pub fn then(
 /// ```gleam
 /// > unwrap(Ok(1), 0)
 /// 1
-/// ```
 ///
-/// ```gleam
 /// > unwrap(Error(""), 0)
 /// 0
 /// ```
@@ -178,9 +176,7 @@ pub fn unwrap(result: Result(a, e), or default: a) -> a {
 /// ```gleam
 /// > lazy_unwrap(Ok(1), fn() { 0 })
 /// 1
-/// ```
 ///
-/// ```gleam
 /// > lazy_unwrap(Error(""), fn() { 0 })
 /// 0
 /// ```
@@ -200,9 +196,7 @@ pub fn lazy_unwrap(result: Result(a, e), or default: fn() -> a) -> a {
 /// ```gleam
 /// > unwrap_error(Error(1), 0)
 /// 1
-/// ```
 ///
-/// ```gleam
 /// > unwrap_error(Ok(""), 0)
 /// 0
 /// ```
@@ -222,9 +216,7 @@ pub fn unwrap_error(result: Result(a, e), or default: e) -> e {
 /// ```gleam
 /// > unwrap_both(Error(1))
 /// 1
-/// ```
 ///
-/// ```gleam
 /// > unwrap_both(Ok(2))
 /// 2
 /// ```
@@ -314,9 +306,7 @@ pub fn lazy_or(
 /// ```gleam
 /// > all([Ok(1), Ok(2)])
 /// Ok([1, 2])
-/// ```
 ///
-/// ```gleam
 /// > all([Ok(1), Error("e")])
 /// Error("e")
 /// ```
@@ -332,9 +322,7 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
 /// ```gleam
 /// > replace(Ok(1), Nil)
 /// Ok(Nil)
-/// ```
 ///
-/// ```gleam
 /// > replace(Error(1), Nil)
 /// Error(1)
 /// ```
@@ -353,9 +341,7 @@ pub fn replace(result: Result(a, e), value: b) -> Result(b, e) {
 /// ```gleam
 /// > replace_error(Error(1), Nil)
 /// Error(Nil)
-/// ```
 ///
-/// ```gleam
 /// > replace_error(Ok(1), Nil)
 /// Ok(1)
 /// ```
@@ -371,7 +357,7 @@ pub fn replace_error(result: Result(a, e1), error: e2) -> Result(a, e2) {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > values([Ok(1), None, Ok(3)])
 /// [1, 3]
 /// ```

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -214,8 +214,8 @@ fn order(first: Set(member), second: Set(member)) -> #(Set(member), Set(member))
 /// ## Examples
 ///
 /// ```gleam
-///  > union(from_list([1, 2]), from_list([2, 3])) |> to_list
-///  [1, 2, 3]
+/// > union(from_list([1, 2]), from_list([2, 3])) |> to_list
+/// [1, 2, 3]
 /// ```
 ///
 pub fn union(of first: Set(member), and second: Set(member)) -> Set(member) {
@@ -230,8 +230,8 @@ pub fn union(of first: Set(member), and second: Set(member)) -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-///  > intersection(from_list([1, 2]), from_list([2, 3])) |> to_list
-///  [2]
+/// > intersection(from_list([1, 2]), from_list([2, 3])) |> to_list
+/// [2]
 /// ```
 ///
 pub fn intersection(

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -40,7 +40,10 @@ pub fn new() -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert(1) |> insert(2) |> size
+/// > new()
+/// > |> insert(1)
+/// > |> insert(2)
+/// > |> size
 /// 2
 /// ```
 ///
@@ -55,7 +58,10 @@ pub fn size(set: Set(member)) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert(1) |> insert(2) |> size
+/// > new()
+/// > |> insert(1)
+/// > |> insert(2)
+/// > |> size
 /// 2
 /// ```
 ///
@@ -70,10 +76,16 @@ pub fn insert(into set: Set(member), this member: member) -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert(2) |> contains(2)
+/// > new()
+/// > |> insert(2)
+/// > |> contains(2)
 /// True
+/// ```
 ///
-/// > new() |> insert(2) |> contains(1)
+/// ```gleam
+/// > new()
+/// > |> insert(2)
+/// > |> contains(1)
 /// False
 /// ```
 ///
@@ -91,7 +103,10 @@ pub fn contains(in set: Set(member), this member: member) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert(2) |> delete(2) |> contains(1)
+/// > new()
+/// > |> insert(2)
+/// > |> delete(2)
+/// > |> contains(1)
 /// False
 /// ```
 ///
@@ -192,7 +207,9 @@ pub fn filter(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3]) |> take([1, 3, 5]) |> to_list
+/// > from_list([1, 2, 3])
+/// > |> take([1, 3, 5])
+/// > |> to_list
 /// [1, 3]
 /// ```
 ///

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -688,6 +688,7 @@ if javascript {
 /// pattern match on `String`s exactly as you would with lists.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > pop_grapheme("gleam")
 /// Ok(#("g", "leam"))

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -19,7 +19,9 @@ if erlang {
 /// ```gleam
 /// > is_empty("")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > is_empty("the world")
 /// False
 /// ```
@@ -38,10 +40,14 @@ pub fn is_empty(str: String) -> Bool {
 /// ```gleam
 /// > length("Gleam")
 /// 5
+/// ```
 ///
+/// ```gleam
 /// > length("ß↑e̊")
 /// 3
+/// ```
 ///
+/// ```gleam
 /// > length("")
 /// 0
 /// ```
@@ -101,7 +107,9 @@ if javascript {
 /// ```gleam
 /// > replace("www.example.com", each: ".", with: "-")
 /// "www-example-com"
+/// ```
 ///
+/// ```gleam
 /// > replace("a,b,c,d,e", each: ",", with: "/")
 /// "a/b/c/d/e"
 /// ```
@@ -178,7 +186,9 @@ if javascript {
 /// ```gleam
 /// > compare("Anthony", "Anthony")
 /// order.Eq
+/// ```
 ///
+/// ```gleam
 /// > compare("A", "B")
 /// order.Lt
 /// ```
@@ -212,16 +222,24 @@ if javascript {
 /// ```gleam
 /// > slice(from: "gleam", at_index: 1, length: 2)
 /// "le"
+/// ```
 ///
+/// ```gleam
 /// > slice(from: "gleam", at_index: 1, length: 10)
 /// "leam"
+/// ```
 ///
+/// ```gleam
 /// > slice(from: "gleam", at_index: 10, length: 3)
 /// ""
+/// ```
 ///
+/// ```gleam
 /// > slice(from: "gleam", at_index: -2, length: 2)
 /// "am"
+/// ```
 ///
+/// ```gleam
 /// > slice(from: "gleam", at_index: -12, length: 2)
 /// ""
 /// ```
@@ -328,10 +346,14 @@ pub fn drop_right(from string: String, up_to num_graphemes: Int) -> String {
 /// ```gleam
 /// > contains(does: "theory", contain: "ory")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > contains(does: "theory", contain: "the")
 /// True
+/// ```
 ///
+/// ```gleam
 /// > contains(does: "theory", contain: "THE")
 /// False
 /// ```
@@ -433,7 +455,9 @@ pub fn split(x: String, on substring: String) -> List(String) {
 /// ```gleam
 /// > split_once("home/gleam/desktop/", on: "/")
 /// Ok(#("home", "gleam/desktop/"))
+/// ```
 ///
+/// ```gleam
 /// > split_once("home/gleam/desktop/", on: "?")
 /// Error(Nil)
 /// ```
@@ -549,10 +573,14 @@ pub fn join(strings: List(String), with separator: String) -> String {
 /// ```gleam
 /// > pad_left("121", to: 5, with: ".")
 /// "..121"
+/// ```
 ///
+/// ```gleam
 /// > pad_left("121", to: 3, with: ".")
 /// "121"
+/// ```
 ///
+/// ```gleam
 /// > pad_left("121", to: 2, with: ".")
 /// "121"
 /// ```
@@ -571,14 +599,18 @@ pub fn pad_left(string: String, to desired_length: Int, with pad_string: String)
 /// ## Examples
 ///
 /// ```gleam
-/// > pad_right("121", to: 5, with: ".")
-/// "121.."
+/// > pad_right("123", to: 5, with: ".")
+/// "123.."
+/// ```
 ///
-/// > pad_right("121", to: 3, with: ".")
-/// "121"
+/// ```gleam
+/// > pad_right("123", to: 3, with: ".")
+/// "123"
+/// ```
 ///
-/// > pad_right("121", to: 2, with: ".")
-/// "121"
+/// ```gleam
+/// > pad_right("123", to: 2, with: ".")
+/// "123"
 /// ```
 ///
 pub fn pad_right(
@@ -692,7 +724,9 @@ if javascript {
 /// ```gleam
 /// > pop_grapheme("gleam")
 /// Ok(#("g", "leam"))
+/// ```
 ///
+/// ```gleam
 /// > pop_grapheme("")
 /// Error(Nil)
 /// ```
@@ -711,7 +745,8 @@ if javascript {
     "../gleam_stdlib.mjs" "pop_grapheme"
 }
 
-/// Converts a `String` to a list of graphemes.
+/// Converts a `String` to a list of
+/// [graphemes](https://en.wikipedia.org/wiki/Grapheme).
 ///
 /// ```gleam
 /// > to_graphemes("abc")
@@ -753,14 +788,17 @@ pub fn utf_codepoint(value: Int) -> Result(UtfCodepoint, Nil) {
   }
 }
 
-/// Converts a `String` into `Option(String)` where an empty `String` becomes `None`.
+/// Converts a `String` into `Option(String)` where an empty `String` becomes
+/// `None`.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > to_option("")
 /// None
+/// ```
 ///
+/// ```gleam
 /// > to_option("hats")
 /// Some("hats")
 /// ```
@@ -781,7 +819,9 @@ pub fn to_option(s: String) -> Option(String) {
 /// ```gleam
 /// > first("")
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > first("icecream")
 /// Ok("i")
 /// ```
@@ -802,7 +842,9 @@ pub fn first(s: String) -> Result(String, Nil) {
 /// ```gleam
 /// > last("")
 /// Error(Nil)
+/// ```
 ///
+/// ```gleam
 /// > last("icecream")
 /// Ok("m")
 /// ```

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -208,6 +208,7 @@ if javascript {
 /// are taken starting from the *end* of the list.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > slice(from: "gleam", at_index: 1, length: 2)
 /// "le"
@@ -261,6 +262,7 @@ if javascript {
 /// If the `from` string does not contain the `before` string, `from` is returned unchanged.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > crop(from: "The Lone Gunmen", before: "Lone")
 /// "Lone Gunmen"
@@ -290,6 +292,7 @@ if javascript {
 /// Drops *n* graphemes from the left side of a `String`.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > drop_left(from: "The Lone Gunmen", up_to: 2)
 /// "e Lone Gunmen"
@@ -305,6 +308,7 @@ pub fn drop_left(from string: String, up_to num_graphemes: Int) -> String {
 /// Drops *n* graphemes from the right side of a `String`.
 ///
 /// ## Examples
+///
 /// ```gleam
 /// > drop_right(from: "Cigarette Smoking Man", up_to: 2)
 /// "Cigarette Smoking M"
@@ -755,9 +759,7 @@ pub fn utf_codepoint(value: Int) -> Result(UtfCodepoint, Nil) {
 /// ```gleam
 /// > to_option("")
 /// None
-/// ```
 ///
-/// ```gleam
 /// > to_option("hats")
 /// Some("hats")
 /// ```
@@ -778,9 +780,7 @@ pub fn to_option(s: String) -> Option(String) {
 /// ```gleam
 /// > first("")
 /// Error(Nil)
-/// ```
 ///
-/// ```gleam
 /// > first("icecream")
 /// Ok("i")
 /// ```
@@ -801,9 +801,7 @@ pub fn first(s: String) -> Result(String, Nil) {
 /// ```gleam
 /// > last("")
 /// Error(Nil)
-/// ```
 ///
-/// ```gleam
 /// > last("icecream")
 /// Ok("m")
 /// ```
@@ -833,7 +831,7 @@ pub fn capitalise(s: String) -> String {
   }
 }
 
-/// Returns a `String` representation of values in Gleam syntax.
+/// Returns a `String` representation of a term in Gleam syntax.
 ///
 pub fn inspect(term: anything) -> String {
   do_inspect(term)

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -300,7 +300,9 @@ if javascript {
 /// ```gleam
 /// > from_strings(["a", "b"]) == from_string("ab")
 /// False
+/// ```
 ///
+/// ```gleam
 /// > is_equal(from_strings(["a", "b"]), from_string("ab"))
 /// True
 /// ```
@@ -326,10 +328,14 @@ if javascript {
 /// ```gleam
 /// > from_string("ok") |> is_empty
 /// False
+/// ```
 ///
+/// ```gleam
 /// > from_string("") |> is_empty
 /// True
+/// ```
 ///
+/// ```gleam
 /// > from_strings([]) |> is_empty
 /// True
 /// ```

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -37,13 +37,23 @@ pub type Uri {
 /// Parses a compliant URI string into the `Uri` Type.
 /// If the string is not a valid URI string then an error is returned.
 ///
-/// The opposite operation is `uri.to_string`
+/// The opposite operation is `uri.to_string`.
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > parse("https://example.com:1234/a/b?query=true#fragment")
-/// Ok(Uri(scheme: Some("https"), ...))
+/// Ok(
+///   Uri(
+///     scheme: Some("https"),
+///     userinfo: None,
+///     host: Some("example.com"),
+///     port: Some(1234),
+///     path: "/a/b",
+///     query: Some("query=true"),
+///     fragment: Some("fragment")
+///   )
+/// )
 /// ```
 ///
 pub fn parse(uri_string: String) -> Result(Uri, Nil) {
@@ -406,7 +416,8 @@ fn join_segments(segments: List(String)) -> String {
 /// Resolves a URI with respect to the given base URI.
 ///
 /// The base URI must be an absolute URI or this function will return an error.
-/// The algorithm for merging uris is described in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-5.2)
+/// The algorithm for merging uris is described in
+/// [RFC 3986](https://tools.ietf.org/html/rfc3986#section-5.2).
 ///
 pub fn merge(base: Uri, relative: Uri) -> Result(Uri, Nil) {
   case base {

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -4,7 +4,7 @@
 //// URIs or encoding query strings). The functions in this module are implemented
 //// according to [RFC 3986](https://tools.ietf.org/html/rfc3986).
 ////
-//// Query encoding (Form encoding) is defined in the 
+//// Query encoding (Form encoding) is defined in the
 //// [W3C specification](https://www.w3.org/TR/html52/sec-forms.html#urlencoded-form-data).
 
 import gleam/int
@@ -41,9 +41,8 @@ pub type Uri {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > parse("https://example.com:1234/a/b?query=true#fragment")
-///
 /// Ok(Uri(scheme: Some("https"), ...))
 /// ```
 ///
@@ -190,9 +189,8 @@ if javascript {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > parse_query("a=1&b=2")
-///
 /// Ok([#("a", "1"), #("b", "2")])
 /// ```
 ///
@@ -216,9 +214,8 @@ if javascript {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > query_to_string([#("a", "1"), #("b", "2")])
-///
 /// "a=1&b=2"
 /// ```
 ///
@@ -242,9 +239,8 @@ fn query_pair(pair: #(String, String)) -> StringBuilder {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > percent_encode("100% great")
-///
 /// "100%25%20great"
 /// ```
 ///
@@ -266,9 +262,8 @@ if javascript {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > percent_decode("100%25+great")
-///
 /// Ok("100% great")
 /// ```
 ///
@@ -316,9 +311,8 @@ fn remove_dot_segments(input: List(String)) -> List(String) {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > path_segments("/users/1")
-///
 /// ["users" ,"1"]
 /// ```
 ///
@@ -332,10 +326,9 @@ pub fn path_segments(path: String) -> List(String) {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > let uri = Uri(Some("http"), None, Some("example.com"), ...)
 /// > to_string(uri)
-///
 /// "https://example.com"
 /// ```
 ///
@@ -377,10 +370,9 @@ pub fn to_string(uri: Uri) -> String {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```gleam
 /// > assert Ok(uri) = parse("http://example.com/path?foo#bar")
 /// > origin(uri)
-///
 /// Ok("http://example.com")
 /// ```
 ///


### PR DESCRIPTION
- add missing gleam markdown prefixes.
- add newlines around Example headers and below source code blocks in docblocks.
- remove trailing line spaces
- remove unnecessary leading spaces
- remove double empty lines
- split multiple examples into multiple `'''gleam` blocks. ~~merge multiple Example blocks into one as that's the majorily common pattern.~~
- do not specify the module name you are in for docblocks
- add some missing imports of references modules/functions