### PR TITLE
Rename `{thing}.filter` predicate's label 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `set.filter` label `for` was renamed to `keeping`.
 - The `map.filter` label `for` was renamed to `keeping`.
 - The `iterator.filter` label `for` was renamed to `keeping`.
 - The `list.filter` label `for` was renamed to `keeping`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `map.filter` label `for` was renamed to `keeping`.
 - The `iterator.filter` label `for` was renamed to `keeping`.
 - The `list.filter` label `for` was renamed to `keeping`.
 - Improved performance of `string.to_graphemes` on JavaScript.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `list.filter` label `for` was renamed to `keeping`.
 - Improved performance of `string.to_graphemes` on JavaScript.
 - The `iterator` module gains the `map2` function.
 - The `list` module gains the `key_filter` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `iterator.filter` label `for` was renamed to `keeping`.
 - The `list.filter` label `for` was renamed to `keeping`.
 - Improved performance of `string.to_graphemes` on JavaScript.
 - The `iterator` module gains the `map2` function.

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -573,7 +573,7 @@ fn do_filter(
 ///
 pub fn filter(
   iterator: Iterator(a),
-  for predicate: fn(a) -> Bool,
+  keeping predicate: fn(a) -> Bool,
 ) -> Iterator(a) {
   fn() { do_filter(iterator.continuation, predicate) }
   |> Iterator

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -317,7 +317,7 @@ fn do_filter(list: List(a), fun: fn(a) -> Bool, acc: List(a)) -> List(a) {
 /// []
 /// ```
 ///
-pub fn filter(list: List(a), for predicate: fn(a) -> Bool) -> List(a) {
+pub fn filter(list: List(a), keeping predicate: fn(a) -> Bool) -> List(a) {
   do_filter(list, predicate, [])
 }
 

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -308,9 +308,9 @@ fn do_values(map: Map(k, v)) -> List(v) {
 ///
 pub fn filter(
   in map: Map(k, v),
-  keeping property: fn(k, v) -> Bool,
+  keeping predicate: fn(k, v) -> Bool,
 ) -> Map(k, v) {
-  do_filter(property, map)
+  do_filter(predicate, map)
 }
 
 @target(erlang)

--- a/src/gleam/map.gleam
+++ b/src/gleam/map.gleam
@@ -306,7 +306,10 @@ fn do_values(map: Map(k, v)) -> List(v) {
 /// from_list([#("a", 0), #("b", 1)])
 /// ```
 ///
-pub fn filter(in map: Map(k, v), for property: fn(k, v) -> Bool) -> Map(k, v) {
+pub fn filter(
+  in map: Map(k, v),
+  keeping property: fn(k, v) -> Bool,
+) -> Map(k, v) {
   do_filter(property, map)
 }
 

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -194,7 +194,7 @@ pub fn fold(
 ///
 pub fn filter(
   in set: Set(member),
-  for property: fn(member) -> Bool,
+  keeping property: fn(member) -> Bool,
 ) -> Set(member) {
   Set(map.filter(in: set.map, keeping: fn(m, _) { property(m) }))
 }

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -194,9 +194,9 @@ pub fn fold(
 ///
 pub fn filter(
   in set: Set(member),
-  keeping property: fn(member) -> Bool,
+  keeping predicate: fn(member) -> Bool,
 ) -> Set(member) {
-  Set(map.filter(in: set.map, keeping: fn(m, _) { property(m) }))
+  Set(map.filter(in: set.map, keeping: fn(m, _) { predicate(m) }))
 }
 
 pub fn drop(from set: Set(member), drop disallowed: List(member)) -> Set(member) {

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -196,7 +196,7 @@ pub fn filter(
   in set: Set(member),
   for property: fn(member) -> Bool,
 ) -> Set(member) {
-  Set(map.filter(in: set.map, for: fn(m, _) { property(m) }))
+  Set(map.filter(in: set.map, keeping: fn(m, _) { property(m) }))
 }
 
 pub fn drop(from set: Set(member), drop disallowed: List(member)) -> Set(member) {

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -68,7 +68,7 @@ pub fn fold_test() {
 pub fn filter_test() {
   [1, 4, 6, 3, 675, 44, 67]
   |> set.from_list()
-  |> set.filter(for: int.is_even)
+  |> set.filter(keeping: int.is_even)
   |> set.to_list
   |> list.sort(int.compare)
   |> should.equal([4, 6, 44])


### PR DESCRIPTION
This PR closes #502 by renaming the `for` labels in the `{thing}.filter` functions to `keeping`