### PR TITLE
Add set drop functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The `float` module gains the `loosely_equals` function.
 - The `io` module gains `print_error` and `println_error` functions for
   printing to stderr.
+- The `set` module gains the `drop` function.
 - The `io.debug` function now prints to stderr instead of stdout when using
   the Erlang target or running in Node.js (but still uses `console.log`
   when running as JavaScript in a browser)

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -199,6 +199,10 @@ pub fn filter(
   Set(map.filter(in: set.map, for: fn(m, _) { property(m) }))
 }
 
+pub fn drop(from set: Set(member), drop disallowed: List(member)) -> Set(member) {
+  list.fold(over: disallowed, from: set, with: delete)
+}
+
 /// Creates a new map from a given map, only including any members which are in
 /// a given list.
 ///

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -80,6 +80,13 @@ pub fn take_test() {
   |> should.equal(set.from_list([1, 3]))
 }
 
+pub fn drop_test() {
+  ["a", "b", "c"]
+  |> set.from_list
+  |> set.drop(["a", "b", "d"])
+  |> should.equal(set.from_list(["c"]))
+}
+
 pub fn union_test() {
   set.union(set.from_list([1, 2]), set.from_list([2, 3]))
   |> set.to_list


### PR DESCRIPTION
Made to look as similar as possible to `map.drop`

I have used the same implementation in my project in several places for example
- https://github.com/midas-framework/project_wisdom/blob/cleanup/eyg/src/eyg/analysis/unification.gleam#L19