### PR TITLE
Introduce ability to decode tuple from list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The `result` module gains the `partition` function.
+- `dynamic.tupleN` functions now support lists.
 
 ## v0.28.2 - 2023-05-09
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -682,15 +682,7 @@ fn ensure_tuple(
   value: Dynamic,
   desired_size: Int,
 ) -> Result(Dynamic, DecodeErrors) {
-  do_ensure_tuple(classify(value), value, desired_size)
-}
-
-fn do_ensure_tuple(
-  value_type: String,
-  value: Dynamic,
-  desired_size: Int,
-) -> Result(Dynamic, DecodeErrors) {
-  case value_type {
+  case classify(value) {
     "Tuple" <> _ -> assert_is_tuple(value, desired_size)
     "List" -> {
       use _ <- result.then(assert_is_list(value, desired_size))

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -99,23 +99,23 @@ decode_tuple(Data) -> decode_error_msg(<<"Tuple">>, Data).
 
 decode_tuple2({_,_} = A) -> {ok, A};
 decode_tuple2([A,B]) -> {ok, {A,B}};
-decode_tuple2(Data) -> decode_error_msg(<<"Tuple or List of 2 elements">>, Data).
+decode_tuple2(Data) -> decode_error_msg(<<"Tuple of 2 elements">>, Data).
 
 decode_tuple3({_,_,_} = A) -> {ok, A};
 decode_tuple3([A,B,C]) -> {ok, {A,B,C}};
-decode_tuple3(Data) -> decode_error_msg(<<"Tuple or List of 3 elements">>, Data).
+decode_tuple3(Data) -> decode_error_msg(<<"Tuple of 3 elements">>, Data).
 
 decode_tuple4({_,_,_,_} = A) -> {ok, A};
 decode_tuple4([A,B,C,D]) -> {ok, {A,B,C,D}};
-decode_tuple4(Data) -> decode_error_msg(<<"Tuple or List of 4 elements">>, Data).
+decode_tuple4(Data) -> decode_error_msg(<<"Tuple of 4 elements">>, Data).
 
 decode_tuple5({_,_,_,_,_} = A) -> {ok, A};
 decode_tuple5([A,B,C,D,E]) -> {ok, {A,B,C,D,E}};
-decode_tuple5(Data) -> decode_error_msg(<<"Tuple or List of 5 elements">>, Data).
+decode_tuple5(Data) -> decode_error_msg(<<"Tuple of 5 elements">>, Data).
 
 decode_tuple6({_,_,_,_,_,_} = A) -> {ok, A};
 decode_tuple6([A,B,C,D,E,F]) -> {ok, {A,B,C,D,E,F}};
-decode_tuple6(Data) -> decode_error_msg(<<"Tuple or List of 6 elements">>, Data).
+decode_tuple6(Data) -> decode_error_msg(<<"Tuple of 6 elements">>, Data).
 
 decode_option(Term, F) ->
     Decode = fun(Inner) ->

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -8,10 +8,11 @@
          bit_string_int_to_u32/1, bit_string_int_from_u32/1, decode_result/1,
          bit_string_slice/3, decode_bit_string/1, compile_regex/2, regex_scan/2,
          percent_encode/1, percent_decode/1, regex_check/2, regex_split/2,
-         base_decode64/1, parse_query/1, bit_string_concat/1, size_of_tuple/1,
-         decode_tuple/1, tuple_get/2, classify_dynamic/1, print/1, println/1,
-         print_error/1, println_error/1, inspect/1, float_to_string/1,
-         int_from_base_string/2, list_to_tuple/1]).
+         base_decode64/1, parse_query/1, bit_string_concat/1, size_of_tuple/1, 
+         decode_tuple/1, decode_tuple2/1, decode_tuple3/1, decode_tuple4/1,
+         decode_tuple5/1, decode_tuple6/1, tuple_get/2, classify_dynamic/1, 
+         print/1, println/1, print_error/1, println_error/1, inspect/1, 
+         float_to_string/1, int_from_base_string/2]).
 
 %% Taken from OTP's uri_string module
 -define(DEC2HEX(X),
@@ -95,6 +96,26 @@ tuple_get(Data, Index) -> {ok, element(Index + 1, Data)}.
 
 decode_tuple(Data) when is_tuple(Data) -> {ok, Data};
 decode_tuple(Data) -> decode_error_msg(<<"Tuple">>, Data).
+
+decode_tuple2({_,_} = A) -> {ok, A};
+decode_tuple2([A,B]) -> {ok, {A,B}};
+decode_tuple2(Data) -> decode_error_msg(<<"Tuple or List of 2 elements">>, Data).
+
+decode_tuple3({_,_,_} = A) -> {ok, A};
+decode_tuple3([A,B,C]) -> {ok, {A,B,C}};
+decode_tuple3(Data) -> decode_error_msg(<<"Tuple or List of 3 elements">>, Data).
+
+decode_tuple4({_,_,_,_} = A) -> {ok, A};
+decode_tuple4([A,B,C,D]) -> {ok, {A,B,C,D}};
+decode_tuple4(Data) -> decode_error_msg(<<"Tuple or List of 4 elements">>, Data).
+
+decode_tuple5({_,_,_,_,_} = A) -> {ok, A};
+decode_tuple5([A,B,C,D,E]) -> {ok, {A,B,C,D,E}};
+decode_tuple5(Data) -> decode_error_msg(<<"Tuple or List of 5 elements">>, Data).
+
+decode_tuple6({_,_,_,_,_,_} = A) -> {ok, A};
+decode_tuple6([A,B,C,D,E,F]) -> {ok, {A,B,C,D,E,F}};
+decode_tuple6(Data) -> decode_error_msg(<<"Tuple or List of 6 elements">>, Data).
 
 decode_option(Term, F) ->
     Decode = fun(Inner) ->
@@ -419,5 +440,3 @@ inspect_maybe_utf8_string(Binary, Acc) ->
 float_to_string(Float) when is_float(Float) ->
     erlang:iolist_to_binary(io_lib_format:fwrite_g(Float)).
 
-list_to_tuple(Data) when is_list(Data) -> {ok, erlang:list_to_tuple(Data)};
-list_to_tuple(Data) -> decode_error_msg(<<"List">>, Data).

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -11,7 +11,7 @@
          base_decode64/1, parse_query/1, bit_string_concat/1, size_of_tuple/1,
          decode_tuple/1, tuple_get/2, classify_dynamic/1, print/1, println/1,
          print_error/1, println_error/1, inspect/1, float_to_string/1,
-         int_from_base_string/2]).
+         int_from_base_string/2, list_to_tuple/1]).
 
 %% Taken from OTP's uri_string module
 -define(DEC2HEX(X),
@@ -418,3 +418,6 @@ inspect_maybe_utf8_string(Binary, Acc) ->
 
 float_to_string(Float) when is_float(Float) ->
     erlang:iolist_to_binary(io_lib_format:fwrite_g(Float)).
+
+list_to_tuple(Data) when is_list(Data) -> {ok, erlang:list_to_tuple(Data)};
+list_to_tuple(Data) -> decode_error_msg(<<"List">>, Data).

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -616,6 +616,10 @@ export function decode_tuple(data) {
   return Array.isArray(data) ? new Ok(data) : decoder_error("Tuple", data);
 }
 
+export function list_to_tuple(data) {
+  return List.isList(data) ? new Ok([...data]) : decoder_error("List", data);
+}
+
 export function tuple_get(data, index) {
   return index >= 0 && data.length > index
     ? new Ok(data[index])

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -616,8 +616,47 @@ export function decode_tuple(data) {
   return Array.isArray(data) ? new Ok(data) : decoder_error("Tuple", data);
 }
 
-export function list_to_tuple(data) {
-  return List.isList(data) ? new Ok([...data]) : decoder_error("List", data);
+export function decode_tuple2(data) {
+  return decode_tupleN(data, 2);
+}
+
+export function decode_tuple3(data) {
+  return decode_tupleN(data, 3);
+}
+
+export function decode_tuple4(data) {
+  return decode_tupleN(data, 4);
+}
+
+export function decode_tuple5(data) {
+  return decode_tupleN(data, 5);
+}
+
+export function decode_tuple6(data) {
+  return decode_tupleN(data, 6);
+}
+
+function decode_tupleN(data, n) {
+  let error_message = `Tuple or List of ${n} elements`;
+
+  if (!(List.isList(data) || Array.isArray(data))) {
+    return decoder_error(error_message, data);
+  }
+
+  let array = List.isList(data) ? [...data] : data; 
+
+  let i = 0;
+  for (; i < n; i++) {
+    if (array[i] === undefined) {
+      return decoder_error(error_message, data);
+    }
+  }
+
+  if (array[i] === undefined) {
+    return new Ok(array);
+  } else {
+    return decoder_error(error_message, data);
+  }
 }
 
 export function tuple_get(data, index) {

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -637,26 +637,29 @@ export function decode_tuple6(data) {
 }
 
 function decode_tupleN(data, n) {
-  let error_message = `Tuple or List of ${n} elements`;
-
-  if (!(List.isList(data) || Array.isArray(data))) {
-    return decoder_error(error_message, data);
+  if (Array.isArray(data) && data.length == n) {
+    return new Ok(data)
   }
 
-  let array = List.isList(data) ? [...data] : data; 
+  let list = decode_exact_length_list(data, n)
+  if (list) return new Ok(list)
 
-  let i = 0;
-  for (; i < n; i++) {
-    if (array[i] === undefined) {
-      return decoder_error(error_message, data);
-    }
+  return decoder_error(`Tuple of ${n} elements`, data);
+}
+
+function decode_exact_length_list(data, n) {
+  if (!List.isList(data)) return;
+
+  let elements = []
+  let current = data
+
+  for (let i = 0; i < n; i++) {
+    if (current.isEmpty()) break;
+    elements.push(current.head)
+    current = current.tail
   }
 
-  if (array[i] === undefined) {
-    return new Ok(array);
-  } else {
-    return decoder_error(error_message, data);
-  }
+  if (elements.length === n && current.isEmpty()) return elements
 }
 
 export function tuple_get(data, index) {

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -511,7 +511,7 @@ pub fn tuple2_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 2 elements",
+      expected: "Tuple of 2 elements",
       found: "Tuple of 3 elements",
     ),
   ]))
@@ -520,7 +520,7 @@ pub fn tuple2_test() {
   |> dynamic.from
   |> dynamic.tuple2(dynamic.int, dynamic.int)
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple or List of 2 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple of 2 elements", found: "Int"),
   ]))
 
   [1, 2]
@@ -547,7 +547,7 @@ pub fn tuple2_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 2 elements",
+      expected: "Tuple of 2 elements",
       found: "List",
     ),
   ]))
