### PR TITLE
improve string.join and string.concat WIP including benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- improve `string.join` and `string.concat` performance on JavaScript target.
+
 ## v0.29.1 - 2023-06-01
 
 - Fixed a bug on target JavaScript where `regex.check` would not correctly execute

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,11 +8,7 @@ links = [
   { title = "Website", href = "https://gleam.run" },
   { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
-
-[dependencies]
-glychee = "~> 0.2"
-
-[dev-dependencies]
+dev-dependencies = { glychee = "~> 0.2"}
 
 [javascript.deno]
 allow_read = [

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,6 +10,7 @@ links = [
 ]
 
 [dependencies]
+glychee = "~> 0.2"
 
 [dev-dependencies]
 

--- a/src/benchmark.gleam
+++ b/src/benchmark.gleam
@@ -55,7 +55,7 @@ if javascript {
     |> string.join_old("\n")
     let timing = read_timer(bench_timer)
     io.print(
-      "string.join (current_impl) took " <> int.to_string(timing) <> "ms\n",
+      "string.join (current impl) took " <> int.to_string(timing) <> "ms\n",
     )
 
     let bench_timer = create_timer()

--- a/src/benchmark.gleam
+++ b/src/benchmark.gleam
@@ -1,0 +1,83 @@
+import gleam/io
+import gleam/list
+import gleam/string
+
+pub fn main() -> Nil {
+  io.print("Running benchmarks...\n")
+
+  run_benchmarks()
+}
+
+if erlang {
+  import glychee/benchmark
+
+  pub fn run_benchmarks() -> Nil {
+    let bench_data =
+      list.repeat("The quick brown fox jumps over the lazy dog", 10_000_000)
+
+    benchmark.run(
+      [
+        benchmark.Function(
+          label: "string.join (current impl)",
+          callable: fn(bench_data) {
+            fn() {
+              bench_data
+              |> string.join_old("\n")
+            }
+          },
+        ),
+        benchmark.Function(
+          label: "string.join (gleam impl)",
+          callable: fn(bench_data) {
+            fn() {
+              bench_data
+              |> string.join_gleam("\n")
+            }
+          },
+        ),
+      ],
+      [benchmark.Data(label: "bench_data", data: bench_data)],
+    )
+  }
+}
+
+if javascript {
+  import gleam/int
+
+  external type Timer
+
+  pub fn run_benchmarks() -> Nil {
+    let bench_data =
+      list.repeat("The quick brown fox jumps over the lazy dog", 10_000_000)
+
+    let bench_timer = create_timer()
+    bench_data
+    |> string.join_old("\n")
+    let timing = read_timer(bench_timer)
+    io.print(
+      "string.join (current_impl) took " <> int.to_string(timing) <> "ms\n",
+    )
+
+    let bench_timer = create_timer()
+    bench_data
+    |> string.join_gleam("\n")
+    let timing = read_timer(bench_timer)
+    io.print(
+      "string.join (gleam impl) took " <> int.to_string(timing) <> "ms\n",
+    )
+
+    let bench_timer = create_timer()
+    bench_data
+    |> string.join("\n")
+    let timing = read_timer(bench_timer)
+    io.print("string.join (js ffi impl) " <> int.to_string(timing) <> "ms\n")
+
+    Nil
+  }
+
+  external fn create_timer() -> Timer =
+    "./gleam_stdlib.mjs" "create_timer"
+
+  external fn read_timer(timer: Timer) -> Int =
+    "./gleam_stdlib.mjs" "read_timer"
+}

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -562,9 +562,46 @@ pub fn repeat(string: String, times times: Int) -> String {
 /// ```
 ///
 pub fn join(strings: List(String), with separator: String) -> String {
+  do_join(strings, separator)
+}
+
+pub fn join_gleam(strings: List(String), with separator: String) -> String {
+  do_join_gleam(strings, separator, "", "")
+}
+
+fn do_join_gleam(
+  strings: List(String),
+  separator: String,
+  previous: String,
+  current: String,
+) -> String {
+  case strings {
+    [] -> previous
+    [string, ..strings] -> {
+      let previous = current <> string
+      let current = previous <> separator
+      do_join_gleam(strings, separator, previous, current)
+    }
+  }
+}
+
+pub fn join_old(strings: List(String), with separator: String) -> String {
   strings
   |> list.intersperse(with: separator)
   |> concat
+}
+
+if erlang {
+  fn do_join(strings: List(String), separator: String) -> String {
+    strings
+    |> list.intersperse(with: separator)
+    |> concat
+  }
+}
+
+if javascript {
+  external fn do_join(strings: List(String), string: String) -> String =
+    "../gleam_stdlib.mjs" "join"
 }
 
 /// Pads a `String` on the left until it has at least given number of graphemes.
@@ -717,8 +754,8 @@ if javascript {
     "../gleam_stdlib.mjs" "trim_right"
 }
 
-/// Splits a non-empty `String` into its head and tail. This lets you
-/// pattern match on `String`s exactly as you would with lists.
+/// Splits a non-empty `String` into its first element (head) and rest (tail).
+/// This lets you pattern match on `String`s exactly as you would with lists.
 ///
 /// ## Examples
 ///

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -89,7 +89,7 @@ if erlang {
 
 if javascript {
   external fn do_from_strings(List(String)) -> StringBuilder =
-    "../gleam_stdlib.mjs" "join"
+    "../gleam_stdlib.mjs" "concat"
 }
 
 /// Joins a list of builders into a single builder.
@@ -107,7 +107,7 @@ if erlang {
 
 if javascript {
   external fn do_concat(List(StringBuilder)) -> StringBuilder =
-    "../gleam_stdlib.mjs" "join"
+    "../gleam_stdlib.mjs" "concat"
 }
 
 /// Converts a string into a builder.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -196,8 +196,20 @@ export function split(xs, pattern) {
   return List.fromArray(xs.split(pattern));
 }
 
-export function join(xs) {
-  return xs.toArray().join("");
+export function join(xs, separator) {
+  let result = "";
+  for (const x of xs) {
+    result = result + x + separator;
+  }
+  return result.slice(0, -separator.length);
+}
+
+export function concat(xs) {
+  let result = "";
+  for (const x of xs) {
+    result = result + x;
+  }
+  return result;
 }
 
 export function length(data) {
@@ -497,14 +509,14 @@ function uint6ToB64(nUint6) {
   return nUint6 < 26
     ? nUint6 + 65
     : nUint6 < 52
-    ? nUint6 + 71
-    : nUint6 < 62
-    ? nUint6 - 4
-    : nUint6 === 62
-    ? 43
-    : nUint6 === 63
-    ? 47
-    : 65;
+      ? nUint6 + 71
+      : nUint6 < 62
+        ? nUint6 - 4
+        : nUint6 === 62
+          ? 43
+          : nUint6 === 63
+            ? 47
+            : 65;
 }
 
 // From https://developer.mozilla.org/en-US/docs/Glossary/Base64#Solution_2_%E2%80%93_rewrite_the_DOMs_atob()_and_btoa()_using_JavaScript's_TypedArrays_and_UTF-8
@@ -512,14 +524,14 @@ function b64ToUint6(nChr) {
   return nChr > 64 && nChr < 91
     ? nChr - 65
     : nChr > 96 && nChr < 123
-    ? nChr - 71
-    : nChr > 47 && nChr < 58
-    ? nChr + 4
-    : nChr === 43
-    ? 62
-    : nChr === 47
-    ? 63
-    : 0;
+      ? nChr - 71
+      : nChr > 47 && nChr < 58
+        ? nChr + 4
+        : nChr === 43
+          ? 62
+          : nChr === 47
+            ? 63
+            : 0;
 }
 
 // From https://developer.mozilla.org/en-US/docs/Glossary/Base64#Solution_2_%E2%80%93_rewrite_the_DOMs_atob()_and_btoa()_using_JavaScript's_TypedArrays_and_UTF-8
@@ -733,3 +745,11 @@ function try_get_field(value, field, or_else) {
     return or_else();
   }
 }
+
+export function create_timer() {
+  return new Date();
+};
+
+export function read_timer(timer) {
+  return create_timer().getTime() - timer.getTime();
+};

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -196,13 +196,28 @@ export function split(xs, pattern) {
   return List.fromArray(xs.split(pattern));
 }
 
+// export function join(xs, separator) {
+//   let result = "";
+//   for (const x of xs) {
+//     result = result + x + separator;
+//   }
+//   return result.slice(0, -separator.length);
+// }
+
 export function join(xs, separator) {
   let result = "";
+  let i = 0;
   for (const x of xs) {
-    result = result + x + separator;
+    if (i == 0) {
+      result = x
+    } else {
+      result = result + separator + x;
+    }
+    i++;
   }
-  return result.slice(0, -separator.length);
+  return result;
 }
+
 
 export function concat(xs) {
   let result = "";


### PR DESCRIPTION
```
❯ asdf local nodejs 20.2.0
❯ gleam run -m benchmark --target javascript
  Compiling deep_merge
  Compiling statistex
  Compiling benchee
  Compiling gleam_stdlib
   Compiled in 0.01s
    Running benchmark.main
Running benchmarks...
string.join (current impl) took 9696ms
string.join (gleam impl) took 2966ms
string.join (js ffi impl) 2240ms
```

```
❯ asdf local nodejs 16.15.0
❯ gleam run -m benchmark --target javascript
  Compiling deep_merge
  Compiling statistex
  Compiling benchee
  Compiling gleam_stdlib
   Compiled in 0.01s
    Running benchmark.main
Running benchmarks...
string.join (current impl) took 14501ms
string.join (gleam impl) took 5426ms
string.join (js ffi impl) 2290ms
```

```
❯ gleam run -m benchmark --target erlang
  Compiling gleam_stdlib
   Compiled in 0.01s
    Running benchmark.main
Running benchmarks...


================================================================================
==== data set: bench_data
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Number of Available Cores: 16
Available memory: 32 GB
Elixir 1.14.2
Erlang 26.0

Benchmark suite executing with the following configuration:
warmup: 4 s
time: 8 s
memory time: 4 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 40 s

Benchmarking list.join (current impl) ...
Benchmarking list.join (gleam impl) ...

Name                               ips        average  deviation         median         99th %
list.join (current impl)          0.76         1.32 s     ±9.35%         1.26 s         1.58 s
list.join (gleam impl)            0.32         3.16 s     ±1.58%         3.17 s         3.21 s

Comparison:
list.join (current impl)          0.76
list.join (gleam impl)            0.32 - 2.40x slower +1.85 s

Memory usage statistics:

Name                        Memory usage
list.join (current impl)       607.25 MB
list.join (gleam impl)         762.94 MB - 1.26x memory usage +155.68 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                             average  deviation         median         99th %
list.join (current impl)         57.36 M     ±0.27%        57.36 M        57.47 M
list.join (gleam impl)           14.41 M     ±2.08%        14.41 M        14.62 M

Comparison:
list.join (current impl)         57.36 M
list.join (gleam impl)           14.41 M - 0.25x reduction count -42.95596 M
```