### PR TITLE
Handle inspect on Erlang atoms (that can be created from strings in Gleam), that are invalid in Gleam.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.0
         with:
           otp-version: "24.2.2"
-          gleam-version: "0.28.3"
+          gleam-version: "0.29"
       - uses: actions/setup-node@v3.5.1
         with:
           node-version: "16.18.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug on target Erlang where `string.inspect` would show atoms created
+  from strings, which are valid in Erlang but invalid in Gleam, as if they were
+  similar equivalent Gleam atoms. Now for atoms created from strings, which are
+  invalid in Gleam, the Erlang representation is shown, instead.
+
 ## v0.30.0 - 2023-07-16
 
 - The `list` module gains the `list.map2` function.

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -417,22 +417,16 @@ inspect(Any) when is_function(Any) ->
 inspect(Any) ->
     ["//erl(", io_lib:format("~p", [Any]), ")"].
 
-% Cannot be an empty string
 inspect_maybe_gleam_atom([], none, []) ->
     {error, no_gleam_atom};
-% Cannot start with a digit
 inspect_maybe_gleam_atom([Head | _Rest], none, []) when ?is_digit_char(Head) ->
     {error, no_gleam_atom};
-% Cannot start with an underscore
 inspect_maybe_gleam_atom([$_ | _Rest], none, []) ->
     {error, no_gleam_atom};
-% Cannot end with an underscore
 inspect_maybe_gleam_atom([$_ | []], _PrevChar, _Acc) ->
     {error, no_gleam_atom};
-% Cannot contain consecutive underscores
 inspect_maybe_gleam_atom([$_ | _Rest], $_, _Acc) ->
     {error, no_gleam_atom};
-% Need to only contain lowercase letters, digits, underscores
 inspect_maybe_gleam_atom([Head | _Rest], _PrevChar, _Acc)
     when ?is_lowercase_char(Head) == false andalso ?is_underscore_char(Head) == false andalso ?is_digit_char(Head) == false ->
     {error, no_gleam_atom};

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -428,7 +428,7 @@ inspect_maybe_gleam_atom([$_ | []], _PrevChar, _Acc) ->
 inspect_maybe_gleam_atom([$_ | _Rest], $_, _Acc) ->
     {error, no_gleam_atom};
 inspect_maybe_gleam_atom([Head | _Rest], _PrevChar, _Acc)
-    when ?is_lowercase_char(Head) == false andalso ?is_underscore_char(Head) == false andalso ?is_digit_char(Head) == false ->
+    when not (?is_lowercase_char(Head) orelse ?is_underscore_char(Head) orelse ?is_digit_char(Head)) ->
     {error, no_gleam_atom};
 inspect_maybe_gleam_atom([Head | Rest], none, Acc) ->
     inspect_maybe_gleam_atom(Rest, Head, [string:uppercase([Head]) | Acc]);

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -984,6 +984,89 @@ if erlang {
     improper_tail,
   ) -> List(anything) =
     "gleam_stdlib_test_ffi" "improper_list_append"