@@ -558,7 +558,7 @@ pub fn tuple2_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 2 elements",
+      expected: "Tuple of 2 elements",
       found: "List",
     ),
   ]))
@@ -607,7 +607,7 @@ pub fn tuple3_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 3 elements",
+      expected: "Tuple of 3 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -627,7 +627,7 @@ pub fn tuple3_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 3 elements",
+      expected: "Tuple of 3 elements",
       found: "List",
     ),
   ]))
@@ -636,7 +636,7 @@ pub fn tuple3_test() {
   |> dynamic.from
   |> dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple or List of 3 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple of 3 elements", found: "Int"),
   ]))
 }
 
@@ -684,7 +684,7 @@ pub fn tuple4_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 4 elements",
+      expected: "Tuple of 4 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -705,7 +705,7 @@ pub fn tuple4_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 4 elements",
+      expected: "Tuple of 4 elements",
       found: "List",
     ),
   ]))
@@ -714,7 +714,7 @@ pub fn tuple4_test() {
   |> dynamic.from
   |> dynamic.tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple or List of 4 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple of 4 elements", found: "Int"),
   ]))
 }
 
@@ -811,7 +811,7 @@ pub fn tuple5_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 5 elements",
+      expected: "Tuple of 5 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -845,7 +845,7 @@ pub fn tuple5_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 5 elements",
+      expected: "Tuple of 5 elements",
       found: "List",
     ),
   ]))
