### PR TITLE
Remove erlang ffi `decode_thunk` as it seems to be used nowhere

### DIFF
--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -1,7 +1,7 @@
 -module(gleam_stdlib).
 
 -export([map_get/2, iodata_append/2, identity/1, decode_int/1, decode_bool/1,
-         decode_float/1, decode_thunk/1, decode_list/1, decode_option/2,
+         decode_float/1, decode_list/1, decode_option/2,
          decode_field/2, parse_int/1, parse_float/1, less_than/2,
          string_pop_grapheme/1, string_starts_with/2, wrap_list/1,
          string_ends_with/2, string_pad/4, decode_map/1, uri_parse/1,
@@ -72,9 +72,6 @@ decode_float(Data) -> decode_error_msg(<<"Float">>, Data).
 
 decode_bool(Data) when is_boolean(Data) -> {ok, Data};
 decode_bool(Data) -> decode_error_msg(<<"Bool">>, Data).
-
-decode_thunk(Data) when is_function(Data, 0) -> {ok, Data};
-decode_thunk(Data) -> decode_error_msg("zero arity function", Data).
 
 decode_list(Data) when is_list(Data) -> {ok, Data};
 decode_list(Data) -> decode_error_msg(<<"List">>, Data).


### PR DESCRIPTION
While editing `function.curry2` I've realized it speaks of arity and I have looked where else stdlib talks about arity and the only other place was `decode_thunk`.

I don't know what `decode_thunk` had been used for but it seems it is not being used anymore, is it?

If it still is removed I'd rephrase `zero arity function` to `function with 0 arguments`?