### PR TITLE
Add `result.any` and `result.lazy_any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The `result` module gains the `try_recover` function.
+- The `result` module gains the `any` and `lazy_any` functions.
 
 ## v0.29.1 - 2023-06-01
 

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -367,8 +367,9 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
   list.try_map(results, fn(x) { x })
 }
 
-/// Iterates through a list of results and returns the first success, if any.
-/// Returns the list otherwise, which will thus be a list of errors.
+/// Iterates through a list of results and returns the first success, if any,
+/// and does not continue iterating after encountering the first success.
+/// Returns the entire list otherwise, which will thus be a list of errors.
 /// 
 /// ## Examples
 /// 
@@ -379,7 +380,7 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
 /// 
 /// ```gleam
 /// > any([Error("e"), Error("b"), Error("c")])
-/// [Error("e"), Error("b"), Error("c")]
+/// Error(["e", "b", "c"])
 /// ```
 pub fn any(results: List(Result(a, e))) -> Result(a, List(e)) {
   case list.find_map(results, function.identity) {
@@ -393,18 +394,19 @@ pub fn any(results: List(Result(a, e))) -> Result(a, List(e)) {
   }
 }
 
-/// Iterates through a list of result-returning functions and returns the first success, if any.
-/// Returns the list of errors otherwise.
+/// Iterates through a list of result-returning functions and returns the first success, if any,
+/// and does not continue iterating after encountering the first success.
+/// Returns the entire list of errors otherwise.
 /// 
 /// ## Examples
 /// 
 /// ```gleam
-/// > any([fn() { Error("e") }, fn() { Ok(1) }, fn() { Error("2") }])
+/// > lazy_any([fn() { Error("e") }, fn() { Ok(1) }, fn() { Error("2") }])
 /// Ok(1)
 /// ```
 /// 
 /// ```gleam
-/// > any([fn() { Error("e") }, fn() { Error("b") }, fn() { Error("c") }])
+/// > lazy_any([fn() { Error("e") }, fn() { Error("b") }, fn() { Error("c") }])
 /// [Error("e"), Error("b"), Error("c")]
 /// ```
 pub fn lazy_any(results: List(fn() -> Result(a, e))) -> Result(a, List(e)) {

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -208,6 +208,10 @@ pub fn any_test() {
   [Error("a"), Error("b"), Error("c")]
   |> result.any
   |> should.equal(Error(["a", "b", "c"]))
+
+  []
+  |> result.any
+  |> should.equal(Error([]))
 }
 
 pub fn lazy_any_test() {
@@ -222,6 +226,10 @@ pub fn lazy_any_test() {
   [fn() { Error("a") }, fn() { Error("b") }, fn() { Error("c") }]
   |> result.lazy_any
   |> should.equal(Error(["a", "b", "c"]))
+
+  []
+  |> result.lazy_any
+  |> should.equal(Error([]))
 }
 
 pub fn partition_test() {

--- a/test/gleam/result_test.gleam
+++ b/test/gleam/result_test.gleam
@@ -196,6 +196,34 @@ pub fn all_test() {
   |> should.equal(Error("a"))
 }
 
+pub fn any_test() {
+  [Error(1), Ok(2), Ok(3)]
+  |> result.any
+  |> should.equal(Ok(2))
+
+  [Ok(1), Error("a"), Error("b"), Ok(3)]
+  |> result.any
+  |> should.equal(Ok(1))
+
+  [Error("a"), Error("b"), Error("c")]
+  |> result.any
+  |> should.equal(Error(["a", "b", "c"]))
+}
+
+pub fn lazy_any_test() {
+  [fn() { Error(1) }, fn() { Ok(2) }, fn() { Ok(3) }]
+  |> result.lazy_any
+  |> should.equal(Ok(2))
+
+  [fn() { Ok(1) }, fn() { Error("a") }, fn() { Error("b") }, fn() { Ok(3) }] 
+  |> result.lazy_any
+  |> should.equal(Ok(1))
+
+  [fn() { Error("a") }, fn() { Error("b") }, fn() { Error("c") }]
+  |> result.lazy_any
+  |> should.equal(Error(["a", "b", "c"]))
+}
+
 pub fn partition_test() {
   []
   |> result.partition


### PR DESCRIPTION
`any` and `lazy_any` work like `all`, but return on the first `Ok` or a list of all errors. 