### PR TITLE
Add description of `Order` ordering

### DIFF
--- a/src/gleam/order.gleam
+++ b/src/gleam/order.gleam
@@ -84,7 +84,7 @@ pub fn compare(a: Order, with b: Order) -> Order {
   }
 }
 
-/// Returns the largest of two orders.
+/// Returns the largest of two orders given that `Gt > Eq > Lt`.
 ///
 /// ## Examples
 ///
@@ -101,7 +101,7 @@ pub fn max(a: Order, b: Order) -> Order {
   }
 }
 
-/// Returns the smallest of two orders.
+/// Returns the smallest of two orders given that `Gt > Eq > Lt`.
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
In the module `order` the functions `max` and `min` did not explicitly state which variant is considered to be bigger/smaller, this may lead to confusion regarding their behaviour