### PR TITLE
Fix formatting in docs for dynamic

### DIFF
--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -742,6 +742,7 @@ pub fn tuple3(
 /// > from(#(1, 2.0, "3", 4))
 /// > |> tuple4(int, float, string, int)
 /// Ok(#(1, 2.0, "3", 4))
+/// ```
 ///
 /// ```gleam
 /// > from([1, 2, 3, 4])
@@ -755,6 +756,7 @@ pub fn tuple3(
 /// Ok(#(1, 2.0, "3", 4))
 /// ```
 ///
+/// ```gleam
 /// > from(#(1, 2))
 /// > |> tuple4(int, float, string, int)
 /// Error([

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -827,7 +827,9 @@ pub fn tuple4(
 /// Error([
 ///   DecodeError(expected: "Tuple of 5 elements", found: "Tuple of 2 elements", path: [])),
 /// ])
+/// ```
 ///
+/// ```gleam
 /// > from("")
 /// > |> tuple5(int, float, string, int, int)
 /// Error([DecodeError(expected: "Tuple of 5 elements", found: "String", path: [])])


### PR DESCRIPTION
This fixes some display issues in the docs for the examples for the `dynamic.tuple4`:

*Old*
![image](https://github.com/gleam-lang/stdlib/assets/3816591/e739118e-dd73-49ab-8394-cd05c5aea7ab)

*New*
![image](https://github.com/gleam-lang/stdlib/assets/3816591/a9c32884-5968-4158-94fd-00b0281eb5c6)

And separates and formats 2 examples for `dynamic.tuple5`:

*Old*
![image](https://github.com/gleam-lang/stdlib/assets/3816591/33a873a3-1ffe-4769-a657-ef77bead0d63)

*New*
![image](https://github.com/gleam-lang/stdlib/assets/3816591/09fb334d-9f49-4983-a0cf-8e8dedcf197d)

