### PR TITLE
Fix edge-case in int.floor_divide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed a bug where `io.print`, `io.print_error`, and `io.print_debug` would use 
   `console.log` and add `"\n"` to the output when running on Deno.
+- Fixed a bug where `int.floor_divide` would return the wrong result in certain
+  edge-cases.
 
 ## v0.26.1 - 2023-02-02
 

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -759,13 +759,11 @@ pub fn modulo(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
   case divisor {
     0 -> Error(Nil)
-    divisor -> {
-      let quotient = dividend / divisor
-      case quotient < 0 && dividend % divisor != 0 {
-        True -> Ok(quotient - 1)
-        False -> Ok(quotient)
+    divisor ->
+      case dividend * divisor < 0 && dividend % divisor != 0 {
+        True -> Ok(dividend / divisor - 1)
+        False -> Ok(dividend / divisor)
       }
-    }
   }
 }
 

--- a/test/gleam/int_test.gleam
+++ b/test/gleam/int_test.gleam
@@ -521,6 +521,9 @@ pub fn floor_divide_test() {
 
   int.floor_divide(-99, by: 2)
   |> should.equal(Ok(-50))
+
+  int.floor_divide(-1, by: 2)
+  |> should.equal(Ok(-1))
 }
 
 pub fn add_test() {


### PR DESCRIPTION
`int.floor_divide(-1, by: 2)` currently returns `0`, instead of `-1`. I added a test case and basically copied what Elixir's [`Integer.floor_div/2`](https://github.com/elixir-lang/elixir/blob/v1.14.3/lib/elixir/lib/integer.ex#L163) does to fix the issue.