### PR TITLE
Add iterator.transform()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The `io.debug` function now prints to stderr instead of stdout when using
   the Erlang target or running in Node.js (but still uses `console.log`
   when running as JavaScript in a browser)
+- The `iterator` module gains the `transform` function.
 - The `list.at` function now returns `Error(Nil)` if given index is smaller than
   zero, instead of returning the first element.
 - Fixed a bug where some string functions would incorrectly handle newlines when

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -69,6 +69,14 @@ pub fn take_test() {
   test(22, [0, 1, 2, 3, 4])
 }
 
+pub fn transform_test() {
+  ["a", "b", "c", "d"]
+  |> iterator.from_list
+  |> iterator.transform(0, fn(i, el) { Next(#(i, el), i + 1) })
+  |> iterator.to_list
+  |> should.equal([#(0, "a"), #(1, "b"), #(2, "c"), #(3, "d")])
+}
+
 // a |> from_list |> fold(a, f) == a |> list.fold(_, a, f)
 pub fn fold_test() {
   let test = fn(subject, acc, f) {

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -69,12 +69,57 @@ pub fn take_test() {
   test(22, [0, 1, 2, 3, 4])
 }
 
-pub fn transform_test() {
+pub fn transform_index_test() {
+  let f = fn(i, el) { Next(#(i, el), i + 1) }
+
   ["a", "b", "c", "d"]
   |> iterator.from_list
-  |> iterator.transform(0, fn(i, el) { Next(#(i, el), i + 1) })
+  |> iterator.transform(0, f)
   |> iterator.to_list
   |> should.equal([#(0, "a"), #(1, "b"), #(2, "c"), #(3, "d")])
+}
+
+pub fn transform_take_test() {
+  let f = fn(rem, el) {
+    case rem > 0 {
+      False -> Done
+      True -> Next(el, rem - 1)
+    }
+  }
+
+  [1, 2, 3, 4, 5]
+  |> iterator.from_list
+  |> iterator.transform(3, f)
+  |> iterator.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn transform_take_while_test() {
+  let f = fn(_, el) {
+    case el < 3 {
+      True -> Next(el, Nil)
+      False -> Done
+    }
+  }
+
+  [1, 2, 3, 2, 4]
+  |> iterator.from_list
+  |> iterator.transform(Nil, f)
+  |> iterator.to_list
+  |> should.equal([1, 2])
+}
+
+pub fn transform_scan_test() {
+  let f = fn(acc, el) {
+    let result = acc + el
+    Next(result, result)
+  }
+
+  [1, 2, 3, 4, 5]
+  |> iterator.from_list
+  |> iterator.transform(0, f)
+  |> iterator.to_list
+  |> should.equal([1, 3, 6, 10, 15])
 }
 
 // a |> from_list |> fold(a, f) == a |> list.fold(_, a, f)


### PR DESCRIPTION
Rationale: this is a piece of missing surface in the public API to create various types of iterators without making `Iterator` itself public.
Notably, `map`, `take`, `take_while`, `index`, `scan`, can be fully written entirely using `transform` and `Step`.

todo:
- [x] test
- [x] changelog