### PR TITLE
Remove special character from `map2`'s doc

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -384,7 +384,7 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
 /// 
 /// If a list is longer than the other the extra elements are dropped.
 /// 
-/// ## Examples
+/// ## Examples
 /// 
 /// ```gleam
 /// > map2([1, 2, 3], [4, 5, 6], fn(x, y) { x + y })


### PR DESCRIPTION
In my `map2` PR I inadvertently used a special character that prevents the markdown doc of map2 to render correctly