### PR TITLE
0.27 gleam fix && gleam format, replace some asserts with panics in tests

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1,3 +1,4 @@
+import gleam/result
 import gleam/int
 import gleam/list
 import gleam/map.{Map}
@@ -1295,7 +1296,7 @@ fn do_try_fold(
   case continuation() {
     Stop -> Ok(accumulator)
     Continue(elem, next) -> {
-      try accumulator = f(accumulator, elem)
+      use accumulator <- result.then(f(accumulator, elem))
       do_try_fold(next, f, accumulator)
     }
   }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -651,7 +651,7 @@ pub fn flatten(lists: List(List(a))) -> List(a) {
   do_flatten(lists, [])
 }
 
-/// Maps the list with the given function and then flattens the result.
+/// Maps the list with the given function and then flattens it.
 ///
 /// ## Examples
 ///
@@ -761,10 +761,11 @@ pub fn try_fold(
 ) -> Result(acc, e) {
   case collection {
     [] -> Ok(accumulator)
-    [first, ..rest] -> {
-      try accumulator = fun(accumulator, first)
-      try_fold(rest, accumulator, fun)
-    }
+    [first, ..rest] ->
+      case fun(accumulator, first) {
+        Ok(result) -> try_fold(rest, result, fun)
+        Error(_) as error -> error
+      }
   }
 }
 
@@ -1748,7 +1749,7 @@ fn do_chunk(
 }
 
 /// Returns a list of chunks in which
-/// the result of calling `f` on each element is the same.
+/// the return value of calling `f` on each element is the same.
 ///
 /// ## Examples
 ///

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -857,7 +857,7 @@ pub fn from_utf_codepoints(utf_codepoints: List(UtfCodepoint)) -> String {
 
 if erlang {
   fn do_from_utf_codepoints(utf_codepoints: List(UtfCodepoint)) -> String {
-    assert Ok(string) =
+    let assert Ok(string) =
       do_from_utf_codepoints_impl(utf_codepoints, bit_string.from_string(""))
       |> bit_string.to_string
     string

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -31,7 +31,7 @@ pub fn step_test() {
         |> should.equal(Done)
 
       [h, ..t] -> {
-        assert Next(h2, t2) = step
+        let assert Next(h2, t2) = step
         h
         |> should.equal(h2)
         t2

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -444,9 +444,7 @@ pub fn all_test() {
       1 -> True
       2 -> False
       // Crash if no short-circuit
-      _ -> {
-        assert True = False
-      }
+      _ -> panic
     }
   })
 
@@ -476,9 +474,7 @@ pub fn any_test() {
       1 -> False
       2 -> True
       // Crash if no short-circuit
-      _ -> {
-        assert True = False
-      }
+      _ -> panic
     }
   })
 
@@ -850,11 +846,11 @@ pub fn key_set_test() {
 }
 
 pub fn each_test() {
-  list.each([1, 1, 1], fn(x) { assert 1 = x })
+  list.each([1, 1, 1], fn(x) { let assert 1 = x })
   |> should.equal(Nil)
 
   // TCO test
-  list.each(list.repeat(1, recursion_test_cycles), fn(x) { assert 1 = x })
+  list.each(list.repeat(1, recursion_test_cycles), fn(x) { let assert 1 = x })
 }
 
 pub fn partition_test() {

--- a/test/gleam/queue_test.gleam
+++ b/test/gleam/queue_test.gleam
@@ -83,7 +83,7 @@ pub fn push_test() {
 }
 
 pub fn pop_back_test() {
-  assert Ok(tup) =
+  let assert Ok(tup) =
     [1, 2, 3]
     |> queue.from_list
     |> queue.pop_back
@@ -99,7 +99,7 @@ pub fn pop_back_test() {
 }
 
 pub fn pop_back_after_push_back_test() {
-  assert Ok(tup) =
+  let assert Ok(tup) =
     queue.new()
     |> queue.push_back(1)
     |> queue.push_back(2)
@@ -112,7 +112,7 @@ pub fn pop_back_after_push_back_test() {
 }
 
 pub fn pop_back_after_push_test() {
-  assert Ok(tup) =
+  let assert Ok(tup) =
     queue.new()
     |> queue.push_front("b")
     |> queue.push_back("x")
@@ -132,7 +132,7 @@ pub fn pop_back_empty_test() {
 }
 
 pub fn pop_front_test() {
-  assert Ok(tup) =
+  let assert Ok(tup) =
     [1, 2, 3]
     |> queue.from_list
     |> queue.pop_front
@@ -148,7 +148,7 @@ pub fn pop_front_test() {
 }
 
 pub fn pop_front_after_push_front_test() {
-  assert Ok(tup) =
+  let assert Ok(tup) =
     queue.new()
     |> queue.push_front(3)
     |> queue.push_front(2)
@@ -161,7 +161,7 @@ pub fn pop_front_after_push_front_test() {
 }
 
 pub fn pop_front_after_push_test() {
-  assert Ok(tup) =
+  let assert Ok(tup) =
     queue.new()
     |> queue.push_front("b")
     |> queue.push_back("x")

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -3,7 +3,7 @@ import gleam/regex.{Match, Options}
 import gleam/should
 
 pub fn from_string_test() {
-  assert Ok(re) = regex.from_string("[0-9]")
+  let assert Ok(re) = regex.from_string("[0-9]")
 
   regex.check(re, "abc123")
   |> should.be_true
@@ -11,31 +11,31 @@ pub fn from_string_test() {
   regex.check(re, "abcxyz")
   |> should.be_false
 
-  assert Error(_) = regex.from_string("[0-9")
+  let assert Error(_) = regex.from_string("[0-9")
 }
 
 pub fn compile_test() {
   let options = Options(case_insensitive: True, multi_line: False)
-  assert Ok(re) = regex.compile("[A-B]", options)
+  let assert Ok(re) = regex.compile("[A-B]", options)
 
   regex.check(re, "abc123")
   |> should.be_true
 
   let options = Options(case_insensitive: False, multi_line: True)
-  assert Ok(re) = regex.compile("^[0-9]", options)
+  let assert Ok(re) = regex.compile("^[0-9]", options)
 
   regex.check(re, "abc\n123")
   |> should.be_true
 
   // For Erlang: This test will only passes if unicode and ucp flags are set
-  assert Ok(re) = regex.compile("\\s", options)
+  let assert Ok(re) = regex.compile("\\s", options)
   // Em space == U+2003 == " " == used below
   regex.check(re, " ")
   |> should.be_true
 }
 
 pub fn check_test() {
-  assert Ok(re) = regex.from_string("^f.o.?")
+  let assert Ok(re) = regex.from_string("^f.o.?")
 
   regex.check(re, "foo")
   |> should.be_true
@@ -45,14 +45,14 @@ pub fn check_test() {
 }
 
 pub fn split_test() {
-  assert Ok(re) = regex.from_string(" *, *")
+  let assert Ok(re) = regex.from_string(" *, *")
 
   regex.split(re, "foo,32, 4, 9  ,0")
   |> should.equal(["foo", "32", "4", "9", "0"])
 }
 
 pub fn scan_test() {
-  assert Ok(re) = regex.from_string("Gl\\w+")
+  let assert Ok(re) = regex.from_string("Gl\\w+")
 
   regex.scan(re, "!Gleam")
   |> should.equal([Match(content: "Gleam", submatches: [])])
@@ -63,7 +63,7 @@ pub fn scan_test() {
   regex.scan(re, "𐍈Gleam")
   |> should.equal([Match(content: "Gleam", submatches: [])])
 
-  assert Ok(re) = regex.from_string("[oi]n a(.?) (\\w+)")
+  let assert Ok(re) = regex.from_string("[oi]n a(.?) (\\w+)")
 
   regex.scan(re, "I am on a boat in a lake.")
   |> should.equal([
@@ -71,11 +71,11 @@ pub fn scan_test() {
     Match(content: "in a lake", submatches: [None, Some("lake")]),
   ])
 
-  assert Ok(re) = regex.from_string("answer (\\d+)")
+  let assert Ok(re) = regex.from_string("answer (\\d+)")
   regex.scan(re, "Is the answer 42?")
   |> should.equal([Match(content: "answer 42", submatches: [Some("42")])])
 
-  assert Ok(re) = regex.from_string("(\\d+)")
+  let assert Ok(re) = regex.from_string("(\\d+)")
   regex.scan(re, "hello 42")
   |> should.equal([Match(content: "42", submatches: [Some("42")])])
 

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -414,7 +414,7 @@ pub fn to_utf_codepoints_test() {
   "gleam"
   |> string.to_utf_codepoints
   |> should.equal({
-    assert #(Ok(g), Ok(l), Ok(e), Ok(a), Ok(m)) = #(
+    let assert #(Ok(g), Ok(l), Ok(e), Ok(a), Ok(m)) = #(
       string.utf_codepoint(103),
       string.utf_codepoint(108),
       string.utf_codepoint(101),
@@ -428,7 +428,7 @@ pub fn to_utf_codepoints_test() {
   |> string.to_utf_codepoints
   |> should.equal({
     // ["🏳", "️", "‍", "🌈"]
-    assert #(
+    let assert #(
       Ok(waving_white_flag),
       Ok(variant_selector_16),
       Ok(zero_width_joiner),
@@ -460,7 +460,7 @@ pub fn from_utf_codepoints_test() {
   |> should.equal("🏳️‍🌈")
 
   {
-    assert #(Ok(a), Ok(b), Ok(c)) = #(
+    let assert #(Ok(a), Ok(b), Ok(c)) = #(
       string.utf_codepoint(97),
       string.utf_codepoint(98),
       string.utf_codepoint(99),
@@ -483,13 +483,13 @@ pub fn utf_codepoint_test() {
 }
 
 pub fn bit_string_utf_codepoint_test() {
-  assert Ok(snake) = string.utf_codepoint(128_013)
+  let assert Ok(snake) = string.utf_codepoint(128_013)
   should.equal(<<snake:utf8_codepoint>>, <<"🐍":utf8>>)
 }
 
 pub fn utf_codepoint_to_int_test() {
   {
-    assert Ok(ordinal_value) = string.utf_codepoint(128_013)
+    let assert Ok(ordinal_value) = string.utf_codepoint(128_013)
     ordinal_value
   }
   |> string.utf_codepoint_to_int
@@ -948,14 +948,14 @@ if erlang {
     |> should.equal("#(1.0)")
 
     // Looks like `//erl(<0.83.0>)`.
-    assert Ok(regular_expression) =
+    let assert Ok(regular_expression) =
       regex.from_string("^\\/\\/erl\\(<[0-9]+\\.[0-9]+\\.[0-9]+>\\)$")
     string.inspect(create_erlang_pid())
     |> regex.check(regular_expression, _)
     |> should.be_true
 
     // Looks like: `//erl(#Ref<0.1809744150.4035444737.100468>)`.
-    assert Ok(regular_expression) =
+    let assert Ok(regular_expression) =
       regex.from_string(
         "^\\/\\/erl\\(#Ref<[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+>\\)$",
       )
@@ -972,7 +972,7 @@ if erlang {
 
   pub fn improper_list_inspect_test() {
     let list = improper_list_append(1, 2, 3)
-    assert "//erl([1, 2 | 3])" = string.inspect(list)
+    let assert "//erl([1, 2 | 3])" = string.inspect(list)
   }
 
   // Warning: The type of this function is incorrect

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -7,7 +7,7 @@ import gleam/string
 import gleam/uri
 
 pub fn full_parse_test() {
-  assert Ok(parsed) =
+  let assert Ok(parsed) =
     uri.parse("https://weebl:bob@example.com:1234/path?query=true#fragment")
   should.equal(parsed.scheme, Some("https"))
   should.equal(parsed.userinfo, Some("weebl:bob"))
@@ -19,7 +19,7 @@ pub fn full_parse_test() {
 }
 
 pub fn parse_only_path_test() {
-  assert Ok(parsed) = uri.parse("")
+  let assert Ok(parsed) = uri.parse("")
   should.equal(parsed.scheme, None)
   should.equal(parsed.userinfo, None)
   should.equal(parsed.host, None)
@@ -30,7 +30,7 @@ pub fn parse_only_path_test() {
 }
 
 pub fn parse_only_host_test() {
-  assert Ok(parsed) = uri.parse("//")
+  let assert Ok(parsed) = uri.parse("//")
   should.equal(parsed.scheme, None)
   should.equal(parsed.userinfo, None)
   should.equal(parsed.host, Some(""))
@@ -150,7 +150,7 @@ pub fn parse_ldap_2_scheme_test() {
 }
 
 fn assert_parse(s) {
-  assert Ok(u) = uri.parse(s)
+  let assert Ok(u) = uri.parse(s)
   u
 }
 
@@ -162,21 +162,21 @@ fn assert_parse(s) {
 //   assert "https" = uri.parse("https").path
 // }
 pub fn parse_downcases_scheme() {
-  assert Ok(uri) = uri.parse("HTTPS://EXAMPLE.COM")
-  assert Some("https") = uri.scheme
-  assert Some("EXAMPLE.COM") = uri.host
+  let assert Ok(uri) = uri.parse("HTTPS://EXAMPLE.COM")
+  let assert Some("https") = uri.scheme
+  let assert Some("EXAMPLE.COM") = uri.host
 }
 
 pub fn parse_empty_fragments_test() {
-  assert Some("") = assert_parse("http://example.com#").fragment
-  assert Some("") = assert_parse("http://example.com/#").fragment
-  assert Some("") = assert_parse("http://example.com/test#").fragment
+  let assert Some("") = assert_parse("http://example.com#").fragment
+  let assert Some("") = assert_parse("http://example.com/#").fragment
+  let assert Some("") = assert_parse("http://example.com/test#").fragment
 }
 
 pub fn parse_empty_queries_test() {
-  assert Some("") = assert_parse("http://example.com?").query
-  assert Some("") = assert_parse("http://example.com/?").query
-  assert Some("") = assert_parse("http://example.com/test?").query
+  let assert Some("") = assert_parse("http://example.com?").query
+  let assert Some("") = assert_parse("http://example.com/?").query
+  let assert Some("") = assert_parse("http://example.com/test?").query
 }
 
 pub fn full_uri_to_string_test() {
@@ -289,18 +289,18 @@ pub fn port_to_string_test() {
 }
 
 pub fn parse_query_string_test() {
-  assert Ok(parsed) = uri.parse_query("weebl+bob=1&city=%C3%B6rebro")
+  let assert Ok(parsed) = uri.parse_query("weebl+bob=1&city=%C3%B6rebro")
   should.equal(parsed, [#("weebl bob", "1"), #("city", "örebro")])
 
   // Duplicates keys not overridden
-  assert Ok(parsed) = uri.parse_query("a[]=1&a[]=2")
+  let assert Ok(parsed) = uri.parse_query("a[]=1&a[]=2")
 
   parsed
   |> should.equal([#("a[]", "1"), #("a[]", "2")])
 }
 
 pub fn parse_empty_query_string_test() {
-  assert Ok(parsed) = uri.parse_query("")
+  let assert Ok(parsed) = uri.parse_query("")
   should.equal(parsed, [])
 }
 
@@ -386,10 +386,10 @@ pub fn percent_decode_consistency_test() {
   let k = "weebl%20bob[]"
   let v = "%C3%B6rebro"
   let query = string.concat([k, "=", v])
-  assert Ok(parsed) = uri.parse_query(query)
+  let assert Ok(parsed) = uri.parse_query(query)
 
-  assert Ok(decoded_key) = uri.percent_decode(k)
-  assert Ok(decoded_value) = uri.percent_decode(v)
+  let assert Ok(decoded_key) = uri.percent_decode(k)
+  let assert Ok(decoded_value) = uri.percent_decode(v)
 
   should.equal(parsed, [#(decoded_key, decoded_value)])
 }
@@ -409,148 +409,148 @@ pub fn parse_segments_test() {
 }
 
 pub fn origin1_test() {
-  assert Ok(parsed) = uri.parse("http://example.test/path?weebl#bob")
+  let assert Ok(parsed) = uri.parse("http://example.test/path?weebl#bob")
   uri.origin(parsed)
   |> should.equal(Ok("http://example.test/"))
 }
 
 pub fn origin2_test() {
-  assert Ok(parsed) = uri.parse("http://example.test:8080")
+  let assert Ok(parsed) = uri.parse("http://example.test:8080")
   uri.origin(parsed)
   |> should.equal(Ok("http://example.test:8080/"))
 }
 
 pub fn origin3_test() {
-  assert Ok(parsed) = uri.parse("https://example.test")
+  let assert Ok(parsed) = uri.parse("https://example.test")
   uri.origin(parsed)
   |> should.equal(Ok("https://example.test/"))
 }
 
 pub fn origin4_test() {
-  assert Ok(parsed) = uri.parse("http:///path")
+  let assert Ok(parsed) = uri.parse("http:///path")
   uri.origin(parsed)
   |> should.equal(Ok("http://"))
 }
 
 pub fn origin5_test() {
-  assert Ok(parsed) = uri.parse("http://")
+  let assert Ok(parsed) = uri.parse("http://")
   uri.origin(parsed)
   |> should.equal(Ok("http://"))
 }
 
 pub fn origin6_test() {
-  assert Ok(parsed) = uri.parse("/path")
+  let assert Ok(parsed) = uri.parse("/path")
   uri.origin(parsed)
   |> should.equal(Error(Nil))
 }
 
 pub fn origin7_test() {
-  assert Ok(parsed) = uri.parse("file:///dev/null")
+  let assert Ok(parsed) = uri.parse("file:///dev/null")
   uri.origin(parsed)
   |> should.equal(Error(Nil))
 }
 
 pub fn merge1_test() {
-  assert Ok(a) = uri.parse("/relative")
-  assert Ok(b) = uri.parse("")
+  let assert Ok(a) = uri.parse("/relative")
+  let assert Ok(b) = uri.parse("")
   uri.merge(a, b)
   |> should.equal(Error(Nil))
 }
 
 pub fn merge2_test() {
-  assert Ok(a) = uri.parse("http://google.com/weebl")
-  assert Ok(b) = uri.parse("http://example.com/baz")
+  let assert Ok(a) = uri.parse("http://google.com/weebl")
+  let assert Ok(b) = uri.parse("http://example.com/baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge3_test() {
-  assert Ok(a) = uri.parse("http://google.com/weebl")
-  assert Ok(b) = uri.parse("http://example.com/.././bob/../../baz")
+  let assert Ok(a) = uri.parse("http://google.com/weebl")
+  let assert Ok(b) = uri.parse("http://example.com/.././bob/../../baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge4_test() {
-  assert Ok(a) = uri.parse("http://google.com/weebl")
-  assert Ok(b) = uri.parse("//example.com/baz")
+  let assert Ok(a) = uri.parse("http://google.com/weebl")
+  let assert Ok(b) = uri.parse("//example.com/baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge5_test() {
-  assert Ok(a) = uri.parse("http://google.com/weebl")
-  assert Ok(b) = uri.parse("//example.com/.././bob/../../../baz")
+  let assert Ok(a) = uri.parse("http://google.com/weebl")
+  let assert Ok(b) = uri.parse("//example.com/.././bob/../../../baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge6_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob")
-  assert Ok(b) = uri.parse("/baz")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob")
+  let assert Ok(b) = uri.parse("/baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge7_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob")
-  assert Ok(b) = uri.parse("baz")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob")
+  let assert Ok(b) = uri.parse("baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/baz"))
 }
 
 pub fn merge8_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/")
-  assert Ok(b) = uri.parse("baz")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/")
+  let assert Ok(b) = uri.parse("baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/baz"))
 }
 
 pub fn merge9_test() {
-  assert Ok(a) = uri.parse("http://example.com")
-  assert Ok(b) = uri.parse("baz")
+  let assert Ok(a) = uri.parse("http://example.com")
+  let assert Ok(b) = uri.parse("baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge10_test() {
-  assert Ok(a) = uri.parse("http://example.com")
-  assert Ok(b) = uri.parse("/.././bob/../../../baz")
+  let assert Ok(a) = uri.parse("http://example.com")
+  let assert Ok(b) = uri.parse("/.././bob/../../../baz")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/baz"))
 }
 
 pub fn merge11_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob")
-  assert Ok(b) = uri.parse("")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob")
+  let assert Ok(b) = uri.parse("")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/bob"))
 }
 
 pub fn merge12_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob")
-  assert Ok(b) = uri.parse("#fragment")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob")
+  let assert Ok(b) = uri.parse("#fragment")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/bob#fragment"))
 }
 
 pub fn merge13_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob")
-  assert Ok(b) = uri.parse("?query")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob")
+  let assert Ok(b) = uri.parse("?query")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/bob?query"))
 }
 
 pub fn merge14_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob?query1")
-  assert Ok(b) = uri.parse("?query2")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob?query1")
+  let assert Ok(b) = uri.parse("?query2")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/bob?query2"))
 }
 
 pub fn merge15_test() {
-  assert Ok(a) = uri.parse("http://example.com/weebl/bob?query")
-  assert Ok(b) = uri.parse("")
+  let assert Ok(a) = uri.parse("http://example.com/weebl/bob?query")
+  let assert Ok(b) = uri.parse("")
   uri.merge(a, b)
   |> should.equal(uri.parse("http://example.com/weebl/bob?query"))
 }


### PR DESCRIPTION
Also covers https://github.com/gleam-lang/stdlib/pull/416 (just because it was easier to run gleam fix/format and apply the one manual change)