### PR TITLE
Add `result.ok()` like in rust

### DIFF
--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -359,6 +359,7 @@ pub fn lazy_or(
 /// ```gleam
 /// > Err("oh no!") |> ok
 /// None
+/// ```
 pub fn ok(
   result: Result(a, e)
 ) -> option.Option(a) {

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -2,6 +2,7 @@
 //// `Ok` means it was successful, `Error` means it was not successful.
 
 import gleam/list
+import gleam/option
 
 /// Checks whether the result is an `Ok` value.
 ///
@@ -343,6 +344,27 @@ pub fn lazy_or(
   case first {
     Ok(_) -> first
     Error(_) -> second()
+  }
+}
+
+/// Returns `Some(a)` if it is `Ok`, otherwise returns `None`.
+/// 
+/// ## Examples
+/// 
+/// ```gleam
+/// > Ok(1) |> ok
+/// Some(1)
+/// ```
+/// 
+/// ```gleam
+/// > Err("oh no!") |> ok
+/// None
+pub fn ok(
+  result: Result(a, e)
+) -> option.Option(a) {
+  case result {
+    Ok(val) -> option.Some(val)
+    Error(_) -> option.None
   }
 }
 

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -1,6 +1,7 @@
 import gleam/list
 import gleam/result
 import gleam/should
+import gleam/option
 
 pub fn is_ok_test() {
   result.is_ok(Ok(1))
@@ -184,6 +185,16 @@ pub fn lazy_or_test() {
   Error("Error 1")
   |> result.lazy_or(fn() { Error("Error 2") })
   |> should.equal(Error("Error 2"))
+}
+
+pub fn ok_test() {
+  Ok(1)
+  |> result.ok
+  |> should.equal(option.Some(1))
+
+  Error("uh oh")
+  |> result.ok
+  |> should.equal(option.None)
 }
 
 pub fn all_test() {


### PR DESCRIPTION
`result.ok()` is a function that transforms `Result(a, e)` into `Option(a)` and is useful for mixing operations that fail with/without errors or otherwise discarding errors when unnecessary. 