### PR TITLE
Adds examples for base functions

### DIFF
--- a/src/gleam/base.gleam
+++ b/src/gleam/base.gleam
@@ -3,6 +3,24 @@ import gleam/string
 
 /// Encodes a BitString into a base 64 encoded string.
 ///
+/// ## Examples
+///
+/// ```gleam
+/// "https://gleam.run"
+/// |> bit_string.from_string()
+/// |> base.encode64(True)
+/// 
+/// // "aHR0cHM6Ly9nbGVhbS5ydW4="
+/// ```
+/// 
+/// ```gleam
+/// "https://gleam.run"
+/// |> bit_string.from_string()
+/// |> base.encode64(False)
+/// 
+/// // "aHR0cHM6Ly9nbGVhbS5ydW4"
+/// ```
+///
 pub fn encode64(input: BitString, padding: Bool) -> String {
   let encoded = do_encode64(input)
   case padding {
@@ -17,6 +35,19 @@ fn do_encode64(a: BitString) -> String
 
 /// Decodes a base 64 encoded string into a `BitString`.
 ///
+/// ## Examples
+///
+/// ```gleam
+/// base.decode64("aHR0cHM6Ly9nbGVhbS5ydW4=")
+/// 
+/// // Ok("https://gleam.run")
+/// ```
+///
+/// ```gleam
+/// base.decode64("a")
+/// 
+/// // Error(Nil)
+/// ```
 pub fn decode64(encoded: String) -> Result(BitString, Nil) {
   let padded = case bit_string.byte_size(bit_string.from_string(encoded)) % 4 {
     0 -> encoded
@@ -31,6 +62,24 @@ fn do_decode64(a: String) -> Result(BitString, Nil)
 
 /// Encodes a `BitString` into a base 64 encoded string with URL and filename safe alphabet.
 ///
+/// ## Examples
+///
+/// ```gleam
+/// "https://gleam.run"
+/// |> bit_string.from_string()
+/// |> base.url_encode64(True)
+/// 
+/// // "aHR0cHM6Ly9nbGVhbS5ydW4="
+/// ```
+/// 
+/// ```gleam
+/// "https://gleam.run"
+/// |> bit_string.from_string()
+/// |> base.url_encode64(False)
+/// 
+/// // "aHR0cHM6Ly9nbGVhbS5ydW4"
+/// ```
+///
 pub fn url_encode64(input: BitString, padding: Bool) -> String {
   encode64(input, padding)
   |> string.replace("+", "-")
@@ -38,6 +87,20 @@ pub fn url_encode64(input: BitString, padding: Bool) -> String {
 }
 
 /// Decodes a base 64 encoded string with URL and filename safe alphabet into a `BitString`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// base.url_decode64("aHR0cHM6Ly9nbGVhbS5ydW4=")
+/// 
+/// // Ok("https://gleam.run")
+/// ```
+/// 
+/// ```gleam
+/// base.url_decode64("a")
+/// 
+/// // Error(Nil)
+/// ```
 ///
 pub fn url_decode64(encoded: String) -> Result(BitString, Nil) {
   encoded


### PR DESCRIPTION
This is a POC for adding examples to our functions in the `base` module. There was some discussion in #general in Discord about how these examples should look and I'm open to feedback. Whatever we adopt here, I'll carry over into other areas of the documentation.

I'd also love feedback on the examples themselves to see if they can be improved :)

![base](https://github.com/gleam-lang/stdlib/assets/921826/bd5c93d2-69ea-4805-97e2-f83e707701f5)
