### PR TITLE
`field` and `optional_field`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   incorrectly stated in some cases.
 - `result.then` is now an alias of `result.try`; both do the same.
 - The `list` module gains the `try_each` function.
+- The `dynamic` module gains the `optional_field` function.
 
 ## v0.28.0 - 2023-03-26
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -474,20 +474,29 @@ if javascript {
 ///
 pub fn field(named name: a, of inner_type: Decoder(t)) -> Decoder(t) {
   fn(value) {
-    value
-    |> decode_field(name)
-    |> result.try(inner_type)
-    |> map_errors(push_path(_, name))
+    case decode_field(value, name) {
+      Error(not_a_map_errors) -> Error(not_a_map_errors)
+      Ok(dynamic_field_result) ->
+        dynamic_field_result
+        |> result.try(inner_type)
+        |> map_errors(push_path(_, name))
+    }
   }
 }
 
 if erlang {
-  external fn decode_field(Dynamic, name) -> Result(Dynamic, DecodeErrors) =
+  external fn decode_field(
+    Dynamic,
+    name,
+  ) -> Result(Result(Dynamic, DecodeErrors), DecodeErrors) =
     "gleam_stdlib" "decode_field"
 }
 
 if javascript {
-  external fn decode_field(Dynamic, name) -> Result(Dynamic, DecodeErrors) =
+  external fn decode_field(
+    Dynamic,
+    name,
+  ) -> Result(Result(Dynamic, DecodeErrors), DecodeErrors) =
     "../gleam_stdlib.mjs" "decode_field"
 }
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -461,7 +461,9 @@ if javascript {
 ///
 /// ```gleam
 /// > import gleam/map
-/// > from(map.new("Hello", "World"))
+/// > map.new()
+/// > |> map.insert("Hello", "World")
+/// > |> from
 /// > |> field(named: "Hello", of: string)
 /// Ok("World")
 /// ```

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -79,9 +79,9 @@ decode_list(Data) -> decode_error_msg(<<"List">>, Data).
 
 decode_field(Data, Key) when is_map(Data) ->
     case Data of
-        #{Key := Value} -> {ok, {ok, Value}};
+        #{Key := Value} -> {ok, {some, Value}};
         _ ->
-            {ok, decode_error(<<"field"/utf8>>, <<"nothing"/utf8>>)}
+            {ok, none}
     end;
 decode_field(Data, _) ->
     decode_error_msg(<<"Map">>, Data).

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -77,12 +77,14 @@ decode_bool(Data) -> decode_error_msg(<<"Bool">>, Data).
 decode_list(Data) when is_list(Data) -> {ok, Data};
 decode_list(Data) -> decode_error_msg(<<"List">>, Data).
 
-decode_field(Data, Key) ->
+decode_field(Data, Key) when is_map(Data) ->
     case Data of
-        #{Key := Value} -> {ok, Value};
+        #{Key := Value} -> {ok, {ok, Value}};
         _ ->
-            decode_error(<<"field"/utf8>>, <<"nothing"/utf8>>)
-    end.
+            {ok, decode_error(<<"field"/utf8>>, <<"nothing"/utf8>>)}
+    end;
+decode_field(Data, _) ->
+    decode_error_msg(<<"Map">>, Data).
 
 size_of_tuple(Data) -> tuple_size(Data).
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -653,14 +653,13 @@ export function decode_option(data, decoder) {
 }
 
 export function decode_field(value, name) {
-  let missing_field_error = () => decoder_error_no_classify("field", "nothing");
   let not_a_map_error = () => decoder_error("Map", value);
 
   if (value instanceof PMap || value instanceof WeakMap || value instanceof Map) {
     let entry = map_get(value, name);
-    return new Ok(entry.isOk() ? entry : missing_field_error());
+    return new Ok(entry.isOk() ? new Some(entry[0]) : new None());
   } else if (Object.getPrototypeOf(value) == Object.prototype) {
-    return try_get_field(value, name, () => new Ok(missing_field_error()));
+    return try_get_field(value, name, () => new Ok(new None()));
   } else {
     return try_get_field(value, name, not_a_map_error);
   }
@@ -668,7 +667,7 @@ export function decode_field(value, name) {
 
 function try_get_field(value, field, or_else) {
   try {
-    return field in value ? new Ok(new Ok(value[field])) : or_else();
+    return field in value ? new Ok(new Some(value[field])) : or_else();
   } catch {
     return or_else();
   }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -653,14 +653,23 @@ export function decode_option(data, decoder) {
 }
 
 export function decode_field(value, name) {
-  let error = () => decoder_error_no_classify("field", "nothing");
-  if (value instanceof PMap) {
+  let missing_field_error = () => decoder_error_no_classify("field", "nothing");
+  let not_a_map_error = () => decoder_error("Map", value);
+
+  if (value instanceof PMap || value instanceof WeakMap || value instanceof Map) {
     let entry = map_get(value, name);
-    return entry.isOk() ? entry : error();
+    return new Ok(entry.isOk() ? entry : missing_field_error());
+  } else if (Object.getPrototypeOf(value) == Object.prototype) {
+    return try_get_field(value, name, () => new Ok(missing_field_error()));
+  } else {
+    return try_get_field(value, name, not_a_map_error);
   }
+}
+
+function try_get_field(value, field, or_else) {
   try {
-    return name in value ? new Ok(value[name]) : error();
+    return field in value ? new Ok(new Ok(value[field])) : or_else();
   } catch {
-    return error();
+    return or_else();
   }
 }

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -330,6 +330,62 @@ pub fn field_test() {
   ]))
 }
 
+pub fn optional_field_test() {
+  map.new()
+  |> map.insert("ok", 1)
+  |> dynamic.from
+  |> dynamic.optional_field(named: "ok", of: dynamic.int)
+  |> should.equal(Ok(Some(1)))
+
+  map.new()
+  |> map.insert("ok", 1.0)
+  |> dynamic.from
+  |> dynamic.optional_field(named: "ok", of: dynamic.float)
+  |> should.equal(Ok(Some(1.0)))
+
+  map.new()
+  |> map.insert("ok", 3)
+  |> map.insert("error", 1)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(Ok(Some(3)))
+
+  map.new()
+  |> map.insert("ok", 3)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.string)
+  |> should.equal(Error([
+    DecodeError(expected: "String", found: "Int", path: ["ok"]),
+  ]))
+
+  map.new()
+  |> map.insert("ok", None)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(Ok(None))
+
+  map.new()
+  |> map.insert("ok", Nil)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(Ok(None))
+
+  map.new()
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(Ok(None))
+
+  1
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(Error([DecodeError(expected: "Map", found: "Int", path: [])]))
+
+  []
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(Error([DecodeError(expected: "Map", found: "List", path: [])]))
+}
+
 pub fn element_test() {
   let ok_one_tuple = #("ok", 1)
 

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -271,7 +271,7 @@ if javascript {
     |> dynamic.from
     |> dynamic.field("Nope", dynamic.int)
     |> should.equal(Error([
-      DecodeError(expected: "field", found: "nothing", path: ["Nope"]),
+      DecodeError(expected: "Map", found: "Result", path: []),
     ]))
   }
 }
@@ -314,15 +314,19 @@ pub fn field_test() {
   1
   |> dynamic.from
   |> dynamic.field("ok", dynamic.int)
-  |> should.equal(Error([
-    DecodeError(expected: "field", found: "nothing", path: ["ok"]),
-  ]))
+  |> should.equal(Error([DecodeError(expected: "Map", found: "Int", path: [])]))
 
   []
   |> dynamic.from
   |> dynamic.field("ok", dynamic.int)
+  |> should.equal(Error([DecodeError(expected: "Map", found: "List", path: [])]))
+
+  map.new()
+  |> map.insert("ok", 1)
+  |> dynamic.from
+  |> dynamic.field("ok", dynamic.field("not_a_field", dynamic.int))
   |> should.equal(Error([
-    DecodeError(expected: "field", found: "nothing", path: ["ok"]),
+    DecodeError(expected: "Map", found: "Int", path: ["ok"]),
   ]))
 }
 


### PR DESCRIPTION
- Add an implementation for `optional_field` (closes #437)
- Fix an [inconsistency](https://discord.com/channels/768594524158427167/1098317468851777566) with the `field` behavior and its documentation. Now the standard behavior is the following:
  - Erlang: if the dynamic is not a map it now states it in the error message, for example `1 |> dynamic.from |> dynamic.field("ok", dynamic.int)` now gives the more appropriate error `DecodeError(expected: Map, got: Int, path: [])` instead of `DecodeError(expected: field, found: nothing, path: [<field-name>])`. This error can only occur if the type is indeed a map but the field is missing
  - Javascript: the behavior is a little more nuanced in case the field is missing:
    - if the dynamic was a `PMap`, `Map`, `WeakMap` or plain object it will give an error like `DecodeError(expected: field, got: nothing, path: [<field-name>])`
    - in all other cases the error will be more generic and say `DecodeError(expected: Map, got: <type>, path: [])` where `<type>` is the actual type of the dynamic