@@ -860,7 +860,7 @@ pub fn tuple5_test() {
     dynamic.int,
   )
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple or List of 5 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple of 5 elements", found: "Int"),
   ]))
 }
 
@@ -966,7 +966,7 @@ pub fn tuple6_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 6 elements",
+      expected: "Tuple of 6 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -1003,7 +1003,7 @@ pub fn tuple6_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple or List of 6 elements",
+      expected: "Tuple of 6 elements",
       found: "List",
     ),
   ]))
@@ -1019,7 +1019,7 @@ pub fn tuple6_test() {
     dynamic.int,
   )
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple or List of 6 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple of 6 elements", found: "Int"),
   ]))
 }
 

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -522,6 +522,35 @@ pub fn tuple2_test() {
   |> should.equal(Error([
     DecodeError(path: [], expected: "Tuple of 2 elements", found: "Int"),
   ]))
+
+  [1, 2]
+  |> dynamic.from
+  |> dynamic.tuple2(dynamic.int, dynamic.int)
+  |> should.equal(Ok(#(1, 2)))
+
+  [dynamic.from(1), dynamic.from("a")]
+  |> dynamic.from
+  |> dynamic.tuple2(dynamic.int, dynamic.string)
+  |> should.equal(Ok(#(1, "a")))
+
+  ["", ""]
+  |> dynamic.from
+  |> dynamic.tuple2(dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(expected: "Int", found: "String", path: ["0"]),
+    DecodeError(expected: "Int", found: "String", path: ["1"]),
+  ]))
+
+  [1, 2, 3]
+  |> dynamic.from
+  |> dynamic.tuple2(dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(
+      path: [],
+      expected: "List of 2 elements",
+      found: "List of 3 elements",
+    ),
+  ]))
 }
 
 pub fn tuple3_test() {
@@ -534,6 +563,16 @@ pub fn tuple3_test() {
   |> dynamic.from
   |> dynamic.tuple3(dynamic.int, dynamic.string, dynamic.float)
   |> should.equal(Ok(#(1, "", 3.0)))
+
+  [1, 2, 3]
+  |> dynamic.from
+  |> dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int)
+  |> should.equal(Ok(#(1, 2, 3)))
+
+  [dynamic.from(1), dynamic.from("a"), dynamic.from(3.0)]
+  |> dynamic.from
+  |> dynamic.tuple3(dynamic.int, dynamic.string, dynamic.float)
+  |> should.equal(Ok(#(1, "a", 3.0)))
 
   #(1, 2, "")
   |> dynamic.from
@@ -562,6 +601,26 @@ pub fn tuple3_test() {
     ),
   ]))
 
+  ["", "", ""]
+  |> dynamic.from
+  |> dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(expected: "Int", found: "String", path: ["0"]),
+    DecodeError(expected: "Int", found: "String", path: ["1"]),
+    DecodeError(expected: "Int", found: "String", path: ["2"]),
+  ]))
+
+  [1, 2]
+  |> dynamic.from
+  |> dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(
+      path: [],
+      expected: "List of 3 elements",
+      found: "List of 2 elements",
+    ),
+  ]))
+
   1
   |> dynamic.from
   |> dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int)
