### PR TITLE
`dynamic` doc fixes

### DIFF
--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -755,7 +755,7 @@ pub fn tuple3(
 /// > from(#(1, 2))
 /// > |> tuple4(int, float, string, int)
 /// Error([
-///   DecodeError(expected: "4 element tuple", found: "2 element tuple", path: []),
+///   DecodeError(expected: "Tuple of 4 elements", found: "Tuple of 2 elements", path: []),
 /// ])
 /// ```
 ///
@@ -763,7 +763,7 @@ pub fn tuple3(
 /// > from("")
 /// > |> tuple4(int, float, string, int)
 /// Error([
-///   DecodeError(expected: "4 element tuple", found: "String", path: []),
+///   DecodeError(expected: "Tuple of 4 elements", found: "String", path: []),
 /// ])
 /// ```
 ///

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -271,7 +271,7 @@ if javascript {
 ///
 /// ```gleam
 /// > shallow_list(1)
-/// Error([DecodeError(expected: "Int", found: "Int", path: [])])
+/// Error([DecodeError(expected: "List", found: "Int", path: [])])
 /// ```
 ///
 pub fn shallow_list(from value: Dynamic) -> Result(List(Dynamic), DecodeErrors) {

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -239,7 +239,7 @@ if javascript {
 ///
 /// ```gleam
 /// > bool(from(123))
-/// Error([DecodeError(expected: "bool", found: "Int", path: [])])
+/// Error([DecodeError(expected: "Bool", found: "Int", path: [])])
 /// ```
 ///
 pub fn bool(from data: Dynamic) -> Result(Bool, DecodeErrors) {

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -321,7 +321,7 @@ if javascript {
 /// ```gleam
 /// > from(123)
 /// > |> result(ok: int, error: string)
-/// Error([DecodeError(expected: "2 element tuple", found: "Int", path: [])])
+/// Error([DecodeError(expected: "Result", found: "Int", path: [])])
 /// ```
 ///
 pub fn result(

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -809,12 +809,12 @@ pub fn tuple4(
 /// > from(#(1, 2))
 /// > |> tuple5(int, float, string, int, int)
 /// Error([
-///   DecodeError(expected: "5 element tuple", found: "2 element tuple", path: [])),
+///   DecodeError(expected: "Tuple of 5 elements", found: "Tuple of 2 elements", path: [])),
 /// ])
 ///
 /// > from("")
 /// > |> tuple5(int, float, string, int, int)
-/// Error([DecodeError(expected: "5 element tuple", found: "String", path: [])])
+/// Error([DecodeError(expected: "Tuple of 5 elements", found: "String", path: [])])
 /// ```
 ///
 pub fn tuple5(

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -371,7 +371,7 @@ pub fn result(
 /// ```gleam
 /// > from([1, 2, 3])
 /// > |> list(of: string)
-/// Error([DecodeError(expected: "String", found: "Int", path: [])])
+/// Error([DecodeError(expected: "String", found: "Int", path: ["*"])])
 /// ```
 ///
 /// ```gleam

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -861,8 +861,14 @@ pub fn tuple5(
 /// > from(#(1, 2))
 /// > |> tuple6(int, float, string, int, int, int)
 /// Error([
-///   DecodeError(expected: "6 element tuple", found: "2 element tuple", path: []),
+///   DecodeError(expected: "Tuple of 6 elements", found: "Tuple of 2 elements", path: []),
 /// ])
+/// ```
+///
+/// ```gleam
+/// > from("")
+/// > |> tuple6(int, float, string, int, int, int)
+/// Error([DecodeError(expected: "Tuple of 6 elements", found: "String", path: [])])
 /// ```
 ///
 pub fn tuple6(

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -981,7 +981,7 @@ if javascript {
 ///
 /// ```gleam
 /// > bool_or_string(from(1))
-/// Error(DecodeError(expected: "unknown", found: "unknown", path: []))
+/// Error(DecodeError(expected: "another type", found: "Int", path: []))
 /// ```
 ///
 pub fn any(of decoders: List(Decoder(t))) -> Decoder(t) {

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -429,7 +429,7 @@ pub fn list(
 /// ```gleam
 /// > from(123)
 /// > |> optional(string)
-/// Error([DecodeError(expected: "BitString", found: "Int", path: [])])
+/// Error([DecodeError(expected: "String", found: "Int", path: [])])
 /// ```
 ///
 pub fn optional(of decode: Decoder(inner)) -> Decoder(Option(inner)) {

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -705,7 +705,7 @@ pub fn tuple2(
 /// > from(#(1, 2))
 /// > |> tuple3(int, float, string)
 /// Error([
-///   DecodeError(expected: "3 element tuple", found: "2 element tuple", path: [])),
+///   DecodeError(expected: "Tuple of 3 elements", found: "Tuple of 2 elements", path: [])),
 /// ])
 /// ```
 ///
@@ -713,7 +713,7 @@ pub fn tuple2(
 /// > from("")
 /// > |> tuple3(int, float, string)
 /// Error([
-///   DecodeError(expected: "3 element tuple", found: "String", path: []),
+///   DecodeError(expected: "Tuple of 3 elements", found: "String", path: []),
 /// ])
 /// ```
 ///

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -657,14 +657,14 @@ fn push_path(error: DecodeError, name: t) -> DecodeError {
 /// > from(#(1, 2, 3))
 /// > |> tuple2(int, float)
 /// Error([
-///   DecodeError(expected: "2 element tuple", found: "3 element tuple", path: []),
+///   DecodeError(expected: "Tuple of 2 elements", found: "Tuple of 3 elements", path: []),
 /// ])
 /// ```
 ///
 /// ```gleam
 /// > from("")
 /// > |> tuple2(int, float)
-/// Error([DecodeError(expected: "2 element tuple", found: "String", path: [])])
+/// Error([DecodeError(expected: "Tuple of 2 elements", found: "String", path: [])])
 /// ```
 ///
 pub fn tuple2(


### PR DESCRIPTION
As reported in #444 there were a couple of inconsistencies between the documentation examples and the actual return values of the `Decoder`s. I ended up finding more errors than those reported in the issue and fixed all of them.

Closes #444  