### PR TITLE
JS/Firefox: also match newlines in string.length and string.pop_grapheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - The `io.debug` function now prints to stderr instead of stdout when using
   the Erlang target or running in Node.js (but still uses `console.log`
   when running as JavaScript in a browser)
+- The `string` module takes into account newlines for `length` and
+  various other functions in Firefox
 
 ## v0.25.0 - 2022-11-19
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -89,7 +89,7 @@ export function string_length(string) {
     }
     return i;
   } else {
-    return string.match(/./gu).length;
+    return string.match(/./gus).length;
   }
 }
 
@@ -111,7 +111,7 @@ export function pop_grapheme(string) {
   if (iterator) {
     first = iterator.next().value?.segment;
   } else {
-    first = string.match(/./u)?.[0];
+    first = string.match(/./us)?.[0];
   }
   if (first) {
     return new Ok([first, string.slice(first.length)]);


### PR DESCRIPTION
Following discussion on Discord. This only applies to the Firefox, which fails the Intl.Segmenter