### PR TITLE
Feature: Add `length` to the iterator module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## v0.27.0 - 2023-02-26
 
 - The `bool` module gains the `guard` function.
-- Fixed a bug where `io.print`, `io.print_error`, and `io.print_debug` would use 
+- Fixed a bug where `io.print`, `io.print_error`, and `io.print_debug` would use
   `console.log` and add `"\n"` to the output when running on Deno.
 - Fixed a bug where `int.floor_divide` would return the wrong result in certain
   edge-cases.
+- The `iterator` module gains the `length` function.
 
 ## v0.26.1 - 2023-02-02
 

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1380,3 +1380,32 @@ pub fn at(in iterator: Iterator(e), get index: Int) -> Result(e, Nil) {
   |> drop(index)
   |> first
 }
+
+fn do_length(over continuation: fn() -> Action(e), with length: Int) -> Int {
+  case continuation() {
+    Stop -> length
+    Continue(_, next) -> do_length(next, length + 1)
+  }
+}
+
+/// Counts the number of elements in the given iterator.
+///
+/// This function has to traverse the entire iterator to count its elements,
+/// so it runs in linear time. 
+///
+/// ## Examples
+/// 
+/// ```gleam
+/// > empty() |> count
+/// 0
+/// ```
+///
+/// ```gleam
+/// > from_list([1, 2, 3, 4]) |> count
+/// 4
+/// ```
+///
+pub fn length(in iterator: Iterator(e)) -> Int {
+  iterator.continuation
+  |> do_length(0)
+}

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1396,16 +1396,16 @@ fn do_length(over continuation: fn() -> Action(e), with length: Int) -> Int {
 /// ## Examples
 /// 
 /// ```gleam
-/// > empty() |> count
+/// > empty() |> length
 /// 0
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> count
+/// > from_list([1, 2, 3, 4]) |> length
 /// 4
 /// ```
 ///
-pub fn length(in iterator: Iterator(e)) -> Int {
+pub fn length(over iterator: Iterator(e)) -> Int {
   iterator.continuation
   |> do_length(0)
 }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -558,3 +558,17 @@ pub fn at_test() {
   |> iterator.at(0)
   |> should.equal(Error(Nil))
 }
+
+pub fn length_test() {
+  iterator.from_list([1])
+  |> iterator.length
+  |> should.equal(1)
+
+  iterator.from_list([1, 2, 3, 4])
+  |> iterator.length
+  |> should.equal(4)
+
+  iterator.empty()
+  |> iterator.length
+  |> should.equal(0)
+}


### PR DESCRIPTION
This PR adds `length` to the iterator module and resolves #382, thanks!