### PR TITLE
Clean up `gleam_stdlib.mjs` source

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -371,7 +371,7 @@ export function utf_codepoint_to_int(utf_codepoint) {
 }
 
 export function regex_check(regex, string) {
-	regex.lastIndex = 0;
+  regex.lastIndex = 0;
   return regex.test(string);
 }
 
@@ -639,11 +639,11 @@ export function decode_tuple6(data) {
 
 function decode_tupleN(data, n) {
   if (Array.isArray(data) && data.length == n) {
-    return new Ok(data)
+    return new Ok(data);
   }
 
-  let list = decode_exact_length_list(data, n)
-  if (list) return new Ok(list)
+  let list = decode_exact_length_list(data, n);
+  if (list) return new Ok(list);
 
   return decoder_error(`Tuple of ${n} elements`, data);
 }
@@ -651,16 +651,16 @@ function decode_tupleN(data, n) {
 function decode_exact_length_list(data, n) {
   if (!List.isList(data)) return;
 
-  let elements = []
-  let current = data
+  let elements = [];
+  let current = data;
 
   for (let i = 0; i < n; i++) {
     if (current.isEmpty()) break;
-    elements.push(current.head)
-    current = current.tail
+    elements.push(current.head);
+    current = current.tail;
   }
 
-  if (elements.length === n && current.isEmpty()) return elements
+  if (elements.length === n && current.isEmpty()) return elements;
 }
 
 export function tuple_get(data, index) {


### PR DESCRIPTION
This PR cleans up the `gleam_stdlib.mjs` source by running it through Prettier.

The following changes were made:
- Replaced a tab literal with spaces to match the rest of the file
- Added missing semicolons on some lines