### PR TITLE
fix: deno print to match node implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Unreleased
-- The `io.print`, `io.print_error`, and `io.print_debug` now match the Node.Js
-  implementation when run with Deno.
+
+- Fixed a bug where `io.print`, `io.print_error`, and `io.print_debug` would use 
+  `console.log` and add `"\n"` to the output when running on Deno.
 
 ## v0.26.1 - 2023-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - For a given empty list as an argument, `int.product` now returns `1` instead
   of `0`, and `float.product` now returns `1.0` instead of `0.0`. This mimicks
   the behavior of Elixir's `Enum.product/1`.
+- The `io.print`, `io.print_error`, and `io.print_debug` now match the Node.Js
+  implementation when run with Deno.
 
 ## v0.26.0 - 2023-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- The `io.print`, `io.print_error`, and `io.print_debug` now match the Node.Js
+  implementation when run with Deno.
+
 ## v0.26.1 - 2023-02-02
 
 - The `prepend` function in the `list` module gains the `this` label.
@@ -9,8 +13,6 @@
 - For a given empty list as an argument, `int.product` now returns `1` instead
   of `0`, and `float.product` now returns `1.0` instead of `0.0`. This mimicks
   the behavior of Elixir's `Enum.product/1`.
-- The `io.print`, `io.print_error`, and `io.print_debug` now match the Node.Js
-  implementation when run with Deno.
 
 ## v0.26.0 - 2023-01-12
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -275,6 +275,8 @@ export function bit_string_to_string(bit_string) {
 export function print(string) {
   if (typeof process === "object") {
     process.stdout.write(string); // We can write without a trailing newline
+  } else if (typeof Deno === "object") {
+    Deno.stdout.writeSync(new TextEncoder().encode(string));
   } else {
     console.log(string); // We're in a browser. Newlines are mandated
   }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -276,7 +276,7 @@ export function print(string) {
   if (typeof process === "object") {
     process.stdout.write(string); // We can write without a trailing newline
   } else if (typeof Deno === "object") {
-    Deno.stdout.writeSync(new TextEncoder().encode(string));
+    Deno.stdout.writeSync(new TextEncoder().encode(string)); // We can write without a trailing newline
   } else {
     console.log(string); // We're in a browser. Newlines are mandated
   }
@@ -285,6 +285,8 @@ export function print(string) {
 export function print_error(string) {
   if (typeof process === "object") {
     process.stderr.write(string); // We can write without a trailing newline
+  } else if (typeof Deno === "object") {
+    Deno.stderr.writeSync(new TextEncoder().encode(string)); // We can write without a trailing newline
   } else {
     console.error(string); // We're in a browser. Newlines are mandated
   }
@@ -293,6 +295,8 @@ export function print_error(string) {
 export function print_debug(string) {
   if (typeof process === "object") {
     process.stderr.write(string + "\n"); // If we're in Node.js, use `stderr`
+  } else if (typeof Deno === "object") {
+    Deno.stderr.writeSync(new TextEncoder().encode(string + "\n")); // If we're in Deno, use `stderr`
   } else {
     console.log(string); // Otherwise, use `console.log` (so that it doesn't look like an error)
   }


### PR DESCRIPTION
Currently when using Deno `print`, `print_error`, and `print_debug` will default to `console.log`. This change makes the functions behave as they do on Node.