### PR TITLE
Replace `list.head` and `list.tail` with `list.first` and `list.rest`

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -245,15 +245,15 @@ pub fn to_list(iterator: Iterator(element)) -> List(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Next(head, tail) = [1, 2, 3, 4]
+/// > let assert Next(first, rest) = [1, 2, 3, 4]
 /// >   |> from_list
 /// >   |> step
-/// > head
+/// > first
 /// 1
 /// ```
 ///
 /// ```gleam
-/// > tail |> to_list
+/// > rest |> to_list
 /// [2, 3, 4]
 /// ```
 ///

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -189,8 +189,8 @@ pub fn is_empty(list: List(a)) -> Bool {
 pub fn contains(list: List(a), any elem: a) -> Bool {
   case list {
     [] -> False
-    [head, ..] if head == elem -> True
-    [_, ..tail] -> contains(tail, elem)
+    [first, ..] if first == elem -> True
+    [_, ..rest] -> contains(rest, elem)
   }
 }
 
@@ -624,7 +624,7 @@ pub fn prepend(to list: List(a), this item: a) -> List(a) {
 fn reverse_and_prepend(list prefix: List(a), to suffix: List(a)) -> List(a) {
   case prefix {
     [] -> suffix
-    [head, ..tail] -> reverse_and_prepend(list: tail, to: [head, ..suffix])
+    [first, ..rest] -> reverse_and_prepend(list: rest, to: [first, ..suffix])
   }
 }
 
@@ -903,9 +903,9 @@ pub fn find_map(
 pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
   case list {
     [] -> True
-    [head, ..tail] ->
-      case predicate(head) {
-        True -> all(tail, predicate)
+    [first, ..rest] ->
+      case predicate(first) {
+        True -> all(rest, predicate)
         False -> False
       }
   }
@@ -940,10 +940,10 @@ pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
 pub fn any(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
   case list {
     [] -> False
-    [head, ..tail] ->
-      case predicate(head) {
+    [first, ..rest] ->
+      case predicate(first) {
         True -> True
-        False -> any(tail, predicate)
+        False -> any(rest, predicate)
       }
   }
 }
@@ -1732,9 +1732,9 @@ fn do_take_while(
 ) -> List(a) {
   case list {
     [] -> reverse(acc)
-    [head, ..tail] ->
-      case predicate(head) {
-        True -> do_take_while(tail, predicate, [head, ..acc])
+    [first, ..rest] ->
+      case predicate(first) {
+        True -> do_take_while(rest, predicate, [first, ..acc])
         False -> reverse(acc)
       }
   }
@@ -1764,14 +1764,14 @@ fn do_chunk(
   acc: List(List(a)),
 ) -> List(List(a)) {
   case list {
-    [head, ..tail] -> {
-      let key = f(head)
+    [first, ..rest] -> {
+      let key = f(first)
       case key == previous_key {
         False -> {
           let new_acc = [reverse(current_chunk), ..acc]
-          do_chunk(tail, f, key, [head], new_acc)
+          do_chunk(rest, f, key, [first], new_acc)
         }
-        _true -> do_chunk(tail, f, key, [head, ..current_chunk], acc)
+        _true -> do_chunk(rest, f, key, [first, ..current_chunk], acc)
       }
     }
     _empty -> reverse([reverse(current_chunk), ..acc])
@@ -1791,7 +1791,7 @@ fn do_chunk(
 pub fn chunk(in list: List(a), by f: fn(a) -> key) -> List(List(a)) {
   case list {
     [] -> []
-    [head, ..tail] -> do_chunk(tail, f, f(head), [head], [])
+    [first, ..rest] -> do_chunk(rest, f, f(first), [first], [])
   }
 }
 
@@ -1808,11 +1808,11 @@ fn do_sized_chunk(
         [] -> reverse(acc)
         remaining -> reverse([reverse(remaining), ..acc])
       }
-    [head, ..tail] -> {
-      let chunk = [head, ..current_chunk]
+    [first, ..rest] -> {
+      let chunk = [first, ..current_chunk]
       case left > 1 {
-        False -> do_sized_chunk(tail, count, count, [], [reverse(chunk), ..acc])
-        True -> do_sized_chunk(tail, count, left - 1, chunk, acc)
+        False -> do_sized_chunk(rest, count, count, [], [reverse(chunk), ..acc])
+        True -> do_sized_chunk(rest, count, left - 1, chunk, acc)
       }
     }
   }
@@ -1864,7 +1864,7 @@ pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
 pub fn reduce(over list: List(a), with fun: fn(a, a) -> a) -> Result(a, Nil) {
   case list {
     [] -> Error(Nil)
-    [head, ..tail] -> Ok(fold(tail, head, fun))
+    [first, ..rest] -> Ok(fold(rest, first, fun))
   }
 }
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -480,12 +480,12 @@ fn do_try_map(
 /// ```
 ///
 /// ```gleam
-/// > try_map([[1], [2, 3]], head)
+/// > try_map([[1], [2, 3]], first)
 /// Ok([1, 2])
 /// ```
 ///
 /// ```gleam
-/// > try_map([[1], [], [2]], head)
+/// > try_map([[1], [], [2]], first)
 /// Error(Nil)
 /// ```
 ///
@@ -851,17 +851,17 @@ pub fn find(
 /// ## Examples
 ///
 /// ```gleam
-/// > find_map([[], [2], [3]], head)
+/// > find_map([[], [2], [3]], first)
 /// Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > find_map([[], []], head)
+/// > find_map([[], []], first)
 /// Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > find_map([], head)
+/// > find_map([], first)
 /// Error(Nil)
 /// ```
 ///
@@ -1461,17 +1461,17 @@ fn do_pop_map(haystack, mapper, checked) {
 /// ## Examples
 ///
 /// ```gleam
-/// > pop_map([[], [2], [3]], head)
+/// > pop_map([[], [2], [3]], first)
 /// Ok(#(2, [[], [3]]))
 /// ```
 ///
 /// ```gleam
-/// > pop_map([[], []], head)
+/// > pop_map([[], []], first)
 /// Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > pop_map([], head)
+/// > pop_map([], first)
 /// Error(Nil)
 /// ```
 ///

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -557,7 +557,7 @@ pub fn update(
 fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(acc, k, v) -> acc) -> acc {
   case list {
     [] -> initial
-    [#(k, v), ..tail] -> do_fold(tail, fun(initial, k, v), fun)
+    [#(k, v), ..rest] -> do_fold(rest, fun(initial, k, v), fun)
   }
 }
 

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -24,7 +24,7 @@ pub fn new() -> Queue(a) {
 }
 
 /// Converts a list of elements into a queue of the same elements in the same
-/// order. The head element in the list becomes the front element in the queue.
+/// order. The first element in the list becomes the front element in the queue.
 ///
 /// This function runs in constant time.
 ///
@@ -40,7 +40,7 @@ pub fn from_list(list: List(a)) -> Queue(a) {
 }
 
 /// Converts a queue of elements into a list of the same elements in the same
-/// order. The front element in the queue becomes the head element in the list.
+/// order. The front element in the queue becomes the first element in the list.
 ///
 /// This function runs in linear time.
 ///

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -812,8 +812,8 @@ if erlang {
     acc: List(UtfCodepoint),
   ) -> List(UtfCodepoint) {
     case bit_string {
-      <<head:utf8_codepoint, rest:binary>> ->
-        do_to_utf_codepoints_impl(rest, [head, ..acc])
+      <<first:utf8_codepoint, rest:binary>> ->
+        do_to_utf_codepoints_impl(rest, [first, ..acc])
       <<>> -> acc
     }
   }
@@ -868,10 +868,10 @@ if erlang {
     acc: BitString,
   ) -> BitString {
     case utf_codepoints {
-      [head, ..tail] ->
+      [first, ..rest] ->
         do_from_utf_codepoints_impl(
-          tail,
-          <<acc:bit_string, head:utf8_codepoint>>,
+          rest,
+          <<acc:bit_string, first:utf8_codepoint>>,
         )
       [] -> acc
     }

--- a/test/gleam/function_test.gleam
+++ b/test/gleam/function_test.gleam
@@ -16,7 +16,7 @@ pub fn compose_test() {
   |> add_five
   |> should.equal(6)
 
-  // Takes a list of ints and returns the head as a string (if there is one, or
+  // Takes a list of ints and returns the first as a string (if there is one, or
   // else "0" if there is not)
   let first_to_string =
     list.first


### PR DESCRIPTION
- The documentation of some modules was still referencing the `list.head` and `list.tail` functions instead of `list.first` and `list.rest`
- To make the codebase more consistent and easy to approach I've also replaced all references to `[head, ..tail]` to `[first, ..rest]` so the naming scheme is consistent throughout the code and examples. This shouldn't create any merge conflict with already open PRs; however, I've kept all changes in a single commit that I can revert before merging if you think it's not necessary to update the codebase in this regard