### PR TITLE
minor fix for one of `regex.scan`'s examples

### DIFF
--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -187,7 +187,7 @@ if javascript {
 /// > scan(with: re, content: "36")
 /// [
 ///   Match(
-///     content: "-36",
+///     content: "36",
 ///     submatches: [None, Some("36")]
 ///   )
 /// ]


### PR DESCRIPTION
Sorry, One of the examples had an issue. I missed a `-` sign!