### PR TITLE
Add set difference function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `set` module gains the `difference` function.
+
 ## v0.34.0 - 2023-12-17
 
 - The `int.random` function now takes a single argument.

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -260,3 +260,20 @@ pub fn intersection(
   let #(larger, smaller) = order(first, second)
   take(from: larger, keeping: to_list(smaller))
 }
+
+/// Creates a new set that contains members that are present in the first set
+/// but not the second.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > difference(from_list([1, 2]), from_list([2, 3, 4])) |> to_list
+/// [1]
+/// ```
+///
+pub fn difference(
+  from first: Set(member),
+  minus second: Set(member),
+) -> Set(member) {
+  drop(from: first, drop: to_list(second))
+}

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -63,6 +63,7 @@ pub fn fold_test() {
   [1, 3, 9]
   |> set.from_list
   |> set.fold(from: 0, with: fn(m, a) { m + a })
+  |> should.equal(13)
 }
 
 pub fn filter_test() {
@@ -99,4 +100,10 @@ pub fn intersection_test() {
   set.intersection(set.from_list([1, 2]), set.from_list([2, 3]))
   |> set.to_list
   |> should.equal([2])
+}
+
+pub fn difference_test() {
+  set.difference(set.from_list([1, 2]), set.from_list([2, 3, 4]))
+  |> set.to_list
+  |> should.equal([1])
 }


### PR DESCRIPTION
While working on a different Gleam project, I noticed there wasn't a quick way to do a difference from one set to another. Figured this could be nice quality of life addition to the set module.