### PR TITLE
Sort out the `flatten`/`concat` naming convention for iterators and lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - `list.flatten` is no longer deprecated and is kept as a synonym of
   `list.concat`
 - The `iterator` module gains the `concat` function.
-- The type of `iterator.flatten` was changed to accept a list of iterators.
 
 ## v0.30.2 - 2023-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- `list.flatten` is no longer deprecated and is kept as a synonym of
+  `list.concat`
+- `flatten` has been renamed to `concat` in the `iterator` module. The old name
+  is still available as an alias and is deprecated.
+
 ## v0.30.2 - 2023-08-31
 
 - Fixed a bug where `base.decode64` could crash on the Erlang target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - `list.flatten` is no longer deprecated and is kept as a synonym of
   `list.concat`
-- `flatten` has been renamed to `concat` in the `iterator` module. The old name
-  is still available as an alias and is deprecated.
+- The `iterator` module gains the `concat` function.
+- The type of `iterator.flatten` was changed to accept a list of iterators.
 
 ## v0.30.2 - 2023-08-31
 

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -413,11 +413,11 @@ pub fn append(to first: Iterator(a), suffix second: Iterator(a)) -> Iterator(a) 
   |> Iterator
 }
 
-fn do_concat(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
+fn do_flatten(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
   case flattened() {
     Stop -> Stop
     Continue(it, next_iterator) ->
-      do_append(it.continuation, fn() { do_concat(next_iterator) })
+      do_append(it.continuation, fn() { do_flatten(next_iterator) })
   }
 }
 
@@ -432,13 +432,13 @@ fn do_concat(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
 /// > from_list([[1, 2], [3, 4]])
 /// > |> map(from_list)
 /// > |> from_list
-/// > |> concat
+/// > |> flatten
 /// > |> to_list
 /// [1, 2, 3, 4]
 /// ```
 ///
-pub fn concat(iterator: Iterator(Iterator(a))) -> Iterator(a) {
-  fn() { do_concat(iterator.continuation) }
+pub fn flatten(iterator: Iterator(Iterator(a))) -> Iterator(a) {
+  fn() { do_flatten(iterator.continuation) }
   |> Iterator
 }
 
@@ -452,13 +452,13 @@ pub fn concat(iterator: Iterator(Iterator(a))) -> Iterator(a) {
 /// ```gleam
 /// > [[1, 2], [3, 4]]
 /// > |> map(from_list)
-/// > |> flatten
+/// > |> concat
 /// > |> to_list
 /// [1, 2, 3, 4]
 /// ```
 ///
-pub fn flatten(iterators: List(Iterator(a))) -> Iterator(a) {
-  concat(from_list(iterators))
+pub fn concat(iterators: List(Iterator(a))) -> Iterator(a) {
+  flatten(from_list(iterators))
 }
 
 /// Creates an iterator from an existing iterator and a transformation function.
@@ -486,7 +486,7 @@ pub fn flat_map(
 ) -> Iterator(b) {
   iterator
   |> map(f)
-  |> concat
+  |> flatten
 }
 
 fn do_filter(
@@ -545,7 +545,7 @@ pub fn filter(
 ///
 pub fn cycle(iterator: Iterator(a)) -> Iterator(a) {
   repeat(iterator)
-  |> concat
+  |> flatten
 }
 
 /// Creates an iterator of ints, starting at a given start int and stepping by

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -421,7 +421,7 @@ fn do_concat(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
   }
 }
 
-/// Flattens an iterator of iterators, creating a new iterator.
+/// Joins an iterator of iterators into a single iterator.
 ///
 /// This function does not evaluate the elements of the iterator, the
 /// computation is performed when the iterator is later run.
@@ -442,11 +442,23 @@ pub fn concat(iterator: Iterator(Iterator(a))) -> Iterator(a) {
   |> Iterator
 }
 
-// TODO: Add deprecation attribute and then remove later.
-/// This function is deprecated, see `concat` instead.
-pub fn flatten(iterator: Iterator(Iterator(a))) -> Iterator(a) {
-  fn() { do_concat(iterator.continuation) }
-  |> Iterator
+/// Joins a list of iterators into a single iterator.
+///
+/// This function does not evaluate the elements of the iterator, the
+/// computation is performed when the iterator is later run.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > [[1, 2], [3, 4]]
+/// > |> map(from_list)
+/// > |> flatten
+/// > |> to_list
+/// [1, 2, 3, 4]
+/// ```
+///
+pub fn flatten(iterators: List(Iterator(a))) -> Iterator(a) {
+  concat(from_list(iterators))
 }
 
 /// Creates an iterator from an existing iterator and a transformation function.

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -421,7 +421,7 @@ fn do_flatten(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
   }
 }
 
-/// Joins an iterator of iterators into a single iterator.
+/// Flattens an iterator of iterators, creating a new iterator.
 ///
 /// This function does not evaluate the elements of the iterator, the
 /// computation is performed when the iterator is later run.
@@ -431,7 +431,6 @@ fn do_flatten(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
 /// ```gleam
 /// > from_list([[1, 2], [3, 4]])
 /// > |> map(from_list)
-/// > |> from_list
 /// > |> flatten
 /// > |> to_list
 /// [1, 2, 3, 4]

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -680,8 +680,18 @@ pub fn concat(lists: List(List(a))) -> List(a) {
   do_concat(lists, [])
 }
 
-// TODO: Add deprecation attribute and then remove later.
-/// This function is deprecated, see `concat` instead.
+/// This is the same as `concat`: it joins a list of lists into a single
+/// list.
+/// 
+/// This function traverses all elements twice.
+/// 
+/// ## Examples
+/// 
+/// ```gleam
+/// > flatten([[1], [2, 3], []])
+/// [1, 2, 3]
+/// ```
+/// 
 pub fn flatten(lists: List(List(a))) -> List(a) {
   do_concat(lists, [])
 }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -156,7 +156,7 @@ pub fn map_test() {
 }
 
 // a |> from_list |> flat_map(f) |> to_list ==
-//   a |> list.map(f) |> list.map(to_list) |> list.flatten
+//   a |> list.map(f) |> list.map(to_list) |> list.concat
 pub fn flat_map_test() {
   let test = fn(subject, f) {
     subject
@@ -178,7 +178,7 @@ pub fn flat_map_test() {
   test([1, 2], f)
 }
 
-// a |> from_list |> append(from_list(b)) |> to_list == list.flatten([a, b])
+// a |> from_list |> append(from_list(b)) |> to_list == list.concat([a, b])
 pub fn append_test() {
   let test = fn(left, right) {
     left
@@ -193,13 +193,13 @@ pub fn append_test() {
   test([1, 2], [3, 4])
 }
 
-// a |> list.map(from_list) |> flatten |> to_list == list.flatten(a)
-pub fn flatten_test() {
+// a |> list.map(from_list) |> concat |> to_list == list.concat(a)
+pub fn concat_test() {
   let test = fn(lists) {
     lists
     |> list.map(iterator.from_list)
     |> iterator.from_list
-    |> iterator.flatten
+    |> iterator.concat
     |> iterator.to_list
     |> should.equal(list.concat(lists))
   }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -193,13 +193,13 @@ pub fn append_test() {
   test([1, 2], [3, 4])
 }
 
-// a |> list.map(from_list) |> from_list |> concat |> to_list == list.concat(a)
-pub fn concat_test() {
+// a |> list.map(from_list) |> from_list |> flatten |> to_list == list.concat(a)
+pub fn flatten_test() {
   let test = fn(lists) {
     lists
     |> list.map(iterator.from_list)
     |> iterator.from_list
-    |> iterator.concat
+    |> iterator.flatten
     |> iterator.to_list
     |> should.equal(list.concat(lists))
   }
@@ -209,12 +209,12 @@ pub fn concat_test() {
   test([[1, 2], [3, 4]])
 }
 
-// a |> list.map(from_list) |> flatten |> to_list == list.concat(a)
-pub fn flatten_test() {
+// a |> list.map(from_list) |> concat |> to_list == list.concat(a)
+pub fn concat_test() {
   let test = fn(lists) {
     lists
     |> list.map(iterator.from_list)
-    |> iterator.flatten
+    |> iterator.concat
     |> iterator.to_list
     |> should.equal(list.concat(lists))
   }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -193,13 +193,28 @@ pub fn append_test() {
   test([1, 2], [3, 4])
 }
 
-// a |> list.map(from_list) |> concat |> to_list == list.concat(a)
+// a |> list.map(from_list) |> from_list |> concat |> to_list == list.concat(a)
 pub fn concat_test() {
   let test = fn(lists) {
     lists
     |> list.map(iterator.from_list)
     |> iterator.from_list
     |> iterator.concat
+    |> iterator.to_list
+    |> should.equal(list.concat(lists))
+  }
+
+  test([[], []])
+  test([[1], [2]])
+  test([[1, 2], [3, 4]])
+}
+
+// a |> list.map(from_list) |> flatten |> to_list == list.concat(a)
+pub fn flatten_test() {
+  let test = fn(lists) {
+    lists
+    |> list.map(iterator.from_list)
+    |> iterator.flatten
     |> iterator.to_list
     |> should.equal(list.concat(lists))
   }

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -306,6 +306,20 @@ pub fn concat_test() {
   // }
 }
 
+pub fn flatten_test() {
+  list.flatten([])
+  |> should.equal([])
+
+  list.flatten([[]])
+  |> should.equal([])
+
+  list.flatten([[], [], []])
+  |> should.equal([])
+
+  list.flatten([[1, 2], [], [3, 4]])
+  |> should.equal([1, 2, 3, 4])
+}
+
 pub fn flat_map_test() {
   list.flat_map([1, 10, 20], fn(x) { [x, x + 1] })
   |> should.equal([1, 2, 10, 11, 20, 21])


### PR DESCRIPTION
As @vonagam pointed out in #474 `iterator.flatten` is not consistent with `list.concat`, this PR deprecates `iterator.flatten` in favour of `iterator.concat`