### PR TITLE
Fix doc for bool.guard

### DIFF
--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -324,9 +324,9 @@ pub fn to_string(bool: Bool) -> String {
   }
 }
 
-/// Run a callback function if the given bool is `True`, otherwise return a
+/// Run a callback function if the given bool is `False`, otherwise return a
 /// default value.
-/// 
+///
 /// With a `use` expression this function can simulate the early-return pattern
 /// found in some other programming languages.
 ///


### PR DESCRIPTION
Previously, the doc suggested that the fallback is run if the input is `True`. The actual behavior is the opposite.