### PR TITLE
Add `map2` and `map3` to `list` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `list` module gains the `list.map2` function.
+
 ## v0.29.2 - 2023-06-21
 
 - improve `string.join` and `string.concat` performance on JavaScript target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The `list` module gains the `list.map2` function.
+- The `list` module gains the `list.map3` function.
 
 ## v0.29.2 - 2023-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 - The `list` module gains the `list.map2` function.
-- The `list` module gains the `list.map3` function.
 
 ## v0.29.2 - 2023-06-21
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -412,6 +412,33 @@ fn do_map2(
   }
 }
 
+/// Combines three lists into a single list using the given function.
+///
+/// If a list is longer than the others the extra elements are dropped.
+///
+pub fn map3(
+  list1: List(a),
+  list2: List(b),
+  list3: List(c),
+  with fun: fn(a, b, c) -> d,
+) -> List(d) {
+  do_map3(list1, list2, list3, fun, [])
+}
+
+fn do_map3(
+  list1: List(a),
+  list2: List(b),
+  list3: List(c),
+  fun: fn(a, b, c) -> d,
+  acc: List(d),
+) -> List(d) {
+  case list1, list2, list3 {
+    [], _, _ | _, [], _ | _, _, [] -> reverse(acc)
+    [a, ..as_], [b, ..bs], [c, ..cs] ->
+      do_map3(as_, bs, cs, fun, [fun(a, b, c), ..acc])
+  }
+}
+
 /// Similar to `map` but also lets you pass around an accumulated value.
 ///
 /// ## Examples

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -412,33 +412,6 @@ fn do_map2(
   }
 }
 
-/// Combines three lists into a single list using the given function.
-///
-/// If a list is longer than the others the extra elements are dropped.
-///
-pub fn map3(
-  list1: List(a),
-  list2: List(b),
-  list3: List(c),
-  with fun: fn(a, b, c) -> d,
-) -> List(d) {
-  do_map3(list1, list2, list3, fun, [])
-}
-
-fn do_map3(
-  list1: List(a),
-  list2: List(b),
-  list3: List(c),
-  fun: fn(a, b, c) -> d,
-  acc: List(d),
-) -> List(d) {
-  case list1, list2, list3 {
-    [], _, _ | _, [], _ | _, _, [] -> reverse(acc)
-    [a, ..as_], [b, ..bs], [c, ..cs] ->
-      do_map3(as_, bs, cs, fun, [fun(a, b, c), ..acc])
-  }
-}
-
 /// Similar to `map` but also lets you pass around an accumulated value.
 ///
 /// ## Examples

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -380,6 +380,38 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
   do_map(list, fun, [])
 }
 
+/// Combines two lists into a single list using the given function.
+/// 
+/// If a list is longer than the other the extra elements are dropped.
+/// 
+/// ## Examples
+/// 
+/// ```gleam
+/// > map2([1, 2, 3], [4, 5, 6], fn(x, y) { x + y })
+/// [5, 7, 9]
+/// ```
+/// 
+/// ```gleam
+/// > map2([1, 2], ["a", "b", "c"], fn(i, x) { #(i, x) })
+/// [#(1, "a"), #(2, "b")]
+/// ```
+/// 
+pub fn map2(list1: List(a), list2: List(b), with fun: fn(a, b) -> c) -> List(c) {
+  do_map2(list1, list2, fun, [])
+}
+
+fn do_map2(
+  list1: List(a),
+  list2: List(b),
+  fun: fn(a, b) -> c,
+  acc: List(c),
+) -> List(c) {
+  case list1, list2 {
+    [], _ | _, [] -> reverse(acc)
+    [a, ..as_], [b, ..bs] -> do_map2(as_, bs, fun, [fun(a, b), ..acc])
+  }
+}
+
 /// Similar to `map` but also lets you pass around an accumulated value.
 ///
 /// ## Examples

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -189,6 +189,29 @@ pub fn map2_test() {
   list.map2(list, list, int.add)
 }
 
+pub fn map3_test() {
+  let add3 = fn(x, y, z) { x + y + z }
+
+  list.map3([], [1, 2, 3], [4, 5, 6], add3)
+  |> should.equal([])
+
+  list.map3([1, 2, 3], [], [4, 5, 6], add3)
+  |> should.equal([])
+
+  list.map3([1, 2, 3], [4, 5, 6], [], add3)
+  |> should.equal([])
+
+  list.map3([1, 2, 3], [4, 5], [6], add3)
+  |> should.equal([11])
+
+  list.map3([1, 2, 3], [4, 5, 6], [7, 8, 9], add3)
+  |> should.equal([12, 15, 18])
+
+  // TCO test
+  let list = list.repeat(0, recursion_test_cycles)
+  list.map3(list, list, list, add3)
+}
+
 pub fn map_fold_test() {
   [1, 2, 3, 4]
   |> list.map_fold(from: 0, with: fn(acc, i) { #(acc + i, i * 2) })

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -189,29 +189,6 @@ pub fn map2_test() {
   list.map2(list, list, int.add)
 }
 
-pub fn map3_test() {
-  let add3 = fn(x, y, z) { x + y + z }
-
-  list.map3([], [1, 2, 3], [4, 5, 6], add3)
-  |> should.equal([])
-
-  list.map3([1, 2, 3], [], [4, 5, 6], add3)
-  |> should.equal([])
-
-  list.map3([1, 2, 3], [4, 5, 6], [], add3)
-  |> should.equal([])
-
-  list.map3([1, 2, 3], [4, 5], [6], add3)
-  |> should.equal([11])
-
-  list.map3([1, 2, 3], [4, 5, 6], [7, 8, 9], add3)
-  |> should.equal([12, 15, 18])
-
-  // TCO test
-  let list = list.repeat(0, recursion_test_cycles)
-  list.map3(list, list, list, add3)
-}
-
 pub fn map_fold_test() {
   [1, 2, 3, 4]
   |> list.map_fold(from: 0, with: fn(acc, i) { #(acc + i, i * 2) })

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -168,6 +168,27 @@ pub fn map_test() {
   |> list.map(fn(x) { x })
 }
 
+pub fn map2_test() {
+  list.map2([1, 2, 3], [], int.add)
+  |> should.equal([])
+
+  list.map2([], [1, 2, 3], int.add)
+  |> should.equal([])
+
+  list.map2([], [], int.add)
+  |> should.equal([])
+
+  list.map2([1, 2, 3], [4, 5], int.add)
+  |> should.equal([5, 7])
+
+  list.map2([1, 2, 3], [4, 5, 6], int.add)
+  |> should.equal([5, 7, 9])
+
+  // TCO test
+  let list = list.repeat(0, recursion_test_cycles)
+  list.map2(list, list, int.add)
+}
+
 pub fn map_fold_test() {
   [1, 2, 3, 4]
   |> list.map_fold(from: 0, with: fn(acc, i) { #(acc + i, i * 2) })


### PR DESCRIPTION
If you feel like it could be useful I could also add `map4`, `map5` etc.