@@ -580,6 +639,16 @@ pub fn tuple4_test() {
   |> dynamic.from
   |> dynamic.tuple4(dynamic.int, dynamic.string, dynamic.float, dynamic.int)
   |> should.equal(Ok(#(1, "", 3.0, 4)))
+
+  [1, 2, 3, 4]
+  |> dynamic.from
+  |> dynamic.tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
+  |> should.equal(Ok(#(1, 2, 3, 4)))
+
+  [dynamic.from(1), dynamic.from("a"), dynamic.from(3.0), dynamic.from(4.0)]
+  |> dynamic.from
+  |> dynamic.tuple4(dynamic.int, dynamic.string, dynamic.float, dynamic.float)
+  |> should.equal(Ok(#(1, "a", 3.0, 4.0)))
 
   #(1, 2, 3, "")
   |> dynamic.from
@@ -606,6 +675,27 @@ pub fn tuple4_test() {
       path: [],
       expected: "Tuple of 4 elements",
       found: "Tuple of 2 elements",
+    ),
+  ]))
+
+  ["", "", "", ""]
+  |> dynamic.from
+  |> dynamic.tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(expected: "Int", found: "String", path: ["0"]),
+    DecodeError(expected: "Int", found: "String", path: ["1"]),
+    DecodeError(expected: "Int", found: "String", path: ["2"]),
+    DecodeError(expected: "Int", found: "String", path: ["3"]),
+  ]))
+
+  [1, 2]
+  |> dynamic.from
+  |> dynamic.tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(
+      path: [],
+      expected: "List of 4 elements",
+      found: "List of 2 elements",
     ),
   ]))
 
