### PR TITLE
Fix map equality checking when the amount of keys differs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Improved performance of `string.to_graphemes` on JavaScript.
 - The `iterator` module gains the `map2` function.
 - The `list` module gains the `key_filter` function.
+- Fixed a bug on target JavaScript where `Map` equality would not be correctly
+  checked for maps of different sizes.
 
 ## v0.31.0 - 2023-09-25
 

--- a/src/persistent-hash-map.mjs
+++ b/src/persistent-hash-map.mjs
@@ -945,7 +945,7 @@ export default class PMap {
    * @returns {boolean}
    */
   equals(o) {
-    if (!(o instanceof PMap)) {
+    if (!(o instanceof PMap) || this.size !== o.size) {
       return false;
     }
     let equal = true;

--- a/test/gleam/map_test.gleam
+++ b/test/gleam/map_test.gleam
@@ -375,3 +375,19 @@ pub fn zero_must_be_contained_test() {
   |> map.has_key(0)
   |> should.equal(True)
 }
+
+pub fn empty_map_equality_test() {
+  let map1 = map.new()
+  let map2 = map.from_list([#(1, 2)])
+
+  should.be_false(map1 == map2)
+  should.be_false(map2 == map1)
+}
+
+pub fn extra_keys_equality_test() {
+  let map1 = map.from_list([#(1, 2), #(3, 4)])
+  let map2 = map.from_list([#(1, 2), #(3, 4), #(4, 5)])
+
+  should.be_false(map1 == map2)
+  should.be_false(map2 == map1)
+}


### PR DESCRIPTION
This is an attempt at a fix for #497. Both JS and Erlang target tests pass.