+
+  // Test inspect on Erlang atoms valid and invalid in Gleam
+  pub external type Dynamic
+
+  external fn string_to_erlang_atom(String) -> Dynamic =
+    "erlang" "binary_to_atom"
+
+  pub fn inspect_erlang_atom_is_valid_in_gleam_test() {
+    string_to_erlang_atom("a_common_erlang_atom_is_valid_in_gleam")
+    |> string.inspect
+    |> should.equal("ACommonErlangAtomIsValidInGleam")
+
+    string_to_erlang_atom(
+      "an_erlang_atom_with_1_or_many_non_leading_digits_is_valid_in_gleam",
+    )
+    |> string.inspect
+    |> should.equal("AnErlangAtomWith1OrManyNonLeadingDigitsIsValidInGleam")
+  }
+
+  pub fn inspect_erlang_atom_with_a_leading_underscore_is_invalid_in_gleam_test() {
+    string_to_erlang_atom(
+      "_an_erlang_atom_with_a_leading_underscore_is_invalid_in_gleam",
+    )
+    |> string.inspect
+    |> should.equal(
+      "//erl('_an_erlang_atom_with_a_leading_underscore_is_invalid_in_gleam')",
+    )
+  }
+
+  pub fn inspect_erlang_atom_with_a_trailing_underscore_is_invalid_in_gleam_test() {
+    string_to_erlang_atom(
+      "an_erlang_atom_with_a_trailing_underscore_is_invalid_in_gleam_",
+    )
+    |> string.inspect
+    |> should.equal(
+      "//erl(an_erlang_atom_with_a_trailing_underscore_is_invalid_in_gleam_)",
+    )
+  }
+
+  pub fn inspect_erlang_atom_with_a_double_underscore_is_invalid_in_gleam_test() {
+    string_to_erlang_atom("an_erlang_atom_with_a_double__underscore_is_invalid")
+    |> string.inspect
+    |> should.equal(
+      "//erl(an_erlang_atom_with_a_double__underscore_is_invalid)",
+    )
+  }
+
+  pub fn inspect_erlang_atom_with_white_spaces_is_invalid_in_gleam_test() {
+    string_to_erlang_atom(
+      "an erlang atom with white spaces is invalid in gleam",
+    )
+    |> string.inspect
+    |> should.equal(
+      "//erl('an erlang atom with white spaces is invalid in gleam')",
+    )
+  }
+
+  pub fn inspect_erlang_atom_that_is_an_empty_string_is_invalid_in_gleam_test() {
+    // An empty string based atom is invalid in gleam
+    string_to_erlang_atom("")
+    |> string.inspect
+    |> should.equal("//erl('')")
+  }
+
+  pub fn inspect_erlang_atom_with_uppercases_invalid_in_gleam_test() {
+    string_to_erlang_atom("AnErlangAtomWithUpperCasesIsInvalidInGleam")
+    |> string.inspect
+    |> should.equal("//erl('AnErlangAtomWithUpperCasesIsInvalidInGleam')")
+  }
+
+  pub fn inspect_erlang_atom_with_leading_digit_invalid_in_gleam_test() {
+    string_to_erlang_atom(
+      "1_erlang_atom_with_a_leading_digit_is_invalid_in_gleam",
+    )
+    |> string.inspect
+    |> should.equal(
+      "//erl('1_erlang_atom_with_a_leading_digit_is_invalid_in_gleam')",
+    )
+
+    string_to_erlang_atom("1ErlangAtomWithALeadingDigitIsInvalidInGleam")
+    |> string.inspect
+    |> should.equal("//erl('1ErlangAtomWithALeadingDigitIsInvalidInGleam')")
+  }
 }
 
 pub fn byte_size_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -917,6 +917,8 @@ if javascript {
 
 if erlang {
   import gleam/regex
+  // Test inspect on Erlang atoms valid and invalid in Gleam
+  import gleam/dynamic.{Dynamic}
 
   external fn create_erlang_pid() -> String =
     "erlang" "self"
@@ -984,9 +986,6 @@ if erlang {
     improper_tail,
   ) -> List(anything) =
     "gleam_stdlib_test_ffi" "improper_list_append"
-
-  // Test inspect on Erlang atoms valid and invalid in Gleam
-  pub external type Dynamic
 
   external fn string_to_erlang_atom(String) -> Dynamic =
     "erlang" "binary_to_atom"

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -1019,7 +1019,7 @@ if erlang {
     )
     |> string.inspect
     |> should.equal(
-      "//erl(an_erlang_atom_with_a_trailing_underscore_is_invalid_in_gleam_)",
+      "//erl('an_erlang_atom_with_a_trailing_underscore_is_invalid_in_gleam_')",
     )
   }
 
@@ -1027,7 +1027,7 @@ if erlang {
     string_to_erlang_atom("an_erlang_atom_with_a_double__underscore_is_invalid")
     |> string.inspect
     |> should.equal(
-      "//erl(an_erlang_atom_with_a_double__underscore_is_invalid)",
+      "//erl('an_erlang_atom_with_a_double__underscore_is_invalid')",
     )
   }
 

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -917,8 +917,9 @@ if javascript {
 
 if erlang {
   import gleam/regex
-  // Test inspect on Erlang atoms valid and invalid in Gleam
   import gleam/dynamic.{Dynamic}
+
+  // Test inspect on Erlang atoms valid and invalid in Gleam
 
   external fn create_erlang_pid() -> String =
     "erlang" "self"


### PR DESCRIPTION
Replaces https://github.com/gleam-lang/stdlib/pull/447