@@ -639,6 +729,34 @@ pub fn tuple5_test() {
     dynamic.int,
   )
   |> should.equal(Ok(#(1, "", 3.0, 4, 5)))
+
+  [1, 2, 3, 4, 5]
+  |> dynamic.from
+  |> dynamic.tuple5(
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+  )
+  |> should.equal(Ok(#(1, 2, 3, 4, 5)))
+
+  [
+    dynamic.from(1),
+    dynamic.from("a"),
+    dynamic.from(3.0),
+    dynamic.from(4.0),
+    dynamic.from(True),
+  ]
+  |> dynamic.from
+  |> dynamic.tuple5(
+    dynamic.int,
+    dynamic.string,
+    dynamic.float,
+    dynamic.float,
+    dynamic.bool,
+  )
+  |> should.equal(Ok(#(1, "a", 3.0, 4.0, True)))
 
   #(1, 2, 3, 4, "")
   |> dynamic.from
@@ -687,6 +805,40 @@ pub fn tuple5_test() {
     ),
   ]))
 
+  ["", "", "", "", ""]
+  |> dynamic.from
+  |> dynamic.tuple5(
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+  )
+  |> should.equal(Error([
+    DecodeError(expected: "Int", found: "String", path: ["0"]),
+    DecodeError(expected: "Int", found: "String", path: ["1"]),
+    DecodeError(expected: "Int", found: "String", path: ["2"]),
+    DecodeError(expected: "Int", found: "String", path: ["3"]),
+    DecodeError(expected: "Int", found: "String", path: ["4"]),
+  ]))
+
+  [1, 2]
+  |> dynamic.from
+  |> dynamic.tuple5(
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+  )
+  |> should.equal(Error([
+    DecodeError(
+      path: [],
+      expected: "List of 5 elements",
+      found: "List of 2 elements",
+    ),
+  ]))
+
   1
   |> dynamic.from
   |> dynamic.tuple5(
@@ -725,6 +877,37 @@ pub fn tuple6_test() {
     dynamic.int,
   )
   |> should.equal(Ok(#(1, "", 3.0, 4, 5, 6)))
+
+  [1, 2, 3, 4, 5, 6]
+  |> dynamic.from
+  |> dynamic.tuple6(
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+  )
+  |> should.equal(Ok(#(1, 2, 3, 4, 5, 6)))
+
+  [
+    dynamic.from(1),
+    dynamic.from("a"),
+    dynamic.from(3.0),
+    dynamic.from(4.0),
+    dynamic.from(True),
+    dynamic.from(6.0),
+  ]
+  |> dynamic.from
+  |> dynamic.tuple6(
+    dynamic.int,
+    dynamic.string,
+    dynamic.float,
+    dynamic.float,
+    dynamic.bool,
+    dynamic.float,
+  )
+  |> should.equal(Ok(#(1, "a", 3.0, 4.0, True, 6.0)))
 
   #(1, 2, 3, 4, 5, "")
   |> dynamic.from
@@ -774,6 +957,43 @@ pub fn tuple6_test() {
       path: [],
       expected: "Tuple of 6 elements",
       found: "Tuple of 2 elements",
+    ),
+  ]))
+
+  ["", "", "", "", "", ""]
+  |> dynamic.from
+  |> dynamic.tuple6(
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+  )
+  |> should.equal(Error([
+    DecodeError(expected: "Int", found: "String", path: ["0"]),
+    DecodeError(expected: "Int", found: "String", path: ["1"]),
+    DecodeError(expected: "Int", found: "String", path: ["2"]),
+    DecodeError(expected: "Int", found: "String", path: ["3"]),
+    DecodeError(expected: "Int", found: "String", path: ["4"]),
+    DecodeError(expected: "Int", found: "String", path: ["5"]),
+  ]))
+
+  [1, 2]
+  |> dynamic.from
+  |> dynamic.tuple6(
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+    dynamic.int,
+  )
+  |> should.equal(Error([
+    DecodeError(
+      path: [],
+      expected: "List of 6 elements",
+      found: "List of 2 elements",
     ),
   ]))
 

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -511,7 +511,7 @@ pub fn tuple2_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple of 2 elements",
+      expected: "Tuple or List of 2 elements",
       found: "Tuple of 3 elements",
     ),
   ]))
@@ -520,7 +520,7 @@ pub fn tuple2_test() {
   |> dynamic.from
   |> dynamic.tuple2(dynamic.int, dynamic.int)
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple of 2 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple or List of 2 elements", found: "Int"),
   ]))
 
   [1, 2]
@@ -547,8 +547,19 @@ pub fn tuple2_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "List of 2 elements",
-      found: "List of 3 elements",
+      expected: "Tuple or List of 2 elements",
+      found: "List",
+    ),
+  ]))
+
+  []
+  |> dynamic.from
+  |> dynamic.tuple2(dynamic.int, dynamic.int)
+  |> should.equal(Error([
+    DecodeError(
+      path: [],
+      expected: "Tuple or List of 2 elements",
+      found: "List",
     ),
   ]))
 }
