### PR TITLE
fix bug in persistent-hash-map.mjs

### DIFF
--- a/src/persistent-hash-map.mjs
+++ b/src/persistent-hash-map.mjs
@@ -581,10 +581,13 @@ function findArray(root, shift, hash, key) {
   if (node === undefined) {
     return undefined;
   }
-  if (node.type === ENTRY) {
+  if (node.type !== ENTRY) {
+    return find(node, shift + SHIFT, hash, key);
+  }
+  if (isEqual(key, node.k)) {
     return node;
   }
-  return find(node, shift + SHIFT, hash, key);
+  return undefined;
 }
 /**
  * @template K,V


### PR DESCRIPTION
@CrowdHailer was having weird issues with the map, and I believe this is it.
There was a missing check for key equality when finding values in specific cases.
