### PR TITLE
list.index_map: change callback signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Changed `list.index_map` callback signature to `fn(a, Int) -> b` from `fn(Int, a) -> b`, to be consistent with `list.index_fold`.
+- Changed `iterator.index` to return `Iterator(#(a, Int))` instead of `Iterator(#(Int, a))`.
 
 ## v0.33.1 - 2023-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Changed `list.index_map` callback signature to `fn(a, Int) -> b` from `fn(Int, a) -> b`, to be consistent with `list.index_fold`.
+
 ## v0.33.1 - 2023-12-02
 
 - Fixed `string.to_graphemes` failing on JavaScript runtimes when the

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -689,12 +689,12 @@ pub fn find(
 fn do_index(
   continuation: fn() -> Action(element),
   next: Int,
-) -> fn() -> Action(#(Int, element)) {
+) -> fn() -> Action(#(element, Int)) {
   fn() {
     case continuation() {
       Stop -> Stop
       Continue(e, continuation) ->
-        Continue(#(next, e), do_index(continuation, next + 1))
+        Continue(#(e, next), do_index(continuation, next + 1))
     }
   }
 }
@@ -705,10 +705,10 @@ fn do_index(
 ///
 /// ```gleam
 /// > from_list(["a", "b", "c"]) |> index |> to_list
-/// [#(0, "a"), #(1, "b"), #(2, "c")]
+/// [#("a", 0), #("b", 1), #("c", 2)]
 /// ```
 ///
-pub fn index(over iterator: Iterator(element)) -> Iterator(#(Int, element)) {
+pub fn index(over iterator: Iterator(element)) -> Iterator(#(element, Int)) {
   iterator.continuation
   |> do_index(0)
   |> Iterator

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -442,14 +442,14 @@ pub fn map_fold(
 
 fn do_index_map(
   list: List(a),
-  fun: fn(Int, a) -> b,
+  fun: fn(a, Int) -> b,
   index: Int,
   acc: List(b),
 ) -> List(b) {
   case list {
     [] -> reverse(acc)
     [x, ..xs] -> {
-      let acc = [fun(index, x), ..acc]
+      let acc = [fun(x, index), ..acc]
       do_index_map(xs, fun, index + 1, acc)
     }
   }
@@ -464,11 +464,11 @@ fn do_index_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > index_map(["a", "b"], fn(i, x) { #(i, x) })
+/// > index_map(["a", "b"], fn(x, i) { #(i, x) })
 /// [#(0, "a"), #(1, "b")]
 /// ```
 ///
-pub fn index_map(list: List(a), with fun: fn(Int, a) -> b) -> List(b) {
+pub fn index_map(list: List(a), with fun: fn(a, Int) -> b) -> List(b) {
   do_index_map(list, fun, 0, [])
 }
 
@@ -1718,7 +1718,7 @@ pub fn permutations(l: List(a)) -> List(List(a)) {
     [] -> [[]]
     _ ->
       l
-      |> index_map(fn(i_idx, i) {
+      |> index_map(fn(i, i_idx) {
         l
         |> index_fold(
           [],

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -362,7 +362,7 @@ pub fn index_test() {
   iterator.from_list(["a", "b", "c"])
   |> iterator.index
   |> iterator.to_list
-  |> should.equal([#(0, "a"), #(1, "b"), #(2, "c")])
+  |> should.equal([#("a", 0), #("b", 1), #("c", 2)])
 }
 
 pub fn iterate_test() {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -697,14 +697,14 @@ pub fn sort_test() {
 }
 
 pub fn index_map_test() {
-  list.index_map([3, 4, 5], fn(i, x) { #(i, x) })
+  list.index_map([3, 4, 5], fn(x, i) { #(i, x) })
   |> should.equal([#(0, 3), #(1, 4), #(2, 5)])
 
-  let f = fn(i, x) { #(x, i) }
+  let f = fn(x, i) { #(x, i) }
   list.index_map(["a", "b"], f)
   |> should.equal([#("a", 0), #("b", 1)])
 
-  let f = fn(i, x) { #(x, i) }
+  let f = fn(x, i) { #(x, i) }
   list.index_map(["a", "b", "c"], f)
   |> should.equal([#("a", 0), #("b", 1), #("c", 2)])
 }


### PR DESCRIPTION
Changed `list.index_map` callback signature to `fn(a, Int) -> b` from `fn(Int, a) -> b`, to be consistent with `list.index_fold`.
