### PR TITLE
Result partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   of `null` or `undefined`.
 - Fixed a bug where `io.debug` would crash when called in a React Native
   environment.
+- The `result` module gains the `partition` function.
 
 ## v0.28.1 - 2023-04-10
 

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -368,13 +368,14 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
 
 /// Given a list of results, returns a pair where the first element is a list
 /// of all the values inside `Ok` and the second element is a list with all the
-/// values inside `Error`.
+/// values inside `Error`. The values in both lists appear in reverse order with
+/// respect to their position in the original list of results. 
 ///
 /// ## Examples
 ///
 /// ```gleam
 /// > partition([Ok(1), Error("a"), Error("b"), Ok(2)])
-/// #([1, 2], ["a", "b"])
+/// #([2, 1], ["b", "a"])
 /// ```
 ///
 pub fn partition(results: List(Result(a, e))) -> #(List(a), List(e)) {
@@ -383,7 +384,7 @@ pub fn partition(results: List(Result(a, e))) -> #(List(a), List(e)) {
 
 fn do_partition(results: List(Result(a, e)), oks: List(a), errors: List(e)) {
   case results {
-    [] -> #(list.reverse(oks), list.reverse(errors))
+    [] -> #(oks, errors)
     [Ok(a), ..rest] -> do_partition(rest, [a, ..oks], errors)
     [Error(e), ..rest] -> do_partition(rest, oks, [e, ..errors])
   }

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -366,6 +366,36 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
   list.try_map(results, fn(x) { x })
 }
 
+/// TODO Add doc!
+pub fn partition(results: List(Result(a, e))) -> Result(List(a), List(e)) {
+  case results {
+    [] -> Ok([])
+    [Ok(a), ..rest] -> do_partition(rest, Ok([a]))
+    [Error(b), ..rest] -> do_partition(rest, Error([b]))
+  }
+}
+
+fn do_partition(results: List(Result(a, b)), acc: Result(List(a), List(b))) {
+  case results {
+    [] ->
+      acc
+      |> map(list.reverse)
+      |> map_error(list.reverse)
+
+    [Ok(a), ..rest] ->
+      case acc {
+        Ok(all_as) -> do_partition(rest, Ok([a, ..all_as]))
+        Error(all_bs) -> do_partition(rest, Error(all_bs))
+      }
+
+    [Error(b), ..rest] ->
+      case acc {
+        Ok(_) -> do_partition(rest, Error([b]))
+        Error(all_bs) -> do_partition(rest, Error([b, ..all_bs]))
+      }
+  }
+}
+
 /// Replace the value within a result
 ///
 /// ## Examples

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -366,7 +366,22 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
   list.try_map(results, fn(x) { x })
 }
 
-/// TODO Add doc!
+/// Combines a list of results into a single result.
+/// If all elements in the list are `Ok` then returns an `Ok` holding the list of values.
+/// If any element is `Error` then returns an `Error` holding the list of all errors.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > partition([Ok(1), Ok(2)])
+/// Ok([1, 2])
+/// ```
+///
+/// ```gleam
+/// > partition([Ok(1), Error("a"), Error("b")])
+/// Error(["a", "b"])
+/// ```
+///
 pub fn partition(results: List(Result(a, e))) -> Result(List(a), List(e)) {
   case results {
     [] -> Ok([])

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -1,3 +1,4 @@
+import gleam/list
 import gleam/result
 import gleam/should
 
@@ -193,6 +194,41 @@ pub fn all_test() {
   [Ok(1), Error("a"), Error("b"), Ok(3)]
   |> result.all
   |> should.equal(Error("a"))
+}
+
+pub fn partition_test() {
+  []
+  |> result.partition
+  |> should.equal(Ok([]))
+
+  [Ok(1), Ok(2), Ok(3)]
+  |> result.partition
+  |> should.equal(Ok([1, 2, 3]))
+
+  [Error("a"), Error("b"), Error("c")]
+  |> result.partition
+  |> should.equal(Error(["a", "b", "c"]))
+
+  [Error("a"), Ok(1), Ok(2)]
+  |> result.partition
+  |> should.equal(Error(["a"]))
+
+  [Ok(1), Ok(2), Error("a")]
+  |> result.partition
+  |> should.equal(Error(["a"]))
+
+  [Ok(1), Error("a"), Ok(2), Error("b"), Error("c")]
+  |> result.partition
+  |> should.equal(Error(["a", "b", "c"]))
+
+  // TCO test
+  list.repeat(Ok(1), 1_000_000)
+  |> result.partition
+  |> should.be_ok
+
+  list.repeat(Error("a"), 1_000_000)
+  |> result.partition
+  |> should.be_error
 }
 
 pub fn replace_error_test() {

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -199,36 +199,26 @@ pub fn all_test() {
 pub fn partition_test() {
   []
   |> result.partition
-  |> should.equal(Ok([]))
+  |> should.equal(#([], []))
 
   [Ok(1), Ok(2), Ok(3)]
   |> result.partition
-  |> should.equal(Ok([1, 2, 3]))
+  |> should.equal(#([1, 2, 3], []))
 
   [Error("a"), Error("b"), Error("c")]
   |> result.partition
-  |> should.equal(Error(["a", "b", "c"]))
-
-  [Error("a"), Ok(1), Ok(2)]
-  |> result.partition
-  |> should.equal(Error(["a"]))
-
-  [Ok(1), Ok(2), Error("a")]
-  |> result.partition
-  |> should.equal(Error(["a"]))
+  |> should.equal(#([], ["a", "b", "c"]))
 
   [Ok(1), Error("a"), Ok(2), Error("b"), Error("c")]
   |> result.partition
-  |> should.equal(Error(["a", "b", "c"]))
+  |> should.equal(#([1, 2], ["a", "b", "c"]))
 
   // TCO test
   list.repeat(Ok(1), 1_000_000)
   |> result.partition
-  |> should.be_ok
 
   list.repeat(Error("a"), 1_000_000)
   |> result.partition
-  |> should.be_error
 }
 
 pub fn replace_error_test() {

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -203,15 +203,15 @@ pub fn partition_test() {
 
   [Ok(1), Ok(2), Ok(3)]
   |> result.partition
-  |> should.equal(#([1, 2, 3], []))
+  |> should.equal(#([3, 2, 1], []))
 
   [Error("a"), Error("b"), Error("c")]
   |> result.partition
-  |> should.equal(#([], ["a", "b", "c"]))
+  |> should.equal(#([], ["c", "b", "a"]))
 
   [Ok(1), Error("a"), Ok(2), Error("b"), Error("c")]
   |> result.partition
-  |> should.equal(#([1, 2], ["a", "b", "c"]))
+  |> should.equal(#([2, 1], ["c", "b", "a"]))
 
   // TCO test
   list.repeat(Ok(1), 1_000_000)


### PR DESCRIPTION
This PR introduces the `result.partition` function; it behaves like `result.all` but instead of short circuiting at the first error it accumulates all errors in the list of results.