### PR TITLE
result.err_if

### DIFF
--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -166,6 +166,35 @@ pub fn try(
   }
 }
 
+/// Given a condition, will either return the provided
+/// error value wrapped in `Error` if the condition is true,
+/// or call the provided function to get the result if the condition
+/// is false.
+///
+/// Useful for ad-hoc constructing errors based on given conditions.
+/// 
+/// ## Examples
+///
+/// ```gleam
+/// > err_if(True, "some error", fn() { Ok(0) })
+/// Error("some error")
+/// ```
+///
+/// ```gleam
+/// > err_if(False, "some error", fn() { Ok(0) })
+/// Ok(0)
+/// ```
+pub fn err_if(
+  condition: Bool,
+  error: e,
+  apply fun: fn() -> Result(b, e),
+) -> Result(b, e) {
+  case condition {
+    True -> Error(error)
+    False -> fun()
+  }
+}
+
 /// An alias for `try`. See the documentation for that function for more information.
 ///
 pub fn then(

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -78,6 +78,20 @@ pub fn try_test() {
   |> should.equal(Error(1))
 }
 
+pub fn err_if_test() {
+  {
+    use <- result.err_if(True, "Should Error")
+    Ok(7)
+  }
+  |> should.equal(Error("Should Error"))
+
+  {
+    use <- result.err_if(False, "Should Not Error")
+    Ok(7)
+  }
+  |> should.equal(Ok(7))
+}
+
 pub fn then_test() {
   Error(1)
   |> result.then(fn(x) { Ok(x + 1) })


### PR DESCRIPTION
Thought about this function while doing an exercism exercise. I really like using multiple `use` statements to cleanly do error handling at the top of a function. `result.try` works exceptionally well for this when you have pre-existing fallible functions. The goal of this function is to provide a similar experience when manually constructing errors in place.

```
use _ <- result.try(some_validation())
use <- result.err_if(user_age < 21, UserNotOfAgeErr)

... some more code
```