### PR TITLE
Fix Inaccurate Examples in Function Documentation

### DIFF
--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -1293,7 +1293,7 @@ pub fn decode7(
 ///
 /// ```gleam
 /// > from(#(1, 2.1, "3", "4", "5", "6", "7", "8"))
-/// > |> decode7(
+/// > |> decode8(
 /// >   MyRecord,
 /// >   element(0, int),
 /// >   element(1, float),
@@ -1309,7 +1309,7 @@ pub fn decode7(
 ///
 /// ```gleam
 /// > from(#("", "", "", "", "", "", "", ""))
-/// > |> decode7(
+/// > |> decode8(
 /// >   MyRecord,
 /// >   element(0, int),
 /// >   element(1, float),
@@ -1362,7 +1362,7 @@ pub fn decode8(
 ///
 /// ```gleam
 /// > from(#(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
-/// > |> decode7(
+/// > |> decode9(
 /// >   MyRecord,
 /// >   element(0, int),
 /// >   element(1, float),
@@ -1379,7 +1379,7 @@ pub fn decode8(
 ///
 /// ```gleam
 /// > from(#("", "", "", "", "", "", "", "", ""))
-/// > |> decode7(
+/// > |> decode9(
 /// >   MyRecord,
 /// >   element(0, int),
 /// >   element(1, float),

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -276,7 +276,7 @@ if javascript {
 /// ## Examples
 ///
 /// ```gleam
-/// > keys(from_list([#("a", 0), #("b", 1)]))
+/// > values(from_list([#("a", 0), #("b", 1)]))
 /// [0, 1]
 /// ```
 ///

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -339,7 +339,7 @@ pub fn path_segments(path: String) -> List(String) {
 /// ```gleam
 /// > let uri = Uri(Some("http"), None, Some("example.com"), ...)
 /// > to_string(uri)
-/// "https://example.com"
+/// "http://example.com"
 /// ```
 ///
 pub fn to_string(uri: Uri) -> String {


### PR DESCRIPTION
Fixing some inaccurate examples in function documentation. This includes:
- `map.values`
- `dynamic.decode8`
- `dynamic.decode9`
- `uri.to_string`