### PR TITLE
Fix `gleam/int.to_base36` doc comment

### DIFF
--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -261,7 +261,7 @@ pub fn to_base16(x: Int) -> String {
   do_to_base_string(x, 16)
 }
 
-/// Prints a given int to a string using base16.
+/// Prints a given int to a string using base36.
 ///
 /// ## Examples
 ///

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -222,7 +222,7 @@ if javascript {
     "../gleam_stdlib.mjs" "int_to_base_string"
 }
 
-/// Prints a given int to a string using base2.
+/// Prints a given int to a string using base-2.
 ///
 /// ## Examples
 ///
@@ -235,7 +235,7 @@ pub fn to_base2(x: Int) -> String {
   do_to_base_string(x, 2)
 }
 
-/// Prints a given int to a string using base8.
+/// Prints a given int to a string using base-8.
 ///
 /// ## Examples
 ///
@@ -248,7 +248,7 @@ pub fn to_base8(x: Int) -> String {
   do_to_base_string(x, 8)
 }
 
-/// Prints a given int to a string using base16.
+/// Prints a given int to a string using base-16.
 ///
 /// ## Examples
 ///
@@ -261,7 +261,7 @@ pub fn to_base16(x: Int) -> String {
   do_to_base_string(x, 16)
 }
 
-/// Prints a given int to a string using base36.
+/// Prints a given int to a string using base-36.
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
## Problem

The doc comment for `int.to_base36` says "Prints a given int to a string using base16."

## Solution

Change 16 to 36.

## Extra

I also updated the language in the comments to say base-2, base-8, base-16, base-36 instead of base2, base8, base16, base36 which looked unnatural to read to me. English is not my first language so I might be off base here and I can revert that commit if so. A quick look at Wikipedia (for binary, octal, hexadecimal etc. numbers) shows me examples with hyphens or spaces. Base36 is written like that on Wikipedia, but it looks like that is because the article is about an encoding with that name.