### PR TITLE
Add list index functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The `iterator` module gains the `map2` function.
+- The `list` module gains the `index_of` and `find_index` functions.
 
 ## v0.31.0 - 2023-09-25
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2118,3 +2118,70 @@ pub fn shuffle(list: List(a)) -> List(a) {
   |> do_shuffle_by_pair_indexes()
   |> do_shuffle_pair_unwrap([])
 }
+
+fn do_find_index(
+  haystack: List(a),
+  is_desired: fn(a) -> Bool,
+  index_acc: Int,
+) -> Result(Int, Nil) {
+  case haystack {
+    [] -> Error(Nil)
+    [first, ..rest] ->
+      case is_desired(first) {
+        True -> Ok(index_acc)
+        False -> do_find_index(rest, is_desired, index_acc + 1)
+      }
+  }
+}
+
+/// Finds the index of the first element in a given list for which the given function returns
+/// `True`.
+///
+/// Returns `Error(Nil)` if no such element is found.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > find_index(["A", "B", "C"], fn(x) { x == "C" })
+/// ```
+///
+/// ```gleam
+/// > find_index([1, 2, 3], fn(x) { x > 1 })
+/// Ok(1)
+/// ```
+///
+/// ```gleam
+/// > find_index([], fn(_) { True })
+/// Error(Nil)
+/// ```
+///
+pub fn find_index(
+  in haystack: List(a),
+  one_that is_desired: fn(a) -> Bool,
+) -> Result(Int, Nil) {
+  do_find_index(haystack, is_desired, 0)
+}
+
+/// Finds the index of the first element in a given list that is equivalent to
+/// the given item.
+///
+/// Returns `Error(Nil)` if no such element is found.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > index_of(["A", "B", "C"], "C")
+/// Ok(2)
+/// ```
+///
+/// ```gleam
+/// > find_index([], True)
+/// Error(Nil)
+/// ```
+///
+pub fn index_of(
+  in haystack: List(a), 
+  the_first match_to: a,
+  ) -> Result(Int, Nil) {
+  find_index(haystack, fn(x) { x == match_to })
+}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1260,3 +1260,31 @@ pub fn shuffle_test() {
   list.range(0, recursion_test_cycles)
   |> list.shuffle()
 }
+
+pub fn index_of_test() {
+  []
+  |> list.index_of(1)
+  |> should.equal(Error(Nil))
+
+  [1, 2, 3, 4]
+  |> list.index_of(3)
+  |> should.equal(Ok(2))
+
+  ["A", "B", "C"]
+  |> list.index_of("D")
+  |> should.equal(Error(Nil))
+}
+
+pub fn find_index_test() {
+  []
+  |> list.find_index(fn(x) { x == 2 })
+  |> should.equal(Error(Nil))
+
+  [1, 2, 3, 4]
+  |> list.find_index(fn(x) { x >= 3 })
+  |> should.equal(2)
+
+  [1, 2, 3]
+  |> list.find_index(fn(x) { x >= 4 })
+  |> should.equal(Error(Nil))
+}


### PR DESCRIPTION
This adds two helper functions to get the index of a matching item:

- `find_index`, like `find`, takes a function.
- `index_of` takes an item, then passes a comparison function to `find_index`.