### PR TITLE
Update examples to use `let assert` syntax instead of `assert`

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -237,7 +237,7 @@ pub fn to_list(iterator: Iterator(element)) -> List(element) {
   |> list.reverse
 }
 
-/// Eagerly accesses the first value of an interator, returning a `Next`
+/// Eagerly accesses the first value of an iterator, returning a `Next`
 /// that contains the first value and the rest of the iterator.
 ///
 /// If called on an empty iterator, `Done` is returned.
@@ -245,7 +245,7 @@ pub fn to_list(iterator: Iterator(element)) -> List(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Next(head, tail) = [1, 2, 3, 4]
+/// > let assert Next(head, tail) = [1, 2, 3, 4]
 /// >   |> from_list
 /// >   |> step
 /// > head

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -40,14 +40,14 @@ pub type Options {
 ///
 /// ```gleam
 /// > let options = Options(case_insensitive: False, multi_line: True)
-/// > assert Ok(re) = compile("^[0-9]", with: options)
+/// > let assert Ok(re) = compile("^[0-9]", with: options)
 /// > check(re, "abc\n123")
 /// True
 /// ```
 ///
 /// ```gleam
 /// > let options = Options(case_insensitive: True, multi_line: False)
-/// > assert Ok(re) = compile("[A-Z]", with: options)
+/// > let assert Ok(re) = compile("[A-Z]", with: options)
 /// > check(re, "abc123")
 /// True
 /// ```
@@ -74,7 +74,7 @@ if javascript {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Ok(re) = from_string("[0-9]")
+/// > let assert Ok(re) = from_string("[0-9]")
 /// > check(re, "abc123")
 /// True
 /// ```
@@ -103,7 +103,7 @@ pub fn from_string(pattern: String) -> Result(Regex, CompileError) {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Ok(re) = from_string("^f.o.?")
+/// > let assert Ok(re) = from_string("^f.o.?")
 /// > check(with: re, content: "foo")
 /// True
 /// ```
@@ -132,7 +132,7 @@ if javascript {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Ok(re) = from_string(" *, *")
+/// > let assert Ok(re) = from_string(" *, *")
 /// > split(with: re, content: "foo,32, 4, 9  ,0")
 /// ["foo", "32", "4", "9", "0"]
 /// ```

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -840,7 +840,7 @@ if javascript {
 ///
 /// ```gleam
 /// > {
-/// >   assert #(Ok(a), Ok(b), Ok(c)) = #(
+/// >   let assert #(Ok(a), Ok(b), Ok(c)) = #(
 /// >     utf_codepoint(97),
 /// >     utf_codepoint(98),
 /// >     utf_codepoint(99),

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -381,7 +381,7 @@ pub fn to_string(uri: Uri) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > assert Ok(uri) = parse("http://example.com/path?foo#bar")
+/// > let assert Ok(uri) = parse("http://example.com/path?foo#bar")
 /// > origin(uri)
 /// Ok("http://example.com")
 /// ```


### PR DESCRIPTION
Some doc examples still used the old `assert` syntax, instead of `let assert`.
(Also there was a typo in the `iterator` doc and I fixed that as well)