@@ -596,7 +607,7 @@ pub fn tuple3_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple of 3 elements",
+      expected: "Tuple or List of 3 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -616,8 +627,8 @@ pub fn tuple3_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "List of 3 elements",
-      found: "List of 2 elements",
+      expected: "Tuple or List of 3 elements",
+      found: "List",
     ),
   ]))
 
@@ -625,7 +636,7 @@ pub fn tuple3_test() {
   |> dynamic.from
   |> dynamic.tuple3(dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple of 3 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple or List of 3 elements", found: "Int"),
   ]))
 }
 
@@ -673,7 +684,7 @@ pub fn tuple4_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple of 4 elements",
+      expected: "Tuple or List of 4 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -694,8 +705,8 @@ pub fn tuple4_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "List of 4 elements",
-      found: "List of 2 elements",
+      expected: "Tuple or List of 4 elements",
+      found: "List",
     ),
   ]))
 
@@ -703,7 +714,7 @@ pub fn tuple4_test() {
   |> dynamic.from
   |> dynamic.tuple4(dynamic.int, dynamic.int, dynamic.int, dynamic.int)
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple of 4 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple or List of 4 elements", found: "Int"),
   ]))
 }
 
@@ -800,7 +811,7 @@ pub fn tuple5_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple of 5 elements",
+      expected: "Tuple or List of 5 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -834,8 +845,8 @@ pub fn tuple5_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "List of 5 elements",
-      found: "List of 2 elements",
+      expected: "Tuple or List of 5 elements",
+      found: "List",
     ),
   ]))
 
@@ -849,7 +860,7 @@ pub fn tuple5_test() {
     dynamic.int,
   )
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple of 5 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple or List of 5 elements", found: "Int"),
   ]))
 }
 
@@ -955,7 +966,7 @@ pub fn tuple6_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "Tuple of 6 elements",
+      expected: "Tuple or List of 6 elements",
       found: "Tuple of 2 elements",
     ),
   ]))
@@ -992,8 +1003,8 @@ pub fn tuple6_test() {
   |> should.equal(Error([
     DecodeError(
       path: [],
-      expected: "List of 6 elements",
-      found: "List of 2 elements",
+      expected: "Tuple or List of 6 elements",
+      found: "List",
     ),
   ]))
 
@@ -1008,7 +1019,7 @@ pub fn tuple6_test() {
     dynamic.int,
   )
   |> should.equal(Error([
-    DecodeError(path: [], expected: "Tuple of 6 elements", found: "Int"),
+    DecodeError(path: [], expected: "Tuple or List of 6 elements", found: "Int"),
   ]))
 }
 


### PR DESCRIPTION
This PR introduces series of `tupleN_from_list` functions to `dynamic` module. The idea is to add ability to decode list into tuple.

Currently code:

```gleam
import gleam/io
import gleam/dynamic
import gleam/json

pub fn main() {
  io.debug(json.decode("[1,2]", dynamic.tuple2(dynamic.int, dynamic.int)))
}
```
Will fail with error:

```gleam
Error(UnexpectedFormat([DecodeError("Tuple of 2 elements", "List", [])]))

```

Now it can be done with `dynamic.tuple2_from_list`:

```gleam
import gleam/io
import gleam/dynamic
import gleam/json

pub fn main() {
  io.debug(json.decode("[1,2]", dynamic.tuple2_from_list(dynamic.int, dynamic.int)))
}
```
Result:

```gleam
#(1, 2)
```

Fixes #420