### PR TITLE
Add string.utf_codepoint_to_int

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -768,11 +768,17 @@ fn do_to_graphemes(string: String, acc: List(String)) -> List(String) {
 if erlang {
   external fn unsafe_int_to_utf_codepoint(Int) -> UtfCodepoint =
     "gleam_stdlib" "identity"
+
+  external fn unsafe_utf_codepoint_to_int(UtfCodepoint) -> Int =
+    "gleam_stdlib" "identity"
 }
 
 if javascript {
   external fn unsafe_int_to_utf_codepoint(Int) -> UtfCodepoint =
     "../gleam_stdlib.mjs" "codepoint"
+
+  external fn unsafe_utf_codepoint_to_int(UtfCodepoint) -> Int =
+    "../gleam_stdlib.mjs" "codepoint_to_int"
 }
 
 /// Converts an integer to a `UtfCodepoint`.
@@ -786,6 +792,11 @@ pub fn utf_codepoint(value: Int) -> Result(UtfCodepoint, Nil) {
     i if i >= 55296 && i <= 57343 -> Error(Nil)
     i -> Ok(unsafe_int_to_utf_codepoint(i))
   }
+}
+
+/// Converts a `UtfCodepoint` to an integer.
+pub fn utf_codepoint_to_int(codepoint: UtfCodepoint) -> Int {
+  unsafe_utf_codepoint_to_int(codepoint)
 }
 
 /// Converts a `String` into `Option(String)` where an empty `String` becomes

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -281,6 +281,10 @@ export function codepoint(int) {
   return new UtfCodepoint(int);
 }
 
+export function codepoint_to_int(codepoint) {
+  return codepoint.value;
+}
+
 export function regex_check(regex, string) {
   return regex.test(string);
 }

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -415,6 +415,11 @@ pub fn utf_codepoint_test() {
 
   string.utf_codepoint(55296)
   |> should.be_error
+
+  assert Ok(star) = string.utf_codepoint(127775)
+  star
+  |> string.utf_codepoint_to_int
+  |> should.equal(127775)
 }
 
 pub fn bit_string_utf_codepoint_test() {


### PR DESCRIPTION
As discussed in https://github.com/gleam-lang/gleam/discussions/1877#discussioncomment-4301358 I took a stab at implementing this.

Allows conversion from `UtfCodepoint` to `Int`