### PR TITLE
Make doc examples consistent in style

### DIFF
--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -19,8 +19,8 @@ pub fn byte_size(x: BitArray) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// > append(to: from_string("butter"), suffix: from_string("fly"))
-/// from_string("butterfly")
+/// append(to: from_string("butter"), suffix: from_string("fly"))
+/// // -> from_string("butterfly")
 /// ```
 ///
 pub fn append(to first: BitArray, suffix second: BitArray) -> BitArray {
@@ -95,8 +95,8 @@ fn do_to_string(a: BitArray) -> Result(String, Nil)
 /// ## Examples
 ///
 /// ```gleam
-/// > concat([from_string("butter"), from_string("fly")])
-/// from_string("butterfly")
+/// concat([from_string("butter"), from_string("fly")])
+/// // -> from_string("butterfly")
 /// ```
 ///
 @external(erlang, "gleam_stdlib", "bit_array_concat")

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -16,18 +16,18 @@ import gleam/order.{type Order}
 /// ## Examples
 ///
 /// ```gleam
-/// > and(True, True)
-/// True
+/// and(True, True)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > and(False, True)
-/// False
+/// and(False, True)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > False |> and(True)
-/// False
+/// False |> and(True)
+/// // -> False
 /// ```
 ///
 pub fn and(a: Bool, b: Bool) -> Bool {
@@ -42,18 +42,18 @@ pub fn and(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > or(True, True)
-/// True
+/// or(True, True)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > or(False, True)
-/// True
+/// or(False, True)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > False |> or(True)
-/// True
+/// False |> or(True)
+/// // -> True
 /// ```
 ///
 pub fn or(a: Bool, b: Bool) -> Bool {
@@ -67,13 +67,13 @@ pub fn or(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > negate(True)
-/// False
+/// negate(True)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > negate(False)
-/// True
+/// negate(False)
+/// // -> True
 /// ```
 ///
 pub fn negate(bool: Bool) -> Bool {
@@ -88,23 +88,23 @@ pub fn negate(bool: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > nor(False, False)
-/// True
+/// nor(False, False)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > nor(False, True)
-/// False
+/// nor(False, True)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > nor(True, False)
-/// False
+/// nor(True, False)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > nor(True, True)
-/// False
+/// nor(True, True)
+/// // -> False
 /// ```
 ///
 pub fn nor(a: Bool, b: Bool) -> Bool {
@@ -121,23 +121,23 @@ pub fn nor(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > nand(False, False)
-/// True
+/// nand(False, False)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > nand(False, True)
-/// True
+/// nand(False, True)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > nand(True, False)
-/// True
+/// nand(True, False)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > nand(True, True)
-/// False
+/// nand(True, True)
+/// // -> False
 /// ```
 ///
 pub fn nand(a: Bool, b: Bool) -> Bool {
@@ -154,23 +154,23 @@ pub fn nand(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > exclusive_or(False, False)
-/// False
+/// exclusive_or(False, False)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > exclusive_or(False, True)
-/// True
+/// exclusive_or(False, True)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > exclusive_or(True, False)
-/// True
+/// exclusive_or(True, False)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > exclusive_or(True, True)
-/// False
+/// exclusive_or(True, True)
+/// // -> False
 /// ```
 ///
 pub fn exclusive_or(a: Bool, b: Bool) -> Bool {
@@ -187,23 +187,23 @@ pub fn exclusive_or(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > exclusive_nor(False, False)
-/// True
+/// exclusive_nor(False, False)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > exclusive_nor(False, True)
-/// False
+/// exclusive_nor(False, True)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > exclusive_nor(True, False)
-/// False
+/// exclusive_nor(True, False)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > exclusive_nor(True, True)
-/// True
+/// exclusive_nor(True, True)
+/// // -> True
 /// ```
 ///
 pub fn exclusive_nor(a: Bool, b: Bool) -> Bool {
@@ -220,9 +220,9 @@ pub fn exclusive_nor(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/order
-/// > compare(True, False)
-/// order.Gt
+/// import gleam/order
+/// compare(True, False)
+/// // -> order.Gt
 /// ```
 ///
 pub fn compare(a: Bool, with b: Bool) -> Order {
@@ -239,18 +239,18 @@ pub fn compare(a: Bool, with b: Bool) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > max(True, False)
-/// True
+/// max(True, False)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > max(False, True)
-/// True
+/// max(False, True)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > max(False, False)
-/// False
+/// max(False, False)
+/// // -> False
 /// ```
 ///
 pub fn max(a: Bool, b: Bool) -> Bool {
@@ -265,16 +265,18 @@ pub fn max(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > min(True, False)
-/// False
+/// min(True, False)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > min(False, True)
-/// False
+/// min(False, True)
+/// // -> False
+/// ```
 ///
-/// > min(False, False)
-/// False
+/// ```gleam
+/// min(False, False)
+/// // -> False
 /// ```
 ///
 pub fn min(a: Bool, b: Bool) -> Bool {
@@ -289,11 +291,13 @@ pub fn min(a: Bool, b: Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_int(True)
-/// 1
+/// to_int(True)
+/// // -> 1
+/// ```
 ///
-/// > to_int(False)
-/// 0
+/// ```gleam
+/// to_int(False)
+/// // -> 0
 /// ```
 ///
 pub fn to_int(bool: Bool) -> Int {
@@ -308,13 +312,13 @@ pub fn to_int(bool: Bool) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_string(True)
-/// "True"
+/// to_string(True)
+/// // -> "True"
 /// ```
 ///
 /// ```gleam
-/// > to_string(False)
-/// "False"
+/// to_string(False)
+/// // -> "False"
 /// ```
 ///
 pub fn to_string(bool: Bool) -> String {
@@ -363,17 +367,17 @@ pub fn to_string(bool: Bool) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > let name = ""
-/// > use <- guard(when: name == "", return: "Welcome!")
-/// > "Hello, " <> name
-/// "Welcome!"
+/// let name = ""
+/// use <- guard(when: name == "", return: "Welcome!")
+/// "Hello, " <> name
+/// // -> "Welcome!"
 /// ```
 ///
 /// ```gleam
-/// > let name = "Kamaka"
-/// > use <- guard(when: name == "", return: "Welcome!")
-/// > "Hello, " <> name
-/// "Hello, Kamaka"
+/// let name = "Kamaka"
+/// use <- guard(when: name == "", return: "Welcome!")
+/// "Hello, " <> name
+/// // -> "Hello, Kamaka"
 /// ```
 ///
 pub fn guard(
@@ -398,22 +402,22 @@ pub fn guard(
 /// ## Examples
 ///
 /// ```gleam
-/// > let name = "Kamaka"
-/// > let inquiry = fn() { "How may we address you?" }
-/// > use <- lazy_guard(when: name == "", return: inquiry)
-/// > "Hello, " <> name
-/// "Hello, Kamaka"
+/// let name = "Kamaka"
+/// let inquiry = fn() { "How may we address you?" }
+/// use <- lazy_guard(when: name == "", return: inquiry)
+/// "Hello, " <> name
+/// // -> "Hello, Kamaka"
 /// ```
 ///
 /// ```gleam
-/// > import gleam/int
-/// > let name = ""
-/// > let greeting = fn() { "Hello, " <> name }
-/// > use <- lazy_guard(when: name == "", otherwise: greeting)
-/// > let number = int.random(1, 99)
-/// > let name = "User " <> int.to_string(number)
-/// > "Welcome, " <> name
-/// "Welcome, User 54"
+/// import gleam/int
+/// let name = ""
+/// let greeting = fn() { "Hello, " <> name }
+/// use <- lazy_guard(when: name == "", otherwise: greeting)
+/// let number = int.random(1, 99)
+/// let name = "User " <> int.to_string(number)
+/// "Welcome, " <> name
+/// // -> "Welcome, User 54"
 /// ```
 ///
 pub fn lazy_guard(

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -22,13 +22,13 @@ pub type Dict(key, value)
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> size()
-/// 0
+/// new() |> size
+/// // -> 0
 /// ```
 ///
 /// ```gleam
-/// > new() |> insert("key", "value") |> size()
-/// 1
+/// new() |> insert("key", "value") |> size
+/// // -> 1
 /// ```
 ///
 @external(erlang, "maps", "size")
@@ -43,13 +43,13 @@ pub fn size(dict: Dict(k, v)) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> to_list()
-/// []
+/// new()
+/// // -> from_list([])
 /// ```
 ///
 /// ```gleam
-/// > new() |> insert("key", 0) |> to_list()
-/// [#("key", 0)]
+/// new() |> insert("key", 0)
+/// // -> from_list([#("key", 0)])
 /// ```
 ///
 @external(erlang, "maps", "to_list")
@@ -81,13 +81,13 @@ fn fold_list_of_pair(
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert("a", 0) |> has_key("a")
-/// True
+/// new() |> insert("a", 0) |> has_key("a")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > new() |> insert("a", 0) |> has_key("b")
-/// False
+/// new() |> insert("a", 0) |> has_key("b")
+/// // -> False
 /// ```
 ///
 pub fn has_key(dict: Dict(k, v), key: k) -> Bool {
@@ -117,13 +117,13 @@ fn do_new() -> Dict(key, value)
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert("a", 0) |> get("a")
-/// Ok(0)
+/// new() |> insert("a", 0) |> get("a")
+/// // -> Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > new() |> insert("a", 0) |> get("b")
-/// Error(Nil)
+/// new() |> insert("a", 0) |> get("b")
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn get(from: Dict(key, value), get: key) -> Result(value, Nil) {
@@ -142,13 +142,13 @@ fn do_get(a: Dict(key, value), b: key) -> Result(value, Nil)
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert("a", 0) |> to_list
-/// [#("a", 0)]
+/// new() |> insert("a", 0)
+/// // -> from_list([#("a", 0)])
 /// ```
 ///
 /// ```gleam
-/// > new() |> insert("a", 0) |> insert("a", 5) |> to_list
-/// [#("a", 5)]
+/// new() |> insert("a", 0) |> insert("a", 5)
+/// // -> from_list([#("a", 5)])
 /// ```
 ///
 pub fn insert(into dict: Dict(k, v), for key: k, insert value: v) -> Dict(k, v) {
@@ -165,10 +165,9 @@ fn do_insert(a: key, b: value, c: Dict(key, value)) -> Dict(key, value)
 /// ## Examples
 ///
 /// ```gleam
-/// > [#(3, 3), #(2, 4)]
-/// > |> from_list
-/// > |> map_values(fn(key, value) { key * value })
-/// [#(3, 9), #(2, 8)]
+/// from_list([#(3, 3), #(2, 4)])
+/// |> map_values(fn(key, value) { key * value })
+/// // -> from_list([#(3, 9), #(2, 8)])
 /// ```
 ///
 pub fn map_values(in dict: Dict(k, v), with fun: fn(k, v) -> w) -> Dict(k, w) {
@@ -191,8 +190,8 @@ fn do_map_values(f: fn(key, value) -> b, dict: Dict(key, value)) -> Dict(key, b)
 /// ## Examples
 ///
 /// ```gleam
-/// > keys([#("a", 0), #("b", 1)])
-/// ["a", "b"]
+/// from_list([#("a", 0), #("b", 1)]) |> keys
+/// // -> ["a", "b"]
 /// ```
 ///
 pub fn keys(dict: Dict(keys, v)) -> List(keys) {
@@ -228,8 +227,8 @@ fn do_keys_acc(list: List(#(k, v)), acc: List(k)) -> List(k) {
 /// ## Examples
 ///
 /// ```gleam
-/// > values(from_list([#("a", 0), #("b", 1)]))
-/// [0, 1]
+/// from_list([#("a", 0), #("b", 1)]) |> values
+/// // -> [0, 1]
 /// ```
 ///
 pub fn values(dict: Dict(k, values)) -> List(values) {
@@ -255,15 +254,15 @@ fn do_values_acc(list: List(#(k, v)), acc: List(v)) -> List(v) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([#("a", 0), #("b", 1)])
-/// > |> filter(fn(key, value) { value != 0 })
-/// from_list([#("b", 1)])
+/// from_list([#("a", 0), #("b", 1)])
+/// |> filter(fn(key, value) { value != 0 })
+/// // -> from_list([#("b", 1)])
 /// ```
 ///
 /// ```gleam
-/// > from_list([#("a", 0), #("b", 1)])
-/// > |> filter(fn(key, value) { True })
 /// from_list([#("a", 0), #("b", 1)])
+/// |> filter(fn(key, value) { True })
+/// // -> from_list([#("a", 0), #("b", 1)])
 /// ```
 ///
 pub fn filter(
@@ -294,15 +293,15 @@ fn do_filter(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([#("a", 0), #("b", 1)])
-/// > |> take(["b"])
-/// from_list([#("b", 1)])
+/// from_list([#("a", 0), #("b", 1)])
+/// |> take(["b"])
+/// // -> from_list([#("b", 1)])
 /// ```
 ///
 /// ```gleam
-/// > from_list([#("a", 0), #("b", 1)])
-/// > |> take(["a", "b", "c"])
 /// from_list([#("a", 0), #("b", 1)])
+/// |> take(["a", "b", "c"])
+/// // -> from_list([#("a", 0), #("b", 1)])
 /// ```
 ///
 pub fn take(from dict: Dict(k, v), keeping desired_keys: List(k)) -> Dict(k, v) {
@@ -339,10 +338,10 @@ fn insert_taken(
 /// ## Examples
 ///
 /// ```gleam
-/// > let a = from_list([#("a", 0), #("b", 1)])
-/// > let b = from_list([#("b", 2), #("c", 3)])
-/// > merge(a, b)
-/// from_list([#("a", 0), #("b", 2), #("c", 3)])
+/// let a = from_list([#("a", 0), #("b", 1)])
+/// let b = from_list([#("b", 2), #("c", 3)])
+/// merge(a, b)
+/// // -> from_list([#("a", 0), #("b", 2), #("c", 3)])
 /// ```
 ///
 pub fn merge(into dict: Dict(k, v), from new_entries: Dict(k, v)) -> Dict(k, v) {
@@ -373,13 +372,13 @@ fn fold_inserts(new_entries: List(#(k, v)), dict: Dict(k, v)) -> Dict(k, v) {
 /// ## Examples
 ///
 /// ```gleam
-/// > delete([#("a", 0), #("b", 1)], "a")
-/// from_list([#("b", 1)])
+/// from_list([#("a", 0), #("b", 1)]) |> delete("a")
+/// // -> from_list([#("b", 1)])
 /// ```
 ///
 /// ```gleam
-/// > delete([#("a", 0), #("b", 1)], "c")
-/// from_list([#("a", 0), #("b", 1)])
+/// from_list([#("a", 0), #("b", 1)]) |> delete("c")
+/// // -> from_list([#("a", 0), #("b", 1)])
 /// ```
 ///
 pub fn delete(from dict: Dict(k, v), delete key: k) -> Dict(k, v) {
@@ -396,18 +395,18 @@ fn do_delete(a: k, b: Dict(k, v)) -> Dict(k, v)
 /// ## Examples
 ///
 /// ```gleam
-/// > drop([#("a", 0), #("b", 1)], ["a"])
-/// from_list([#("b", 2)])
+/// from_list([#("a", 0), #("b", 1)]) |> drop(["a"])
+/// // -> from_list([#("b", 2)])
 /// ```
 ///
 /// ```gleam
-/// > delete([#("a", 0), #("b", 1)], ["c"])
-/// from_list([#("a", 0), #("b", 1)])
+/// from_list([#("a", 0), #("b", 1)]) |> drop(["c"])
+/// // -> from_list([#("a", 0), #("b", 1)])
 /// ```
 ///
 /// ```gleam
-/// > drop([#("a", 0), #("b", 1)], ["a", "b", "c"])
-/// from_list([])
+/// from_list([#("a", 0), #("b", 1)]) |> drop(["a", "b", "c"])
+/// // -> from_list([])
 /// ```
 ///
 pub fn drop(from dict: Dict(k, v), drop disallowed_keys: List(k)) -> Dict(k, v) {
@@ -425,21 +424,19 @@ pub fn drop(from dict: Dict(k, v), drop disallowed_keys: List(k)) -> Dict(k, v) 
 /// ## Example
 ///
 /// ```gleam
-/// > let increment = fn(x) {
-/// >   case x {
-/// >     Some(i) -> i + 1
-/// >     None -> 0
-/// >   }
-/// > }
-/// > let dict = from_list([#("a", 0)])
-/// >
-/// > update(dict, "a", increment)
-/// from_list([#("a", 1)])
-/// ```
+/// let dict = from_list([#("a", 0)])
+/// let increment = fn(x) {
+///   case x {
+///     Some(i) -> i + 1
+///     None -> 0
+///   }
+/// }
 ///
-/// ```gleam
-/// > update(dict, "b", increment)
-/// from_list([#("a", 0), #("b", 0)])
+///  update(dict, "a", increment)
+/// // -> from_list([#("a", 1)])
+///
+/// update(dict, "b", increment)
+/// // -> from_list([#("a", 0), #("b", 0)])
 /// ```
 ///
 pub fn update(
@@ -471,15 +468,19 @@ fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(acc, k, v) -> acc) -> acc 
 /// # Examples
 ///
 /// ```gleam
-/// > let dict = from_list([#("a", 1), #("b", 3), #("c", 9)])
-/// > fold(dict, 0, fn(accumulator, key, value) { accumulator + value })
-/// 13
+/// let dict = from_list([#("a", 1), #("b", 3), #("c", 9)])
+/// fold(dict, 0, fn(accumulator, key, value) { accumulator + value })
+/// // -> 13
 /// ```
 ///
 /// ```gleam
-/// > import gleam/string.{append}
-/// > fold(dict, "", fn(accumulator, key, value) { append(accumulator, key) })
-/// "abc"
+/// import gleam/string
+///
+/// let dict = from_list([#("a", 1), #("b", 3), #("c", 9)])
+/// fold(dict, "", fn(accumulator, key, value) { 
+///   string.append(accumulator, key)
+/// })
+/// // -> "abc"
 /// ```
 ///
 pub fn fold(

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -66,13 +66,14 @@ pub fn dynamic(value: Dynamic) -> Result(Dynamic, List(DecodeError)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > bit_array(from("Hello")) == bit_array.from_string("Hello")
-/// True
+/// import gleam/bit_array
+/// bit_array(from("Hello")) == bit_array.from_string("Hello")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > bit_array(from(123))
-/// Error([DecodeError(expected: "BitArray", found: "Int", path: [])])
+/// bit_array(from(123))
+/// // -> Error([DecodeError(expected: "BitArray", found: "Int", path: [])])
 /// ```
 ///
 pub fn bit_array(from data: Dynamic) -> Result(BitArray, DecodeErrors) {
@@ -94,13 +95,13 @@ fn decode_bit_array(a: Dynamic) -> Result(BitArray, DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > string(from("Hello"))
-/// Ok("Hello")
+/// string(from("Hello"))
+/// // -> Ok("Hello")
 /// ```
 ///
 /// ```gleam
-/// > string(from(123))
-/// Error([DecodeError(expected: "String", found: "Int", path: [])])
+/// string(from(123))
+/// // -> Error([DecodeError(expected: "String", found: "Int", path: [])])
 /// ```
 ///
 pub fn string(from data: Dynamic) -> Result(String, DecodeErrors) {
@@ -139,8 +140,8 @@ fn decode_string(a: Dynamic) -> Result(String, DecodeErrors)
 /// Return a string indicating the type of the dynamic value.
 ///
 /// ```gleam
-/// > classify(from("Hello"))
-/// "String"
+/// classify(from("Hello"))
+/// // -> "String"
 /// ```
 ///
 pub fn classify(data: Dynamic) -> String {
@@ -157,13 +158,13 @@ fn do_classify(a: Dynamic) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > int(from(123))
-/// Ok(123)
+/// int(from(123))
+/// // -> Ok(123)
 /// ```
 ///
 /// ```gleam
-/// > int(from("Hello"))
-/// Error([DecodeError(expected: "Int", found: "String", path: [])])
+/// int(from("Hello"))
+/// // -> Error([DecodeError(expected: "Int", found: "String", path: [])])
 /// ```
 ///
 pub fn int(from data: Dynamic) -> Result(Int, DecodeErrors) {
@@ -180,13 +181,13 @@ fn decode_int(a: Dynamic) -> Result(Int, DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > float(from(2.0))
-/// Ok(2.0)
+/// float(from(2.0))
+/// // -> Ok(2.0)
 /// ```
 ///
 /// ```gleam
-/// > float(from(123))
-/// Error([DecodeError(expected: "Float", found: "Int", path: [])])
+/// float(from(123))
+/// // -> Error([DecodeError(expected: "Float", found: "Int", path: [])])
 /// ```
 ///
 pub fn float(from data: Dynamic) -> Result(Float, DecodeErrors) {
@@ -203,13 +204,13 @@ fn decode_float(a: Dynamic) -> Result(Float, DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > bool(from(True))
-/// Ok(True)
+/// bool(from(True))
+/// // -> Ok(True)
 /// ```
 ///
 /// ```gleam
-/// > bool(from(123))
-/// Error([DecodeError(expected: "Bool", found: "Int", path: [])])
+/// bool(from(123))
+/// // -> Error([DecodeError(expected: "Bool", found: "Int", path: [])])
 /// ```
 ///
 pub fn bool(from data: Dynamic) -> Result(Bool, DecodeErrors) {
@@ -229,13 +230,13 @@ fn decode_bool(a: Dynamic) -> Result(Bool, DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > shallow_list(from(["a", "b", "c"]))
-/// Ok([from("a"), from("b"), from("c")])
+/// shallow_list(from(["a", "b", "c"]))
+/// // -> Ok([from("a"), from("b"), from("c")])
 /// ```
 ///
 /// ```gleam
-/// > shallow_list(1)
-/// Error([DecodeError(expected: "List", found: "Int", path: [])])
+/// shallow_list(1)
+/// // -> Error([DecodeError(expected: "List", found: "Int", path: [])])
 /// ```
 ///
 pub fn shallow_list(from value: Dynamic) -> Result(List(Dynamic), DecodeErrors) {
@@ -259,21 +260,18 @@ fn decode_result(a: Dynamic) -> Result(Result(a, e), DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > from(Ok(1))
-/// > |> result(ok: int, error: string)
-/// Ok(Ok(1))
+/// from(Ok(1)) |> result(ok: int, error: string)
+/// // -> Ok(Ok(1))
 /// ```
 ///
 /// ```gleam
-/// > from(Error("boom"))
-/// > |> result(ok: int, error: string)
-/// Ok(Error("boom"))
+/// from(Error("boom")) |> result(ok: int, error: string)
+/// // -> Ok(Error("boom"))
 /// ```
 ///
 /// ```gleam
-/// > from(123)
-/// > |> result(ok: int, error: string)
-/// Error([DecodeError(expected: "Result", found: "Int", path: [])])
+/// from(123) |> result(ok: int, error: string)
+/// // -> Error([DecodeError(expected: "Result", found: "Int", path: [])])
 /// ```
 ///
 pub fn result(
@@ -315,21 +313,18 @@ pub fn result(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(["a", "b", "c"])
-/// > |> list(of: string)
-/// Ok(["a", "b", "c"])
+/// from(["a", "b", "c"]) |> list(of: string)
+/// // -> Ok(["a", "b", "c"])
 /// ```
 ///
 /// ```gleam
-/// > from([1, 2, 3])
-/// > |> list(of: string)
-/// Error([DecodeError(expected: "String", found: "Int", path: ["*"])])
+/// from([1, 2, 3]) |> list(of: string)
+/// // -> Error([DecodeError(expected: "String", found: "Int", path: ["*"])])
 /// ```
 ///
 /// ```gleam
-/// > from("ok")
-/// > |> list(of: string)
-/// Error([DecodeError(expected: "List", found: "String", path: [])])
+/// from("ok") |> list(of: string)
+/// // -> Error([DecodeError(expected: "List", found: "String", path: [])])
 /// ```
 ///
 pub fn list(
@@ -349,39 +344,36 @@ pub fn list(
 /// ## Examples
 ///
 /// ```gleam
-/// > from("Hello")
-/// > |> optional(string)
-/// Ok(Some("Hello"))
+/// from("Hello") |> optional(string)
+/// // -> Ok(Some("Hello"))
 /// ```
 ///
 /// ```gleam
-/// > from("Hello")
-/// > |> optional(string)
-/// Ok(Some("Hello"))
+/// from("Hello") |> optional(string)
+/// // -> Ok(Some("Hello"))
 /// ```
 ///
 /// ```gleam
-/// > from(atom.from_string("null"))
-/// > |> optional(string)
-/// Ok(None)
+/// import gleam/erlang/atom
+/// from(atom.from_string("null")) |> optional(string)
+/// // -> Ok(None)
 /// ```
 ///
 /// ```gleam
-/// > from(atom.from_string("nil"))
-/// > |> optional(string)
-/// Ok(None)
+/// import gleam/erlang/atom
+/// from(atom.from_string("nil")) |> optional(string)
+/// // -> Ok(None)
 /// ```
 ///
 /// ```gleam
-/// > from(atom.from_string("undefined"))
-/// > |> optional(string)
-/// Ok(None)
+/// import gleam/erlang/atom
+/// from(atom.from_string("undefined")) |> optional(string)
+/// // -> Ok(None)
 /// ```
 ///
 /// ```gleam
-/// > from(123)
-/// > |> optional(string)
-/// Error([DecodeError(expected: "String", found: "Int", path: [])])
+/// from(123) |> optional(string)
+/// // -> Error([DecodeError(expected: "String", found: "Int", path: [])])
 /// ```
 ///
 pub fn optional(of decode: Decoder(inner)) -> Decoder(Option(inner)) {
@@ -400,18 +392,17 @@ fn decode_optional(a: Dynamic, b: Decoder(a)) -> Result(Option(a), DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/dict
-/// > dict.new()
-/// > |> dict.insert("Hello", "World")
-/// > |> from
-/// > |> field(named: "Hello", of: string)
-/// Ok("World")
+/// import gleam/dict
+/// dict.new()
+/// |> dict.insert("Hello", "World")
+/// |> from
+/// |> field(named: "Hello", of: string)
+/// // -> Ok("World")
 /// ```
 ///
 /// ```gleam
-/// > from(123)
-/// > |> field("Hello", string)
-/// Error([DecodeError(expected: "Map", found: "Int", path: [])])
+/// from(123) |> field("Hello", string)
+/// // -> Error([DecodeError(expected: "Map", found: "Int", path: [])])
 /// ```
 ///
 pub fn field(named name: a, of inner_type: Decoder(t)) -> Decoder(t) {
@@ -434,26 +425,26 @@ pub fn field(named name: a, of inner_type: Decoder(t)) -> Decoder(t) {
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/dict
-/// > dict.new()
-/// > |> dict.insert("Hello", "World")
-/// > |> from
-/// > |> field(named: "Hello", of: string)
-/// Ok(Some("World"))
+/// import gleam/dict
+/// dict.new()
+/// |> dict.insert("Hello", "World")
+/// |> from
+/// |> field(named: "Hello", of: string)
+/// // -> Ok(Some("World"))
 /// ```
 ///
 /// ```gleam
-/// > import gleam/dict
-/// > dict.new()
-/// > |> from
-/// > |> field(named: "Hello", of: string)
-/// Ok(None)
+/// import gleam/dict
+/// dict.new()
+/// |> from
+/// |> field(named: "Hello", of: string)
+/// // -> Ok(None)
 /// ```
 ///
 /// ```gleam
-/// > from(123)
-/// > |> field("Hello", string)
-/// Error([DecodeError(expected: "Map", found: "Int", path: [])])
+/// from(123)
+/// |> field("Hello", string)
+/// // -> Error([DecodeError(expected: "Map", found: "Int", path: [])])
 /// ```
 ///
 pub fn optional_field(
@@ -482,21 +473,21 @@ fn decode_field(a: Dynamic, b: name) -> Result(Option(Dynamic), DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> element(0, int)
-/// Ok(from(1))
+/// from(#(1, 2))
+/// |> element(0, int)
+/// // -> Ok(from(1))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> element(2, int)
-/// Error([
-///   DecodeError(
-///     expected: "Tuple of at least 3 elements",
-///     found: "Tuple of 2 elements",
-///     path: [],
-///   ),
-/// ])
+/// from(#(1, 2))
+/// |> element(2, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of at least 3 elements",
+/// //     found: "Tuple of 2 elements",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 pub fn element(at index: Int, of inner_type: Decoder(t)) -> Decoder(t) {
@@ -611,41 +602,51 @@ fn push_path(error: DecodeError, name: t) -> DecodeError {
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> tuple2(int, int)
-/// Ok(#(1, 2))
+/// from(#(1, 2))
+/// |> tuple2(int, int)
+/// // -> Ok(#(1, 2))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2.0))
-/// > |> tuple2(int, float)
-/// Ok(#(1, 2.0))
+/// from(#(1, 2.0))
+/// |> tuple2(int, float)
+/// // -> Ok(#(1, 2.0))
 /// ```
 ///
 /// ```gleam
-/// > from([1, 2])
-/// > |> tuple2(int, int)
-/// Ok(#(1, 2))
+/// from([1, 2])
+/// |> tuple2(int, int)
+/// // -> Ok(#(1, 2))
 /// ```
 ///
 /// ```gleam
-/// > from([from(1), from(2.0)])
-/// > |> tuple2(int, float)
-/// Ok(#(1, 2.0))
+/// from([from(1), from(2.0)])
+/// |> tuple2(int, float)
+/// // -> Ok(#(1, 2.0))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2, 3))
-/// > |> tuple2(int, float)
-/// Error([
-///   DecodeError(expected: "Tuple of 2 elements", found: "Tuple of 3 elements", path: []),
-/// ])
+/// from(#(1, 2, 3))
+/// |> tuple2(int, float)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 2 elements",
+/// //     found: "Tuple of 3 elements",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 /// ```gleam
-/// > from("")
-/// > |> tuple2(int, float)
-/// Error([DecodeError(expected: "Tuple of 2 elements", found: "String", path: [])])
+/// from("")
+/// |> tuple2(int, float)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 2 elements",
+/// //     found: "String",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 pub fn tuple2(
@@ -670,43 +671,51 @@ pub fn tuple2(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2, 3))
-/// > |> tuple3(int, int, int)
-/// Ok(#(1, 2, 3))
+/// from(#(1, 2, 3))
+/// |> tuple3(int, int, int)
+/// // -> Ok(#(1, 2, 3))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3"))
-/// > |> tuple3(int, float, string)
-/// Ok(#(1, 2.0, "3"))
+/// from(#(1, 2.0, "3"))
+/// |> tuple3(int, float, string)
+/// // -> Ok(#(1, 2.0, "3"))
 /// ```
 ///
 /// ```gleam
-/// > from([1, 2, 3])
-/// > |> tuple3(int, int, int)
-/// Ok(#(1, 2, 3))
+/// from([1, 2, 3])
+/// |> tuple3(int, int, int)
+/// // -> Ok(#(1, 2, 3))
 /// ```
 ///
 /// ```gleam
-/// > from([from(1), from(2.0), from("3")])
-/// > |> tuple3(int, float, string)
-/// Ok(#(1, 2.0, "3"))
+/// from([from(1), from(2.0), from("3")])
+/// |> tuple3(int, float, string)
+/// // -> Ok(#(1, 2.0, "3"))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> tuple3(int, float, string)
-/// Error([
-///   DecodeError(expected: "Tuple of 3 elements", found: "Tuple of 2 elements", path: [])),
-/// ])
+/// from(#(1, 2))
+/// |> tuple3(int, float, string)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 3 elements",
+/// //     found: "Tuple of 2 elements",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 /// ```gleam
-/// > from("")
-/// > |> tuple3(int, float, string)
-/// Error([
-///   DecodeError(expected: "Tuple of 3 elements", found: "String", path: []),
-/// ])
+/// from("")
+/// |> tuple3(int, float, string)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 3 elements",
+/// //     found: "String",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 pub fn tuple3(
@@ -733,43 +742,51 @@ pub fn tuple3(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2, 3, 4))
-/// > |> tuple4(int, int, int, int)
-/// Ok(#(1, 2, 3, 4))
+/// from(#(1, 2, 3, 4))
+/// |> tuple4(int, int, int, int)
+/// // -> Ok(#(1, 2, 3, 4))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3", 4))
-/// > |> tuple4(int, float, string, int)
-/// Ok(#(1, 2.0, "3", 4))
+/// from(#(1, 2.0, "3", 4))
+/// |> tuple4(int, float, string, int)
+/// // -> Ok(#(1, 2.0, "3", 4))
 /// ```
 ///
 /// ```gleam
-/// > from([1, 2, 3, 4])
-/// > |> tuple4(int, int, int, int)
-/// Ok(#(1, 2, 3, 4))
+/// from([1, 2, 3, 4])
+/// |> tuple4(int, int, int, int)
+/// // -> Ok(#(1, 2, 3, 4))
 /// ```
 ///
 /// ```gleam
-/// > from([from(1), from(2.0), from("3"), from(4)])
-/// > |> tuple4(int, float, string, int)
-/// Ok(#(1, 2.0, "3", 4))
+/// from([from(1), from(2.0), from("3"), from(4)])
+/// |> tuple4(int, float, string, int)
+/// // -> Ok(#(1, 2.0, "3", 4))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> tuple4(int, float, string, int)
-/// Error([
-///   DecodeError(expected: "Tuple of 4 elements", found: "Tuple of 2 elements", path: []),
-/// ])
+/// from(#(1, 2))
+/// |> tuple4(int, float, string, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 4 elements",
+/// //     found: "Tuple of 2 elements",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 /// ```gleam
-/// > from("")
-/// > |> tuple4(int, float, string, int)
-/// Error([
-///   DecodeError(expected: "Tuple of 4 elements", found: "String", path: []),
-/// ])
+/// from("")
+/// |> tuple4(int, float, string, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 4 elements",
+/// //     found: "String",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 pub fn tuple4(
@@ -798,41 +815,51 @@ pub fn tuple4(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2, 3, 4, 5))
-/// > |> tuple5(int, int, int, int, int)
-/// Ok(#(1, 2, 3, 4, 5))
+/// from(#(1, 2, 3, 4, 5))
+/// |> tuple5(int, int, int, int, int)
+/// // -> Ok(#(1, 2, 3, 4, 5))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3", 4, 5))
-/// > |> tuple5(int, float, string, int, int)
-/// Ok(#(1, 2.0, "3", 4, 5))
+/// from(#(1, 2.0, "3", 4, 5))
+/// |> tuple5(int, float, string, int, int)
+/// // -> Ok(#(1, 2.0, "3", 4, 5))
 /// ```
 ///
 /// ```gleam
-/// > from([1, 2, 3, 4, 5])
-/// > |> tuple5(int, int, int, int, int)
-/// Ok(#(1, 2, 3, 4, 5))
+/// from([1, 2, 3, 4, 5])
+/// |> tuple5(int, int, int, int, int)
+/// // -> Ok(#(1, 2, 3, 4, 5))
 /// ```
 ///
 /// ```gleam
-/// > from([from(1), from(2.0), from("3"), from(4), from(True)])
-/// > |> tuple5(int, float, string, int, bool)
-/// Ok(#(1, 2.0, "3", 4, True))
+/// from([from(1), from(2.0), from("3"), from(4), from(True)])
+/// |> tuple5(int, float, string, int, bool)
+/// // -> Ok(#(1, 2.0, "3", 4, True))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> tuple5(int, float, string, int, int)
-/// Error([
-///   DecodeError(expected: "Tuple of 5 elements", found: "Tuple of 2 elements", path: [])),
-/// ])
+/// from(#(1, 2))
+/// |> tuple5(int, float, string, int, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 5 elements",
+/// //     found: "Tuple of 2 elements",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 /// ```gleam
-/// > from("")
-/// > |> tuple5(int, float, string, int, int)
-/// Error([DecodeError(expected: "Tuple of 5 elements", found: "String", path: [])])
+/// from("")
+/// |> tuple5(int, float, string, int, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 5 elements",
+/// //     found: "String",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 pub fn tuple5(
@@ -863,41 +890,51 @@ pub fn tuple5(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2, 3, 4, 5, 6))
-/// > |> tuple6(int, int, int, int, int, int)
-/// Ok(#(1, 2, 3, 4, 5, 6))
+/// from(#(1, 2, 3, 4, 5, 6))
+/// |> tuple6(int, int, int, int, int, int)
+/// // -> Ok(#(1, 2, 3, 4, 5, 6))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3", 4, 5, 6))
-/// > |> tuple6(int, float, string, int, int, int)
-/// Ok(#(1, 2.0, "3", 4, 5, 6))
+/// from(#(1, 2.0, "3", 4, 5, 6))
+/// |> tuple6(int, float, string, int, int, int)
+/// // -> Ok(#(1, 2.0, "3", 4, 5, 6))
 /// ```
 ///
 /// ```gleam
-/// > from([1, 2, 3, 4, 5, 6])
-/// > |> tuple6(int, int, int, int, int, int)
-/// Ok(#(1, 2, 3, 4, 5, 6))
+/// from([1, 2, 3, 4, 5, 6])
+/// |> tuple6(int, int, int, int, int, int)
+/// // -> Ok(#(1, 2, 3, 4, 5, 6))
 /// ```
 ///
 /// ```gleam
-/// > from([from(1), from(2.0), from("3"), from(4), from(True), from(False)])
-/// > |> tuple6(int, float, string, int, bool, bool)
-/// Ok(#(1, 2.0, "3", 4, True, False))
+/// from([from(1), from(2.0), from("3"), from(4), from(True), from(False)])
+/// |> tuple6(int, float, string, int, bool, bool)
+/// // -> Ok(#(1, 2.0, "3", 4, True, False))
 /// ```
 ///
 /// ```gleam
-/// > from(#(1, 2))
-/// > |> tuple6(int, float, string, int, int, int)
-/// Error([
-///   DecodeError(expected: "Tuple of 6 elements", found: "Tuple of 2 elements", path: []),
-/// ])
+/// from(#(1, 2))
+/// |> tuple6(int, float, string, int, int, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 6 elements",
+/// //     found: "Tuple of 2 elements",
+/// //     path: [],
+/// //   ),
+/// // ])
 /// ```
 ///
 /// ```gleam
-/// > from("")
-/// > |> tuple6(int, float, string, int, int, int)
-/// Error([DecodeError(expected: "Tuple of 6 elements", found: "String", path: [])])
+/// from("")
+/// |> tuple6(int, float, string, int, int, int)
+/// // -> Error([
+/// //   DecodeError(
+/// //     expected: "Tuple of 6 elements",
+/// //     found: "String",
+/// //     path: [],
+/// //  ),
+/// // ])
 /// ```
 ///
 pub fn tuple6(
@@ -936,19 +973,19 @@ pub fn tuple6(
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/dict
-/// > dict.new() |> from |> map(string, int)
-/// Ok(dict.new())
+/// import gleam/dict
+/// dict.new() |> from |> map(string, int)
+/// // -> Ok(dict.new())
 /// ```
 ///
 /// ```gleam
-/// > from(1) |> map(string, int)
-/// Error(DecodeError(expected: "Map", found: "Int", path: []))
+/// from(1) |> map(string, int)
+/// // -> Error(DecodeError(expected: "Map", found: "Int", path: []))
 /// ```
 ///
 /// ```gleam
-/// > from("") |> map(string, int)
-/// Error(DecodeError(expected: "Map", found: "String", path: []))
+/// from("") |> map(string, int)
+/// // -> Error(DecodeError(expected: "Map", found: "String", path: []))
 /// ```
 ///
 pub fn dict(
@@ -995,23 +1032,21 @@ fn decode_map(a: Dynamic) -> Result(Dict(Dynamic, Dynamic), DecodeErrors)
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/result
-/// > let bool_or_string = any(of: [
-/// >   string,
-/// >   fn(x) { result.map(bool(x), fn(_) { "a bool" }) }
-/// > ])
-/// > bool_or_string(from("ok"))
-/// Ok("ok")
-/// ```
+/// import gleam/result
+/// 
+/// let bool_or_string = any(of: [
+///   string,
+///   fn(x) { result.map(bool(x), fn(_) { "a bool" }) }
+/// ])
+/// 
+/// bool_or_string(from("ok"))
+/// // -> Ok("ok")
 ///
-/// ```gleam
-/// > bool_or_string(from(True))
-/// Ok("a bool")
-/// ```
+/// bool_or_string(from(True))
+/// // -> Ok("a bool")
 ///
-/// ```gleam
-/// > bool_or_string(from(1))
-/// Error(DecodeError(expected: "another type", found: "Int", path: []))
+/// bool_or_string(from(1))
+/// // -> Error(DecodeError(expected: "another type", found: "Int", path: []))
 /// ```
 ///
 pub fn any(of decoders: List(Decoder(t))) -> Decoder(t) {
@@ -1036,17 +1071,15 @@ pub fn any(of decoders: List(Decoder(t))) -> Decoder(t) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3"))
-/// > |> decode1(MyRecord, element(0, int))
-/// Ok(MyRecord(1))
+/// from(#(1, 2.0, "3")) |> decode1(MyRecord, element(0, int))
+/// // -> Ok(MyRecord(1))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", ""))
-/// > |> decode1(MyRecord, element(0, int))
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-/// ])
+/// from(#("", "", "")) |> decode1(MyRecord, element(0, int))
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// // ])
 /// ```
 ///
 pub fn decode1(constructor: fn(t1) -> t, t1: Decoder(t1)) -> Decoder(t) {
@@ -1063,18 +1096,18 @@ pub fn decode1(constructor: fn(t1) -> t, t1: Decoder(t1)) -> Decoder(t) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3"))
-/// > |> decode2(MyRecord, element(0, int), element(1, float))
-/// Ok(MyRecord(1, 2.0))
+/// from(#(1, 2.0, "3"))
+/// |> decode2(MyRecord, element(0, int), element(1, float))
+/// // -> Ok(MyRecord(1, 2.0))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", ""))
-/// > |> decode2(MyRecord, element(0, int), element(1, float))
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", ""))
+/// |> decode2(MyRecord, element(0, int), element(1, float))
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode2(
@@ -1095,18 +1128,18 @@ pub fn decode2(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.0, "3"))
-/// > |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
-/// Ok(MyRecord(1, 2.0, "3"))
+/// from(#(1, 2.0, "3"))
+/// |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
+/// // -> Ok(MyRecord(1, 2.0, "3"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", ""))
-/// > |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", ""))
+/// |> decode3(MyRecord, element(0, int), element(1, float), element(2, string))
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode3(
@@ -1129,30 +1162,30 @@ pub fn decode3(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.1, "3", "4"))
-/// > |> decode4(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// > )
-/// Ok(MyRecord(1, 2.1, "3", "4"))
+/// from(#(1, 2.1, "3", "4"))
+/// |> decode4(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+/// )
+/// // -> Ok(MyRecord(1, 2.1, "3", "4"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", "", ""))
-/// > |> decode4(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// > )
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", "", ""))
+/// |> decode4(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+/// )
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode4(
@@ -1183,32 +1216,32 @@ pub fn decode4(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.1, "3", "4", "5"))
-/// > |> decode5(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// > )
-/// Ok(MyRecord(1, 2.1, "3", "4", "5"))
+/// from(#(1, 2.1, "3", "4", "5"))
+/// |> decode5(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+/// )
+/// // -> Ok(MyRecord(1, 2.1, "3", "4", "5"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", "", "", ""))
-/// > |> decode5(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// > )
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", "", "", ""))
+/// |> decode5(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+/// )
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode5(
@@ -1241,34 +1274,34 @@ pub fn decode5(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.1, "3", "4", "5", "6"))
-/// > |> decode6(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// > )
-/// Ok(MyRecord(1, 2.1, "3", "4", "5", "6"))
+/// from(#(1, 2.1, "3", "4", "5", "6"))
+/// |> decode6(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+/// )
+/// // -> Ok(MyRecord(1, 2.1, "3", "4", "5", "6"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", "", "", "", ""))
-/// > |> decode6(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// > )
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", "", "", "", ""))
+/// |> decode6(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+/// )
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode6(
@@ -1304,36 +1337,36 @@ pub fn decode6(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.1, "3", "4", "5", "6"))
-/// > |> decode7(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// >   element(6, string),
-/// > )
-/// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7"))
+/// from(#(1, 2.1, "3", "4", "5", "6"))
+/// |> decode7(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+///   element(6, string),
+/// )
+/// // -> Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", "", "", "", "", ""))
-/// > |> decode7(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// >   element(6, string),
-/// > )
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", "", "", "", "", ""))
+/// |> decode7(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+///   element(6, string),
+/// )
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode7(
@@ -1371,38 +1404,38 @@ pub fn decode7(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.1, "3", "4", "5", "6", "7", "8"))
-/// > |> decode8(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// >   element(6, string),
-/// >   element(7, string),
-/// > )
-/// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8"))
+/// from(#(1, 2.1, "3", "4", "5", "6", "7", "8"))
+/// |> decode8(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+///   element(6, string),
+///   element(7, string),
+/// )
+/// // -> Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", "", "", "", "", "", ""))
-/// > |> decode8(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// >   element(6, string),
-/// >   element(7, string),
-/// > )
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", "", "", "", "", "", ""))
+/// |> decode8(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+///   element(6, string),
+///   element(7, string),
+/// )
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode8(
@@ -1442,40 +1475,40 @@ pub fn decode8(
 /// ## Examples
 ///
 /// ```gleam
-/// > from(#(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
-/// > |> decode9(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// >   element(6, string),
-/// >   element(7, string),
-/// >   element(8, string),
-/// > )
-/// Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
+/// from(#(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
+/// |> decode9(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+///   element(6, string),
+///   element(7, string),
+///   element(8, string),
+/// )
+/// // -> Ok(MyRecord(1, 2.1, "3", "4", "5", "6", "7", "8", "9"))
 /// ```
 ///
 /// ```gleam
-/// > from(#("", "", "", "", "", "", "", "", ""))
-/// > |> decode9(
-/// >   MyRecord,
-/// >   element(0, int),
-/// >   element(1, float),
-/// >   element(2, string),
-/// >   element(3, string),
-/// >   element(4, string),
-/// >   element(5, string),
-/// >   element(6, string),
-/// >   element(7, string),
-/// >   element(8, string),
-/// > )
-/// Error([
-///   DecodeError(expected: "Int", found: "String", path: ["0"]),
-///   DecodeError(expected: "Float", found: "String", path: ["1"]),
-/// ])
+/// from(#("", "", "", "", "", "", "", "", ""))
+/// |> decode9(
+///   MyRecord,
+///   element(0, int),
+///   element(1, float),
+///   element(2, string),
+///   element(3, string),
+///   element(4, string),
+///   element(5, string),
+///   element(6, string),
+///   element(7, string),
+///   element(8, string),
+/// )
+/// // -> Error([
+/// //   DecodeError(expected: "Int", found: "String", path: ["0"]),
+/// //   DecodeError(expected: "Float", found: "String", path: ["1"]),
+/// // ])
 /// ```
 ///
 pub fn decode9(

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -20,13 +20,13 @@ import gleam/order.{type Order}
 /// ## Examples
 ///
 /// ```gleam
-/// > parse("2.3")
-/// Ok(2.3)
+/// parse("2.3")
+/// // -> Ok(2.3)
 /// ```
 ///
 /// ```gleam
-/// > parse("ABC")
-/// Error(Nil)
+/// parse("ABC")
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn parse(string: String) -> Result(Float, Nil) {
@@ -42,8 +42,8 @@ fn do_parse(a: String) -> Result(Float, Nil)
 /// ## Examples
 ///
 /// ```gleam
-/// > to_string(2.3)
-/// "2.3"
+/// to_string(2.3)
+/// // -> "2.3"
 /// ```
 ///
 pub fn to_string(x: Float) -> String {
@@ -59,8 +59,8 @@ fn do_to_string(a: Float) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > clamp(1.2, min: 1.4, max: 1.6)
-/// 1.4
+/// clamp(1.2, min: 1.4, max: 1.6)
+/// // -> 1.4
 /// ```
 ///
 pub fn clamp(x: Float, min min_bound: Float, max max_bound: Float) -> Float {
@@ -75,8 +75,8 @@ pub fn clamp(x: Float, min min_bound: Float, max max_bound: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > compare(2.0, 2.3)
-/// Lt
+/// compare(2.0, 2.3)
+/// // -> Lt
 /// ```
 ///
 /// To handle
@@ -106,8 +106,8 @@ pub fn compare(a: Float, with b: Float) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > loosely_compare(5.0, with: 5.3, tolerating: 0.5)
-/// Eq
+/// loosely_compare(5.0, with: 5.3, tolerating: 0.5)
+/// // -> Eq
 /// ```
 ///
 /// If you want to check only for equality you may use
@@ -137,13 +137,13 @@ pub fn loosely_compare(
 /// ## Examples
 ///
 /// ```gleam
-/// > loosely_equals(5.0, with: 5.3, tolerating: 0.5)
-/// True
+/// loosely_equals(5.0, with: 5.3, tolerating: 0.5)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > loosely_equals(5.0, with: 5.1, tolerating: 0.1)
-/// False
+/// loosely_equals(5.0, with: 5.1, tolerating: 0.1)
+/// // -> False
 /// ```
 ///
 pub fn loosely_equals(
@@ -160,8 +160,8 @@ pub fn loosely_equals(
 /// ## Examples
 ///
 /// ```gleam
-/// > min(2.0, 2.3)
-/// 2.0
+/// min(2.0, 2.3)
+/// // -> 2.0
 /// ```
 ///
 pub fn min(a: Float, b: Float) -> Float {
@@ -176,8 +176,8 @@ pub fn min(a: Float, b: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > max(2.0, 2.3)
-/// 2.3
+/// max(2.0, 2.3)
+/// // -> 2.3
 /// ```
 ///
 pub fn max(a: Float, b: Float) -> Float {
@@ -192,8 +192,8 @@ pub fn max(a: Float, b: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > ceiling(2.3)
-/// 3.0
+/// ceiling(2.3)
+/// // -> 3.0
 /// ```
 ///
 pub fn ceiling(x: Float) -> Float {
@@ -209,8 +209,8 @@ fn do_ceiling(a: Float) -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// > floor(2.3)
-/// 2.0
+/// floor(2.3)
+/// // -> 2.0
 /// ```
 ///
 pub fn floor(x: Float) -> Float {
@@ -226,13 +226,13 @@ fn do_floor(a: Float) -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// > round(2.3)
-/// 2
+/// round(2.3)
+/// // -> 2
 /// ```
 ///
 /// ```gleam
-/// > round(2.5)
-/// 3
+/// round(2.5)
+/// // -> 3
 /// ```
 ///
 pub fn round(x: Float) -> Int {
@@ -260,8 +260,8 @@ fn js_round(a: Float) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// > truncate(2.4343434847383438)
-/// 2
+/// truncate(2.4343434847383438)
+/// // -> 2
 /// ```
 ///
 pub fn truncate(x: Float) -> Int {
@@ -277,13 +277,13 @@ fn do_truncate(a: Float) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// > absolute_value(-12.5)
-/// 12.5
+/// absolute_value(-12.5)
+/// // -> 12.5
 /// ```
 ///
 /// ```gleam
-/// > absolute_value(10.2)
-/// 10.2
+/// absolute_value(10.2)
+/// // -> 10.2
 /// ```
 ///
 pub fn absolute_value(x: Float) -> Float {
@@ -299,28 +299,28 @@ pub fn absolute_value(x: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > power(2.0, -1.0)
-/// Ok(0.5)
+/// power(2.0, -1.0)
+/// // -> Ok(0.5)
 /// ```
 ///
 /// ```gleam
-/// > power(2.0, 2.0)
-/// Ok(4.0)
+/// power(2.0, 2.0)
+/// // -> Ok(4.0)
 /// ```
 ///
 /// ```gleam
-/// > power(8.0, 1.5)
-/// Ok(22.627416997969522)
+/// power(8.0, 1.5)
+/// // -> Ok(22.627416997969522)
 /// ```
 ///
 /// ```gleam
-/// > 4.0 |> power(of: 2.0)
-/// Ok(16.0)
+/// 4.0 |> power(of: 2.0)
+/// // -> Ok(16.0)
 /// ```
 ///
 /// ```gleam
-/// > power(-1.0, 0.5)
-/// Error(Nil)
+/// power(-1.0, 0.5)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn power(base: Float, of exponent: Float) -> Result(Float, Nil) {
@@ -346,13 +346,13 @@ fn do_power(a: Float, b: Float) -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// > square_root(4.0)
-/// Ok(2.0)
+/// square_root(4.0)
+/// // -> Ok(2.0)
 /// ```
 ///
 /// ```gleam
-/// > square_root(-16.0)
-/// Error(Nil)
+/// square_root(-16.0)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn square_root(x: Float) -> Result(Float, Nil) {
@@ -364,8 +364,8 @@ pub fn square_root(x: Float) -> Result(Float, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > negate(1.0)
-/// -1.0
+/// negate(1.0)
+/// // -> -1.0
 /// ```
 ///
 pub fn negate(x: Float) -> Float {
@@ -377,8 +377,8 @@ pub fn negate(x: Float) -> Float {
 /// ## Example
 ///
 /// ```gleam
-/// > sum([1.0, 2.2, 3.3])
-/// 6.5
+/// sum([1.0, 2.2, 3.3])
+/// // -> 6.5
 /// ```
 ///
 pub fn sum(numbers: List(Float)) -> Float {
@@ -398,8 +398,8 @@ fn do_sum(numbers: List(Float), initial: Float) -> Float {
 /// ## Example
 ///
 /// ```gleam
-/// > product([2.5, 3.2, 4.2])
-/// 33.6
+/// product([2.5, 3.2, 4.2])
+/// // -> 33.6
 /// ```
 ///
 pub fn product(numbers: List(Float)) -> Float {
@@ -425,8 +425,8 @@ fn do_product(numbers: List(Float), initial: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > random()
-/// 0.646355926896028
+/// random()
+/// // -> 0.646355926896028
 /// ```
 ///
 @external(erlang, "rand", "uniform")
@@ -438,13 +438,13 @@ pub fn random() -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// > divide(0.0, 1.0)
-/// Ok(1.0)
+/// divide(0.0, 1.0)
+/// // -> Ok(1.0)
 /// ```
 ///
 /// ```gleam
-/// > divide(1.0, 0.0)
-/// Error(Nil)
+/// divide(1.0, 0.0)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn divide(a: Float, by b: Float) -> Result(Float, Nil) {
@@ -462,19 +462,19 @@ pub fn divide(a: Float, by b: Float) -> Result(Float, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > add(1.0, 2.0)
-/// 3.0
+/// add(1.0, 2.0)
+/// // -> 3.0
 /// ```
 ///
 /// ```gleam
-/// > import gleam/list
-/// > list.fold([1.0, 2.0, 3.0], 0.0, add)
-/// 6.0
+/// import gleam/list
+/// list.fold([1.0, 2.0, 3.0], 0.0, add)
+/// // -> 6.0
 /// ```
 ///
 /// ```gleam
-/// > 3.0 |> add(2.0)
-/// 5.0
+/// 3.0 |> add(2.0)
+/// // -> 5.0
 /// ```
 ///
 pub fn add(a: Float, b: Float) -> Float {
@@ -489,19 +489,19 @@ pub fn add(a: Float, b: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > multiply(2.0, 4.0)
-/// 8.0
+/// multiply(2.0, 4.0)
+/// // -> 8.0
 /// ```
 ///
 /// ```gleam
 /// import gleam/list
-/// > list.fold([2.0, 3.0, 4.0], 1.0, multiply)
-/// 24.0
+/// list.fold([2.0, 3.0, 4.0], 1.0, multiply)
+/// // -> 24.0
 /// ```
 ///
 /// ```gleam
-/// > 3.0 |> multiply(2.0)
-/// 6.0
+/// 3.0 |> multiply(2.0)
+/// // -> 6.0
 /// ```
 ///
 pub fn multiply(a: Float, b: Float) -> Float {
@@ -516,24 +516,24 @@ pub fn multiply(a: Float, b: Float) -> Float {
 /// ## Examples
 ///
 /// ```gleam
-/// > subtract(3.0, 1.0)
-/// 2.0
+/// subtract(3.0, 1.0)
+/// // -> 2.0
 /// ```
 ///
 /// ```gleam
-/// > import gleam/list
-/// > list.fold([1.0, 2.0, 3.0], 10.0, subtract)
-/// 4.0
+/// import gleam/list
+/// list.fold([1.0, 2.0, 3.0], 10.0, subtract)
+/// // -> 4.0
 /// ```
 ///
 /// ```gleam
-/// > 3.0 |> subtract(_, 2.0)
-/// 1.0
+/// 3.0 |> subtract(_, 2.0)
+/// // -> 1.0
 /// ```
 ///
 /// ```gleam
-/// > 3.0 |> subtract(2.0, _)
-/// -1.0
+/// 3.0 |> subtract(2.0, _)
+/// // -> -1.0
 /// ```
 ///
 pub fn subtract(a: Float, b: Float) -> Float {

--- a/src/gleam/function.gleam
+++ b/src/gleam/function.gleam
@@ -18,24 +18,24 @@ pub fn compose(fun1: fn(a) -> b, fun2: fn(b) -> c) -> fn(a) -> c {
 /// and producing a sequence of `n` single-argument functions. Given:
 ///
 /// ```gleam
-/// > fn my_fun(i: Int, s: String) -> String { ... }
+/// fn my_fun(i: Int, s: String) -> String { ... }
 /// ```
 ///
 /// …calling `curry2(my_fun)` would return the curried equivalent, like so:
 ///
 /// ```gleam
-/// > curry2(my_fun)
-/// fn(Int) -> fn(String) -> String
+/// curry2(my_fun)
+/// // fn(Int) -> fn(String) -> String
 /// ```
 ///
 /// Currying is useful when you want to partially apply a function with
 /// some arguments and then pass it somewhere else, for example:
 ///
 /// ```gleam
-/// > import gleam/list
-/// > let multiply = curry2(fn(x, y) { x * y })
-/// > let doubles = list.map([1, 2, 3], multiply(2))
-/// [2, 4, 6]
+/// import gleam/list
+/// let multiply = curry2(fn(x, y) { x * y })
+/// list.map([1, 2, 3], multiply(2))
+/// // -> [2, 4, 6]
 /// ```
 ///
 pub fn curry2(fun: fn(a, b) -> value) {
@@ -128,13 +128,12 @@ pub fn tap(arg: a, effect: fn(a) -> b) -> a {
 /// ## Example
 ///
 /// ```gleam
-/// > let doubler = fn() {
-/// >  fn(x: Int) { x * 2 }
-/// > }
-/// >
-/// > doubler()
-/// > |> apply1(2)
-/// 4
+/// let doubler = fn() {
+///   fn(x: Int) { x * 2 }
+/// }
+/// 
+/// doubler() |> apply1(2)
+/// // -> 4
 /// ```
 ///
 pub fn apply1(fun: fn(a) -> value, arg1: a) -> value {

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -18,12 +18,12 @@ import gleam/order.{type Order}
 /// ## Examples
 ///
 /// ```gleam
-/// > absolute_value(-12)
+/// absolute_value(-12)
 /// 12
 /// ```
 ///
 /// ```gleam
-/// > absolute_value(10)
+/// absolute_value(10)
 /// 10
 /// ```
 ///
@@ -40,27 +40,27 @@ pub fn absolute_value(x: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > power(2, -1.0)
+/// power(2, -1.0)
 /// Ok(0.5)
 /// ```
 ///
 /// ```gleam
-/// > power(2, 2.0)
+/// power(2, 2.0)
 /// Ok(4.0)
 /// ```
 ///
 /// ```gleam
-/// > power(8, 1.5)
+/// power(8, 1.5)
 /// Ok(22.627416997969522)
 /// ```
 ///
 /// ```gleam
-/// > 4 |> power(of: 2.0)
+/// 4 |> power(of: 2.0)
 /// Ok(16.0)
 /// ```
 ///
 /// ```gleam
-/// > power(-1, 0.5)
+/// power(-1, 0.5)
 /// Error(Nil)
 /// ```
 ///
@@ -75,12 +75,12 @@ pub fn power(base: Int, of exponent: Float) -> Result(Float, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > square_root(4)
+/// square_root(4)
 /// Ok(2.0)
 /// ```
 ///
 /// ```gleam
-/// > square_root(-16)
+/// square_root(-16)
 /// Error(Nil)
 /// ```
 ///
@@ -95,12 +95,12 @@ pub fn square_root(x: Int) -> Result(Float, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > parse("2")
+/// parse("2")
 /// Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > parse("ABC")
+/// parse("ABC")
 /// Error(Nil)
 /// ```
 ///
@@ -118,19 +118,19 @@ fn do_parse(a: String) -> Result(Int, Nil)
 /// ## Examples
 ///
 /// ```gleam
-/// > base_parse("10", 2)
+/// base_parse("10", 2)
 /// Ok(2)
 ///
-/// > base_parse("30", 16)
+/// base_parse("30", 16)
 /// Ok(48)
 ///
-/// > base_parse("1C", 36)
+/// base_parse("1C", 36)
 /// Ok(48)
 ///
-/// > base_parse("48", 1)
+/// base_parse("48", 1)
 /// Error(Nil)
 ///
-/// > base_parse("48", 37)
+/// base_parse("48", 37)
 /// Error(Nil)
 /// ```
 ///
@@ -150,7 +150,7 @@ fn do_base_parse(a: String, b: Int) -> Result(Int, Nil)
 /// ## Examples
 ///
 /// ```gleam
-/// > to_string(2)
+/// to_string(2)
 /// "2"
 /// ```
 ///
@@ -175,27 +175,27 @@ pub type InvalidBase {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_base_string(2, 2)
+/// to_base_string(2, 2)
 /// Ok("10")
 /// ```
 ///
 /// ```gleam
-/// > to_base_string(48, 16)
+/// to_base_string(48, 16)
 /// Ok("30")
 /// ```
 ///
 /// ```gleam
-/// > to_base_string(48, 36)
+/// to_base_string(48, 36)
 /// Ok("1C")
 /// ```
 ///
 /// ```gleam
-/// > to_base_string(48, 1)
+/// to_base_string(48, 1)
 /// Error(InvalidBase)
 /// ```
 ///
 /// ```gleam
-/// > to_base_string(48, 37)
+/// to_base_string(48, 37)
 /// Error(InvalidBase)
 /// ```
 ///
@@ -215,7 +215,7 @@ fn do_to_base_string(a: Int, b: Int) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > to_base2(2)
+/// to_base2(2)
 /// "10"
 /// ```
 ///
@@ -228,7 +228,7 @@ pub fn to_base2(x: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_base8(15)
+/// to_base8(15)
 /// "17"
 /// ```
 ///
@@ -241,7 +241,7 @@ pub fn to_base8(x: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_base16(48)
+/// to_base16(48)
 /// "30"
 /// ```
 ///
@@ -254,7 +254,7 @@ pub fn to_base16(x: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_base36(48)
+/// to_base36(48)
 /// "1C"
 /// ```
 ///
@@ -267,17 +267,17 @@ pub fn to_base36(x: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_float(5)
+/// to_float(5)
 /// 5.0
 /// ```
 ///
 /// ```gleam
-/// > to_float(0)
+/// to_float(0)
 /// 0.0
 /// ```
 ///
 /// ```gleam
-/// > to_float(-3)
+/// to_float(-3)
 /// -3.0
 /// ```
 ///
@@ -294,7 +294,7 @@ fn do_to_float(a: Int) -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// > clamp(40, min: 50, max: 60)
+/// clamp(40, min: 50, max: 60)
 /// 50
 /// ```
 ///
@@ -309,17 +309,17 @@ pub fn clamp(x: Int, min min_bound: Int, max max_bound: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > compare(2, 3)
+/// compare(2, 3)
 /// Lt
 /// ```
 ///
 /// ```gleam
-/// > compare(4, 3)
+/// compare(4, 3)
 /// Gt
 /// ```
 ///
 /// ```gleam
-/// > compare(3, 3)
+/// compare(3, 3)
 /// Eq
 /// ```
 ///
@@ -339,7 +339,7 @@ pub fn compare(a: Int, with b: Int) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > min(2, 3)
+/// min(2, 3)
 /// 2
 /// ```
 ///
@@ -355,7 +355,7 @@ pub fn min(a: Int, b: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > max(2, 3)
+/// max(2, 3)
 /// 3
 /// ```
 ///
@@ -371,12 +371,12 @@ pub fn max(a: Int, b: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > is_even(2)
+/// is_even(2)
 /// True
 /// ```
 ///
 /// ```gleam
-/// > is_even(3)
+/// is_even(3)
 /// False
 /// ```
 ///
@@ -389,12 +389,12 @@ pub fn is_even(x: Int) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > is_odd(3)
+/// is_odd(3)
 /// True
 /// ```
 ///
 /// ```gleam
-/// > is_odd(2)
+/// is_odd(2)
 /// False
 /// ```
 ///
@@ -407,7 +407,7 @@ pub fn is_odd(x: Int) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > negate(1)
+/// negate(1)
 /// -1
 /// ```
 ///
@@ -420,7 +420,7 @@ pub fn negate(x: Int) -> Int {
 /// ## Example
 ///
 /// ```gleam
-/// > sum([1, 2, 3])
+/// sum([1, 2, 3])
 /// 6
 /// ```
 ///
@@ -441,7 +441,7 @@ fn do_sum(numbers: List(Int), initial: Int) -> Int {
 /// ## Example
 ///
 /// ```gleam
-/// > product([2, 3, 4])
+/// product([2, 3, 4])
 /// 24
 /// ```
 ///
@@ -464,12 +464,12 @@ fn do_product(numbers: List(Int), initial: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > digits(234, 10)
+/// digits(234, 10)
 /// Ok([2,3,4])
 /// ```
 ///
 /// ```gleam
-/// > digits(234, 1)
+/// digits(234, 1)
 /// Error(InvalidBase)
 /// ```
 ///
@@ -493,17 +493,17 @@ fn do_digits(x: Int, base: Int, acc: List(Int)) -> List(Int) {
 /// ## Examples
 ///
 /// ```gleam
-/// > undigits([2,3,4], 10)
+/// undigits([2,3,4], 10)
 /// Ok(234)
 /// ```
 ///
 /// ```gleam
-/// > undigits([2,3,4], 1)
+/// undigits([2,3,4], 1)
 /// Error(InvalidBase)
 /// ```
 ///
 /// ```gleam
-/// > undigits([2,3,4], 2)
+/// undigits([2,3,4], 2)
 /// Error(InvalidBase)
 /// ```
 ///
@@ -533,18 +533,18 @@ fn do_undigits(
 /// ## Examples
 ///
 /// ```gleam
-/// > random(10)
-/// 4
+/// random(10)
+/// // -> 4
 /// ```
 ///
 /// ```gleam
-/// > random(1)
-/// 0
+/// random(1)
+/// // -> 0
 /// ```
 ///
 /// ```gleam
-/// > random(-1)
-/// -1
+/// random(-1)
+/// // -> -1
 /// ```
 ///
 pub fn random(max: Int) -> Int {
@@ -561,23 +561,23 @@ pub fn random(max: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > divide(0, 1)
-/// Ok(1)
+/// divide(0, 1)
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > divide(1, 0)
-/// Error(Nil)
+/// divide(1, 0)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > divide(5, 2)
-/// Ok(2)
+/// divide(5, 2)
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > divide(-99, 2)
-/// Ok(-49)
+/// divide(-99, 2)
+/// // -> Ok(-49)
 /// ```
 ///
 pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
@@ -598,38 +598,38 @@ pub fn divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > remainder(3, 2)
-/// Ok(1)
+/// remainder(3, 2)
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > remainder(1, 0)
-/// Error(Nil)
+/// remainder(1, 0)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > remainder(10, -1)
-/// Ok(0)
+/// remainder(10, -1)
+/// // -> Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > remainder(13, by: 3)
-/// Ok(1)
+/// remainder(13, by: 3)
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > remainder(-13, by: 3)
-/// Ok(-1)
+/// remainder(-13, by: 3)
+/// // -> Ok(-1)
 /// ```
 ///
 /// ```gleam
-/// > remainder(13, by: -3)
-/// Ok(1)
+/// remainder(13, by: -3)
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > remainder(-13, by: -3)
-/// Ok(-1)
+/// remainder(-13, by: -3)
+/// // -> Ok(-1)
 /// ```
 ///
 pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
@@ -650,38 +650,38 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > modulo(3, 2)
-/// Ok(1)
+/// modulo(3, 2)
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > modulo(1, 0)
-/// Error(Nil)
+/// modulo(1, 0)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > modulo(10, -1)
-/// Ok(0)
+/// modulo(10, -1)
+/// // -> Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > modulo(13, by: 3)
-/// Ok(1)
+/// modulo(13, by: 3)
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > modulo(-13, by: 3)
-/// Ok(2)
+/// modulo(-13, by: 3)
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > modulo(13, by: -3)
-/// Ok(-2)
+/// modulo(13, by: -3)
+/// // -> Ok(-2)
 /// ```
 ///
 /// ```gleam
-/// > modulo(-13, by: -3)
-/// Ok(-1)
+/// modulo(-13, by: -3)
+/// // -> Ok(-1)
 /// ```
 ///
 pub fn modulo(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
@@ -709,23 +709,23 @@ pub fn modulo(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > floor_divide(1, 0)
-/// Error(Nil)
+/// floor_divide(1, 0)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > floor_divide(5, 2)
-/// Ok(2)
+/// floor_divide(5, 2)
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > floor_divide(6, -4)
-/// Ok(-2)
+/// floor_divide(6, -4)
+/// // -> Ok(-2)
 /// ```
 ///
 /// ```gleam
-/// > floor_divide(-99, 2)
-/// Ok(-50)
+/// floor_divide(-99, 2)
+/// // -> Ok(-50)
 /// ```
 ///
 pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
@@ -747,19 +747,19 @@ pub fn floor_divide(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > add(1, 2)
-/// 3
+/// add(1, 2)
+/// // -> 3
 /// ```
 ///
 /// ```gleam
 /// import gleam/list
-/// > list.fold([1, 2, 3], 0, add)
-/// 6
+/// list.fold([1, 2, 3], 0, add)
+/// // -> 6
 /// ```
 ///
 /// ```gleam
-/// > 3 |> add(2)
-/// 5
+/// 3 |> add(2)
+/// // -> 5
 /// ```
 ///
 pub fn add(a: Int, b: Int) -> Int {
@@ -774,19 +774,19 @@ pub fn add(a: Int, b: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > multiply(2, 4)
-/// 8
+/// multiply(2, 4)
+/// // -> 8
 /// ```
 ///
 /// ```gleam
 /// import gleam/list
-/// > list.fold([2, 3, 4], 1, multiply)
-/// 24
+/// list.fold([2, 3, 4], 1, multiply)
+/// // -> 24
 /// ```
 ///
 /// ```gleam
-/// > 3 |> multiply(2)
-/// 6
+/// 3 |> multiply(2)
+/// // -> 6
 /// ```
 ///
 pub fn multiply(a: Int, b: Int) -> Int {
@@ -801,24 +801,24 @@ pub fn multiply(a: Int, b: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > subtract(3, 1)
-/// 2.0
+/// subtract(3, 1)
+/// // -> 2.0
 /// ```
 ///
 /// ```gleam
 /// import gleam/list
-/// > list.fold([1, 2, 3], 10, subtract)
-/// 4
+/// list.fold([1, 2, 3], 10, subtract)
+/// // -> 4
 /// ```
 ///
 /// ```gleam
-/// > 3 |> subtract(2)
-/// 1
+/// 3 |> subtract(2)
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > 3 |> subtract(2, _)
-/// -1
+/// 3 |> subtract(2, _)
+/// // -> -1
 /// ```
 ///
 pub fn subtract(a: Int, b: Int) -> Int {

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -7,9 +7,9 @@ import gleam/string
 /// ## Example
 ///
 /// ```gleam
-/// > io.print("Hi mum")
-/// // -> Hi mum
-/// Nil
+/// io.print("Hi mum")
+/// // -> Nil
+/// // Hi mum
 /// ```
 ///
 pub fn print(string: String) -> Nil {
@@ -27,9 +27,9 @@ fn do_print(string string: String) -> Nil
 /// ## Example
 ///
 /// ```
-/// > io.print_error("Hi pop")
-/// // -> Hi pop
-/// Nil
+/// io.print_error("Hi pop")
+/// // -> Nil
+/// // Hi pop
 /// ```
 ///
 pub fn print_error(string: String) -> Nil {
@@ -45,9 +45,9 @@ fn do_print_error(string string: String) -> Nil
 /// ## Example
 ///
 /// ```gleam
-/// > io.println("Hi mum")
-/// // -> Hi mum
-/// Nil
+/// io.println("Hi mum")
+/// // -> Nil
+/// // Hi mum
 /// ```
 ///
 pub fn println(string: String) -> Nil {
@@ -63,9 +63,9 @@ fn do_println(string string: String) -> Nil
 /// ## Example
 ///
 /// ```gleam
-/// > io.println_error("Hi pop")
-/// // -> Hi mum
-/// Nil
+/// io.println_error("Hi pop")
+/// // -> Nil
+/// // Hi mum
 /// ```
 ///
 pub fn println_error(string: String) -> Nil {
@@ -83,25 +83,25 @@ fn do_println_error(string string: String) -> Nil
 /// ## Example
 ///
 /// ```gleam
-/// > debug("Hi mum")
-/// // -> <<"Hi mum">>
-/// "Hi mum"
+/// debug("Hi mum")
+/// // -> "Hi mum"
+/// // <<"Hi mum">>
 /// ```
 ///
 /// ```gleam
-/// > debug(Ok(1))
-/// // -> {ok, 1}
-/// Ok(1)
+/// debug(Ok(1))
+/// // -> Ok(1)
+/// // {ok, 1}
 /// ```
 ///
 /// ```gleam
-/// > import list
-/// > [1, 2]
-/// > |> list.map(fn(x) { x + 1 })
-/// > |> debug
-/// > |> list.map(fn(x) { x * 2 })
-/// // -> [2, 3]
-/// [4, 6]
+/// import gleam/list
+/// [1, 2]
+/// |> list.map(fn(x) { x + 1 })
+/// |> debug
+/// |> list.map(fn(x) { x * 2 })
+/// // -> [4, 6]
+/// // [2, 3]
 /// ```
 ///
 pub fn debug(term: anything) -> anything {

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -63,14 +63,14 @@ fn do_unfold(
 /// ## Examples
 ///
 /// ```gleam
-/// > unfold(from: 5, with: fn(n) {
-/// >  case n {
-/// >    0 -> Done
-/// >    n -> Next(element: n, accumulator: n - 1)
-/// >  }
-/// > })
-/// > |> to_list
-/// [5, 4, 3, 2, 1]
+/// unfold(from: 5, with: fn(n) {
+///  case n {
+///    0 -> Done
+///    n -> Next(element: n, accumulator: n - 1)
+///  }
+/// })
+/// |> to_list
+/// // -> [5, 4, 3, 2, 1]
 /// ```
 ///
 pub fn unfold(
@@ -95,10 +95,10 @@ pub fn repeatedly(f: fn() -> element) -> Iterator(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > repeat(10)
-/// > |> take(4)
-/// > |> to_list
-/// [10, 10, 10, 10]
+/// repeat(10)
+/// |> take(4)
+/// |> to_list
+/// // -> [10, 10, 10, 10]
 /// ```
 ///
 pub fn repeat(x: element) -> Iterator(element) {
@@ -110,9 +110,9 @@ pub fn repeat(x: element) -> Iterator(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4])
-/// > |> to_list
-/// [1, 2, 3, 4]
+/// from_list([1, 2, 3, 4])
+/// |> to_list
+/// // -> [1, 2, 3, 4]
 /// ```
 ///
 pub fn from_list(list: List(element)) -> Iterator(element) {
@@ -155,11 +155,12 @@ fn do_transform(
 /// Approximate implementation of `index` in terms of `transform`:
 ///
 /// ```gleam
-/// > from_list(["a", "b", "c"])
-/// > |> transform(0, fn(i, el) { Next(#(i, el), i + 1) })
-/// > |> to_list
-/// [#(0, "a"), #(1, "b"), #(2, "c")]
+/// from_list(["a", "b", "c"])
+/// |> transform(0, fn(i, el) { Next(#(i, el), i + 1) })
+/// |> to_list
+/// // -> [#(0, "a"), #(1, "b"), #(2, "c")]
 /// ```
+/// 
 pub fn transform(
   over iterator: Iterator(a),
   from initial: acc,
@@ -192,10 +193,9 @@ fn do_fold(
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4]
-/// > |> from_list
-/// > |> fold(from: 0, with: fn(acc, element) { element + acc })
-/// 10
+/// from_list([1, 2, 3, 4])
+/// |> fold(from: 0, with: fn(acc, element) { element + acc })
+/// // -> 10
 /// ```
 ///
 pub fn fold(
@@ -224,11 +224,10 @@ pub fn run(iterator: Iterator(e)) -> Nil {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3]
-/// > |> from_list
-/// > |> map(fn(x) { x * 2 })
-/// > |> to_list
-/// [2, 4, 6]
+/// from_list([1, 2, 3])
+/// |> map(fn(x) { x * 2 })
+/// |> to_list
+/// // -> [2, 4, 6]
 /// ```
 ///
 pub fn to_list(iterator: Iterator(element)) -> List(element) {
@@ -245,21 +244,18 @@ pub fn to_list(iterator: Iterator(element)) -> List(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Next(first, rest) = [1, 2, 3, 4]
-/// >   |> from_list
-/// >   |> step
-/// > first
-/// 1
+/// let assert Next(first, rest) = from_list([1, 2, 3, 4]) |> step
+/// 
+/// first
+/// // -> 1
+///
+/// rest |> to_list
+/// // -> [2, 3, 4]
 /// ```
 ///
 /// ```gleam
-/// > rest |> to_list
-/// [2, 3, 4]
-/// ```
-///
-/// ```gleam
-/// > empty() |> step
-/// Done
+/// empty() |> step
+/// // -> Done
 /// ```
 ///
 pub fn step(iterator: Iterator(e)) -> Step(e, Iterator(e)) {
@@ -289,19 +285,17 @@ fn do_take(continuation: fn() -> Action(e), desired: Int) -> fn() -> Action(e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5]
-/// > |> from_list
-/// > |> take(up_to: 3)
-/// > |> to_list
-/// [1, 2, 3]
+/// from_list([1, 2, 3, 4, 5])
+/// |> take(up_to: 3)
+/// |> to_list
+/// // -> [1, 2, 3]
 /// ```
 ///
 /// ```gleam
-/// > [1, 2]
-/// > |> from_list
-/// > |> take(up_to: 3)
-/// > |> to_list
-/// [1, 2]
+/// from_list([1, 2])
+/// |> take(up_to: 3)
+/// |> to_list
+/// // -> [1, 2]
 /// ```
 ///
 pub fn take(from iterator: Iterator(e), up_to desired: Int) -> Iterator(e) {
@@ -333,19 +327,17 @@ fn do_drop(continuation: fn() -> Action(e), desired: Int) -> Action(e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5]
-/// > |> from_list
-/// > |> drop(up_to: 3)
-/// > |> to_list
-/// [4, 5]
+/// from_list([1, 2, 3, 4, 5])
+/// |> drop(up_to: 3)
+/// |> to_list
+/// // -> [4, 5]
 /// ```
 ///
 /// ```gleam
-/// > [1, 2]
-/// > |> from_list
-/// > |> drop(up_to: 3)
-/// > |> to_list
-/// []
+/// from_list([1, 2])
+/// |> drop(up_to: 3)
+/// |> to_list
+/// // -> []
 /// ```
 ///
 pub fn drop(from iterator: Iterator(e), up_to desired: Int) -> Iterator(e) {
@@ -373,11 +365,10 @@ fn do_map(continuation: fn() -> Action(a), f: fn(a) -> b) -> fn() -> Action(b) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3]
-/// > |> from_list
-/// > |> map(fn(x) { x * 2 })
-/// > |> to_list
-/// [2, 4, 6]
+/// from_list([1, 2, 3])
+/// |> map(fn(x) { x * 2 })
+/// |> to_list
+/// // -> [2, 4, 6]
 /// ```
 ///
 pub fn map(over iterator: Iterator(a), with f: fn(a) -> b) -> Iterator(b) {
@@ -451,11 +442,10 @@ fn do_append(first: fn() -> Action(a), second: fn() -> Action(a)) -> Action(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2]
-/// > |> from_list
-/// > |> append([3, 4] |> from_list)
-/// > |> to_list
-/// [1, 2, 3, 4]
+/// from_list([1, 2])
+/// |> append(from_list([3, 4]))
+/// |> to_list
+/// // -> [1, 2, 3, 4]
 /// ```
 ///
 pub fn append(to first: Iterator(a), suffix second: Iterator(a)) -> Iterator(a) {
@@ -479,11 +469,11 @@ fn do_flatten(flattened: fn() -> Action(Iterator(a))) -> Action(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([[1, 2], [3, 4]])
-/// > |> map(from_list)
-/// > |> flatten
-/// > |> to_list
-/// [1, 2, 3, 4]
+/// from_list([[1, 2], [3, 4]])
+/// |> map(from_list)
+/// |> flatten
+/// |> to_list
+/// // -> [1, 2, 3, 4]
 /// ```
 ///
 pub fn flatten(iterator: Iterator(Iterator(a))) -> Iterator(a) {
@@ -499,11 +489,11 @@ pub fn flatten(iterator: Iterator(Iterator(a))) -> Iterator(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [[1, 2], [3, 4]]
-/// > |> map(from_list)
-/// > |> concat
-/// > |> to_list
-/// [1, 2, 3, 4]
+/// [[1, 2], [3, 4]]
+/// |> map(from_list)
+/// |> concat
+/// |> to_list
+/// // -> [1, 2, 3, 4]
 /// ```
 ///
 pub fn concat(iterators: List(Iterator(a))) -> Iterator(a) {
@@ -522,11 +512,10 @@ pub fn concat(iterators: List(Iterator(a))) -> Iterator(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2]
-/// > |> from_list
-/// > |> flat_map(fn(x) { from_list([x, x + 1]) })
-/// > |> to_list
-/// [1, 2, 2, 3]
+/// from_list([1, 2])
+/// |> flat_map(fn(x) { from_list([x, x + 1]) })
+/// |> to_list
+/// // -> [1, 2, 2, 3]
 /// ```
 ///
 pub fn flat_map(
@@ -563,12 +552,11 @@ fn do_filter(
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/int
-/// > [1, 2, 3, 4]
-/// > |> from_list
-/// > |> filter(int.is_even)
-/// > |> to_list
-/// [2, 4]
+/// import gleam/int
+/// from_list([1, 2, 3, 4])
+/// |> filter(int.is_even)
+/// |> to_list
+/// // -> [2, 4]
 /// ```
 ///
 pub fn filter(
@@ -584,12 +572,11 @@ pub fn filter(
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2]
-/// > |> from_list
-/// > |> cycle
-/// > |> take(6)
-/// > |> to_list
-/// [1, 2, 1, 2, 1, 2]
+/// from_list([1, 2])
+/// |> cycle
+/// |> take(6)
+/// |> to_list
+/// // -> [1, 2, 1, 2, 1, 2]
 /// ```
 ///
 pub fn cycle(iterator: Iterator(a)) -> Iterator(a) {
@@ -603,18 +590,18 @@ pub fn cycle(iterator: Iterator(a)) -> Iterator(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > range(from: 1, to: 5) |> to_list
-/// [1, 2, 3, 4, 5]
+/// range(from: 1, to: 5) |> to_list
+/// // -> [1, 2, 3, 4, 5]
 /// ```
 ///
 /// ```gleam
-/// > range(from: 1, to: -2) |> to_list
-/// [1, 0, -1, -2]
+/// range(from: 1, to: -2) |> to_list
+/// // -> [1, 0, -1, -2]
 /// ```
 ///
 /// ```gleam
-/// > range(from: 0, to: 0) |> to_list
-/// [0]
+/// range(from: 0, to: 0) |> to_list
+/// // -> [0]
 /// ```
 ///
 pub fn range(from start: Int, to stop: Int) -> Iterator(Int) {
@@ -658,18 +645,18 @@ fn do_find(continuation: fn() -> Action(a), f: fn(a) -> Bool) -> Result(a, Nil) 
 /// ## Examples
 ///
 /// ```gleam
-/// > find(from_list([1, 2, 3]), fn(x) { x > 2 })
-/// Ok(3)
+/// find(from_list([1, 2, 3]), fn(x) { x > 2 })
+/// // -> Ok(3)
 /// ```
 ///
 /// ```gleam
-/// > find(from_list([1, 2, 3]), fn(x) { x > 4 })
-/// Error(Nil)
+/// find(from_list([1, 2, 3]), fn(x) { x > 4 })
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > find(empty(), fn(_) { True })
-/// Error(Nil)
+/// find(empty(), fn(_) { True })
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn find(
@@ -698,8 +685,8 @@ fn do_index(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list(["a", "b", "c"]) |> index |> to_list
-/// [#("a", 0), #("b", 1), #("c", 2)]
+/// from_list(["a", "b", "c"]) |> index |> to_list
+/// // -> [#("a", 0), #("b", 1), #("c", 2)]
 /// ```
 ///
 pub fn index(over iterator: Iterator(element)) -> Iterator(#(element, Int)) {
@@ -713,8 +700,8 @@ pub fn index(over iterator: Iterator(element)) -> Iterator(#(element, Int)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > iterate(1, fn(n) { n * 3 }) |> take(5) |> to_list
-/// [1, 3, 9, 27, 81]
+/// iterate(1, fn(n) { n * 3 }) |> take(5) |> to_list
+/// // -> [1, 3, 9, 27, 81]
 /// ```
 ///
 pub fn iterate(
@@ -745,10 +732,10 @@ fn do_take_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 2, 4])
-/// > |> take_while(satisfying: fn(x) { x < 3 })
-/// > |> to_list
-/// [1, 2]
+/// from_list([1, 2, 3, 2, 4])
+/// |> take_while(satisfying: fn(x) { x < 3 })
+/// |> to_list
+/// // -> [1, 2]
 /// ```
 ///
 pub fn take_while(
@@ -780,10 +767,10 @@ fn do_drop_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 2, 5])
-/// > |> drop_while(satisfying: fn(x) { x < 4 })
-/// > |> to_list
-/// [4, 2, 5]
+/// from_list([1, 2, 3, 4, 2, 5])
+/// |> drop_while(satisfying: fn(x) { x < 4 })
+/// |> to_list
+/// // -> [4, 2, 5]
 /// ```
 ///
 pub fn drop_while(
@@ -818,10 +805,10 @@ fn do_scan(
 ///
 /// ```gleam
 /// // Generate a sequence of partial sums
-/// > from_list([1, 2, 3, 4, 5])
-/// > |> scan(from: 0, with: fn(acc, el) { acc + el })
-/// > |> to_list
-/// [1, 3, 6, 10, 15]
+/// from_list([1, 2, 3, 4, 5])
+/// |> scan(from: 0, with: fn(acc, el) { acc + el })
+/// |> to_list
+/// // -> [1, 3, 6, 10, 15]
 /// ```
 ///
 pub fn scan(
@@ -857,10 +844,10 @@ fn do_zip(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list(["a", "b", "c"])
-/// > |> zip(range(20, 30))
-/// > |> to_list
-/// [#("a", 20), #("b", 21), #("c", 22)]
+/// from_list(["a", "b", "c"])
+/// |> zip(range(20, 30))
+/// |> to_list
+/// // -> [#("a", 20), #("b", 21), #("c", 22)]
 /// ```
 ///
 pub fn zip(left: Iterator(a), right: Iterator(b)) -> Iterator(#(a, b)) {
@@ -911,10 +898,10 @@ fn do_chunk(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 2, 3, 4, 4, 6, 7, 7])
-/// > |> chunk(by: fn(n) { n % 2 })
-/// > |> to_list
-/// [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
+/// from_list([1, 2, 2, 3, 4, 4, 6, 7, 7])
+/// |> chunk(by: fn(n) { n % 2 })
+/// |> to_list
+/// // -> [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
 /// ```
 ///
 pub fn chunk(
@@ -982,17 +969,17 @@ fn do_sized_chunk(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 5, 6])
-/// > |> sized_chunk(into: 2)
-/// > |> to_list
-/// [[1, 2], [3, 4], [5, 6]]
+/// from_list([1, 2, 3, 4, 5, 6])
+/// |> sized_chunk(into: 2)
+/// |> to_list
+/// // -> [[1, 2], [3, 4], [5, 6]]
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 5, 6, 7, 8])
-/// > |> sized_chunk(into: 3)
-/// > |> to_list
-/// [[1, 2, 3], [4, 5, 6], [7, 8]]
+/// from_list([1, 2, 3, 4, 5, 6, 7, 8])
+/// |> sized_chunk(into: 3)
+/// |> to_list
+/// // -> [[1, 2, 3], [4, 5, 6], [7, 8]]
 /// ```
 ///
 pub fn sized_chunk(
@@ -1023,20 +1010,24 @@ fn do_intersperse(
 /// ## Examples
 ///
 /// ```gleam
-/// > empty()
-/// > |> intersperse(with: 0)
-/// > |> to_list
-/// []
-///
-/// > from_list([1])
-/// > |> intersperse(with: 0)
-/// > |> to_list
-/// [1]
-///
-/// > from_list([1, 2, 3, 4, 5])
-/// > |> intersperse(with: 0)
-/// > |> to_list
-/// [1, 0, 2, 0, 3, 0, 4, 0, 5]
+/// empty()
+/// |> intersperse(with: 0)
+/// |> to_list
+/// // -> []
+/// ```
+/// 
+/// ```gleam
+/// from_list([1])
+/// |> intersperse(with: 0)
+/// |> to_list
+/// // -> [1]
+/// ```
+/// 
+/// ```gleam
+/// from_list([1, 2, 3, 4, 5])
+/// |> intersperse(with: 0)
+/// |> to_list
+/// // -> [1, 0, 2, 0, 3, 0, 4, 0, 5]
 /// ```
 ///
 pub fn intersperse(
@@ -1076,18 +1067,21 @@ fn do_any(
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> any(fn(n) { n % 2 == 0 })
-/// False
+/// empty()
+/// |> any(fn(n) { n % 2 == 0 })
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 5, 7, 9]) |> any(fn(n) { n % 2 == 0 })
-/// True
+/// from_list([1, 2, 5, 7, 9])
+/// |> any(fn(n) { n % 2 == 0 })
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 3, 5, 7, 9]) |> any(fn(n) { n % 2 == 0 })
-/// False
+/// from_list([1, 3, 5, 7, 9])
+/// |> any(fn(n) { n % 2 == 0 })
+/// // -> False
 /// ```
 ///
 pub fn any(
@@ -1122,18 +1116,21 @@ fn do_all(
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> all(fn(n) { n % 2 == 0 })
-/// True
+/// empty()
+/// |> all(fn(n) { n % 2 == 0 })
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > from_list([2, 4, 6, 8]) |> all(fn(n) { n % 2 == 0 })
-/// True
+/// from_list([2, 4, 6, 8])
+/// |> all(fn(n) { n % 2 == 0 })
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > from_list([2, 4, 5, 8]) |> all(fn(n) { n % 2 == 0 })
-/// False
+/// from_list([2, 4, 5, 8])
+/// |> all(fn(n) { n % 2 == 0 })
+/// // -> False
 /// ```
 ///
 pub fn all(
@@ -1170,8 +1167,9 @@ fn group_updater(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 5, 6]) |> group(by: fn(n) { n % 3 })
-/// dict.from_list([#(0, [3, 6]), #(1, [1, 4]), #(2, [2, 5])])
+/// from_list([1, 2, 3, 4, 5, 6])
+/// |> group(by: fn(n) { n % 3 })
+/// // -> dict.from_list([#(0, [3, 6]), #(1, [1, 4]), #(2, [2, 5])])
 /// ```
 ///
 pub fn group(
@@ -1193,13 +1191,15 @@ pub fn group(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([]) |> reduce(fn(acc, x) { acc + x })
-/// Error(Nil)
+/// from_list([])
+/// |> reduce(fn(acc, x) { acc + x })
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4, 5]) |> reduce(fn(acc, x) { acc + x })
-/// Ok(15)
+/// from_list([1, 2, 3, 4, 5])
+/// |> reduce(fn(acc, x) { acc + x })
+/// // -> Ok(15)
 /// ```
 ///
 pub fn reduce(
@@ -1223,13 +1223,13 @@ pub fn reduce(
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> last
-/// Error(Nil)
+/// empty() |> last
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > range(1, 10) |> last
-/// Ok(9)
+/// range(1, 10) |> last
+/// // -> Ok(9)
 /// ```
 ///
 pub fn last(iterator: Iterator(element)) -> Result(element, Nil) {
@@ -1242,8 +1242,8 @@ pub fn last(iterator: Iterator(element)) -> Result(element, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> to_list
-/// []
+/// empty() |> to_list
+/// // -> []
 /// ```
 ///
 pub fn empty() -> Iterator(element) {
@@ -1255,8 +1255,8 @@ pub fn empty() -> Iterator(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > once(fn() { 1 }) |> to_list
-/// [1]
+/// once(fn() { 1 }) |> to_list
+/// // -> [1]
 /// ```
 ///
 pub fn once(f: fn() -> element) -> Iterator(element) {
@@ -1269,8 +1269,8 @@ pub fn once(f: fn() -> element) -> Iterator(element) {
 /// ## Examples
 ///
 /// ```gleam
-/// > single(1) |> to_list
-/// [1]
+/// single(1) |> to_list
+/// // -> [1]
 /// ```
 ///
 pub fn single(elem: element) -> Iterator(element) {
@@ -1294,13 +1294,17 @@ fn do_interleave(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> interleave(from_list([11, 12, 13, 14])) |> to_list
-/// [1, 11, 2, 12, 3, 13, 4, 14]
+/// from_list([1, 2, 3, 4])
+/// |> interleave(from_list([11, 12, 13, 14]))
+/// |> to_list
+/// // -> [1, 11, 2, 12, 3, 13, 4, 14]
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> interleave(from_list([100])) |> to_list
-/// [1, 100, 2, 3, 4]
+/// from_list([1, 2, 3, 4])
+/// |> interleave(from_list([100]))
+/// |> to_list
+/// // -> [1, 100, 2, 3, 4]
 /// ```
 ///
 pub fn interleave(
@@ -1336,18 +1340,18 @@ fn do_fold_until(
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/list
-/// > let f = fn(acc, e) {
-/// >   case e {
-/// >     _ if e < 4 -> list.Continue(e + acc)
-/// >     _ -> list.Stop(acc)
-/// >   }
-/// > }
-/// >
-/// > [1, 2, 3, 4]
-/// > |> from_list
-/// > |> fold_until(from: acc, with: f)
-/// 6
+/// import gleam/list
+///
+/// let f = fn(acc, e) {
+///   case e {
+///     _ if e < 4 -> list.Continue(e + acc)
+///     _ -> list.Stop(acc)
+///   }
+/// }
+///
+/// from_list([1, 2, 3, 4])
+/// |> fold_until(from: acc, with: f)
+/// // -> 6
 /// ```
 ///
 pub fn fold_until(
@@ -1382,15 +1386,14 @@ fn do_try_fold(
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4]
-/// > |> iterator.from_list()
-/// > |> try_fold(0, fn(acc, i) {
-/// >   case i < 3 {
-/// >     True -> Ok(acc + i)
-/// >     False -> Error(Nil)
-/// >   }
-/// > })
-/// Error(Nil)
+/// from_list([1, 2, 3, 4])
+/// |> try_fold(0, fn(acc, i) {
+///   case i < 3 {
+///     True -> Ok(acc + i)
+///     False -> Error(Nil)
+///   }
+/// })
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn try_fold(
@@ -1408,13 +1411,13 @@ pub fn try_fold(
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3]) |> first
-/// Ok(1)
+/// from_list([1, 2, 3]) |> first
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > empty() |> first
-/// Error(Nil)
+/// empty() |> first
+/// // -> Error(Nil)
 /// ```
 pub fn first(from iterator: Iterator(e)) -> Result(e, Nil) {
   case iterator.continuation() {
@@ -1432,18 +1435,18 @@ pub fn first(from iterator: Iterator(e)) -> Result(e, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> at(2)
-/// Ok(3)
+/// from_list([1, 2, 3, 4]) |> at(2)
+/// // -> Ok(3)
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> at(4)
-/// Error(Nil)
+/// from_list([1, 2, 3, 4]) |> at(4)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > empty() |> at(0)
-/// Error(Nil)
+/// empty() |> at(0)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn at(in iterator: Iterator(e), get index: Int) -> Result(e, Nil) {
@@ -1467,13 +1470,13 @@ fn do_length(over continuation: fn() -> Action(e), with length: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> length
-/// 0
+/// empty() |> length
+/// // -> 0
 /// ```
 ///
 /// ```gleam
-/// > from_list([1, 2, 3, 4]) |> length
-/// 4
+/// from_list([1, 2, 3, 4]) |> length
+/// // -> 4
 /// ```
 ///
 pub fn length(over iterator: Iterator(e)) -> Int {
@@ -1486,16 +1489,16 @@ pub fn length(over iterator: Iterator(e)) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > empty() |> each(io.println)
-/// Nil
+/// empty() |> each(io.println)
+/// // -> Nil
 /// ```
 ///
 /// ```gleam
-/// > from_list(["Tom", "Malory", "Louis"]) |> each(io.println)
-/// // -> Tom
-/// // -> Malory
-/// // -> Louis
-/// Nil
+/// from_list(["Tom", "Malory", "Louis"]) |> each(io.println)
+/// // -> Nil
+/// // Tom
+/// // Malory
+/// // Louis
 /// ```
 ///
 pub fn each(over iterator: Iterator(a), with f: fn(a) -> b) -> Nil {
@@ -1512,11 +1515,14 @@ pub fn each(over iterator: Iterator(a), with f: fn(a) -> b) -> Nil {
 /// ## Examples
 /// 
 /// ```gleam
-/// > use <- iterator.yield(1)
-/// > use <- iterator.yield(2)
-/// > use <- iterator.yield(3)
-/// > iterator.empty()
-/// iterator.from_list([1, 2, 3])
+/// let iterator = {
+///   use <- yield(1)
+///   use <- yield(2)
+///   use <- yield(3)
+///   empty()
+/// }
+/// iterator |> to_list
+/// // -> [1, 2, 3]
 /// ```
 /// 
 pub fn yield(element: a, next: fn() -> Iterator(a)) -> Iterator(a) {

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -45,18 +45,18 @@ pub type LengthMismatch {
 /// ## Examples
 ///
 /// ```gleam
-/// > length([])
-/// 0
+/// length([])
+/// // -> 0
 /// ```
 ///
 /// ```gleam
-/// > length([1])
-/// 1
+/// length([1])
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > length([1, 2])
-/// 2
+/// length([1, 2])
+/// // -> 2
 /// ```
 ///
 pub fn length(of list: List(a)) -> Int {
@@ -92,18 +92,18 @@ fn do_length_acc(list: List(a), count: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > reverse([])
-/// []
+/// reverse([])
+/// // -> []
 /// ```
 ///
 /// ```gleam
-/// > reverse([1])
-/// [1]
+/// reverse([1])
+/// // -> [1]
 /// ```
 ///
 /// ```gleam
-/// > reverse([1, 2])
-/// [2, 1]
+/// reverse([1, 2])
+/// // -> [2, 1]
 /// ```
 ///
 pub fn reverse(xs: List(a)) -> List(a) {
@@ -134,18 +134,18 @@ fn do_reverse_acc(remaining, accumulator) {
 /// ## Examples
 ///
 /// ```gleam
-/// > is_empty([])
-/// True
+/// is_empty([])
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > is_empty([1])
-/// False
+/// is_empty([1])
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > is_empty([1, 1])
-/// False
+/// is_empty([1, 1])
+/// // -> False
 /// ```
 ///
 pub fn is_empty(list: List(a)) -> Bool {
@@ -160,28 +160,28 @@ pub fn is_empty(list: List(a)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > [] |> contains(any: 0)
-/// False
+/// [] |> contains(any: 0)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > [0] |> contains(any: 0)
-/// True
+/// [0] |> contains(any: 0)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > [1] |> contains(any: 0)
-/// False
+/// [1] |> contains(any: 0)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > [1, 1] |> contains(any: 0)
-/// False
+/// [1, 1] |> contains(any: 0)
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > [1, 0] |> contains(any: 0)
-/// True
+/// [1, 0] |> contains(any: 0)
+/// // -> True
 /// ```
 ///
 pub fn contains(list: List(a), any elem: a) -> Bool {
@@ -197,18 +197,18 @@ pub fn contains(list: List(a), any elem: a) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > first([])
-/// Error(Nil)
+/// first([])
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > first([0])
-/// Ok(0)
+/// first([0])
+/// // -> Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > first([1, 2])
-/// Ok(1)
+/// first([1, 2])
+/// // -> Ok(1)
 /// ```
 ///
 pub fn first(list: List(a)) -> Result(a, Nil) {
@@ -226,18 +226,18 @@ pub fn first(list: List(a)) -> Result(a, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > rest([])
-/// Error(Nil)
+/// rest([])
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > rest([0])
-/// Ok([])
+/// rest([0])
+/// // -> Ok([])
 /// ```
 ///
 /// ```gleam
-/// > rest([1, 2])
-/// Ok([2])
+/// rest([1, 2])
+/// // -> Ok([2])
 /// ```
 ///
 pub fn rest(list: List(a)) -> Result(List(a), Nil) {
@@ -266,23 +266,27 @@ fn update_group(
 /// ## Examples
 ///
 /// ```gleam
-/// > [Ok(3), Error("Wrong"), Ok(200), Ok(73)]
-///   |> group(by: fn(i) {
-///     case i {
-///       Ok(_) -> "Successful"
-///       Error(_) -> "Failed"
-///     }
-///   })
-///   |> dict.to_list
-///
-/// [
-///   #("Failed", [Error("Wrong")]),
-///   #("Successful", [Ok(73), Ok(200), Ok(3)])
-/// ]
-///
-/// > group([1,2,3,4,5], by: fn(i) { i - i / 3 * 3 })
+/// import gleam/dict
+/// 
+/// [Ok(3), Error("Wrong"), Ok(200), Ok(73)]
+/// |> group(by: fn(i) {
+///   case i {
+///     Ok(_) -> "Successful"
+///     Error(_) -> "Failed"
+///   }
+/// })
 /// |> dict.to_list
-/// [#(0, [3]), #(1, [4, 1]), #(2, [5, 2])]
+/// // -> [
+/// //   #("Failed", [Error("Wrong")]),
+/// //   #("Successful", [Ok(73), Ok(200), Ok(3)])
+/// // ]
+/// ```
+/// 
+/// ```gleam
+/// import gleam/dict
+/// group([1,2,3,4,5], by: fn(i) { i - i / 3 * 3 })
+/// |> dict.to_list
+/// // -> [#(0, [3]), #(1, [4, 1]), #(2, [5, 2])]
 /// ```
 ///
 pub fn group(list: List(v), by key: fn(v) -> k) -> Dict(k, List(v)) {
@@ -308,13 +312,13 @@ fn do_filter(list: List(a), fun: fn(a) -> Bool, acc: List(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > filter([2, 4, 6, 1], fn(x) { x > 2 })
-/// [4, 6]
+/// filter([2, 4, 6, 1], fn(x) { x > 2 })
+/// // -> [4, 6]
 /// ```
 ///
 /// ```gleam
-/// > filter([2, 4, 6, 1], fn(x) { x > 6 })
-/// []
+/// filter([2, 4, 6, 1], fn(x) { x > 6 })
+/// // -> []
 /// ```
 ///
 pub fn filter(list: List(a), keeping predicate: fn(a) -> Bool) -> List(a) {
@@ -344,13 +348,13 @@ fn do_filter_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > filter_map([2, 4, 6, 1], Error)
-/// []
+/// filter_map([2, 4, 6, 1], Error)
+/// // -> []
 /// ```
 ///
 /// ```gleam
-/// > filter_map([2, 4, 6, 1], fn(x) { Ok(x + 1) })
-/// [3, 5, 7, 2]
+/// filter_map([2, 4, 6, 1], fn(x) { Ok(x + 1) })
+/// // -> [3, 5, 7, 2]
 /// ```
 ///
 pub fn filter_map(list: List(a), with fun: fn(a) -> Result(b, e)) -> List(b) {
@@ -370,8 +374,8 @@ fn do_map(list: List(a), fun: fn(a) -> b, acc: List(b)) -> List(b) {
 /// ## Examples
 ///
 /// ```gleam
-/// > map([2, 4, 6], fn(x) { x * 2 })
-/// [4, 8, 12]
+/// map([2, 4, 6], fn(x) { x * 2 })
+/// // -> [4, 8, 12]
 /// ```
 ///
 pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
@@ -385,13 +389,13 @@ pub fn map(list: List(a), with fun: fn(a) -> b) -> List(b) {
 /// ## Examples
 /// 
 /// ```gleam
-/// > map2([1, 2, 3], [4, 5, 6], fn(x, y) { x + y })
-/// [5, 7, 9]
+/// map2([1, 2, 3], [4, 5, 6], fn(x, y) { x + y })
+/// // -> [5, 7, 9]
 /// ```
 /// 
 /// ```gleam
-/// > map2([1, 2], ["a", "b", "c"], fn(i, x) { #(i, x) })
-/// [#(1, "a"), #(2, "b")]
+/// map2([1, 2], ["a", "b", "c"], fn(i, x) { #(i, x) })
+/// // -> [#(1, "a"), #(2, "b")]
 /// ```
 /// 
 pub fn map2(list1: List(a), list2: List(b), with fun: fn(a, b) -> c) -> List(c) {
@@ -415,12 +419,12 @@ fn do_map2(
 /// ## Examples
 ///
 /// ```gleam
-/// > map_fold(
-///     over: [1, 2, 3],
-///     from: 100,
-///     with: fn(memo, i) { #(memo + i, i * 2) }
-///   )
-/// #(106, [2, 4, 6])
+/// map_fold(
+///   over: [1, 2, 3],
+///   from: 100,
+///   with: fn(memo, i) { #(memo + i, i * 2) }
+/// )
+/// // -> #(106, [2, 4, 6])
 /// ```
 ///
 pub fn map_fold(
@@ -460,8 +464,8 @@ fn do_index_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > index_map(["a", "b"], fn(x, i) { #(i, x) })
-/// [#(0, "a"), #(1, "b")]
+/// index_map(["a", "b"], fn(x, i) { #(i, x) })
+/// // -> [#(0, "a"), #(1, "b")]
 /// ```
 ///
 pub fn index_map(list: List(a), with fun: fn(a, Int) -> b) -> List(b) {
@@ -496,23 +500,23 @@ fn do_try_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > try_map([1, 2, 3], fn(x) { Ok(x + 2) })
-/// Ok([3, 4, 5])
+/// try_map([1, 2, 3], fn(x) { Ok(x + 2) })
+/// // -> Ok([3, 4, 5])
 /// ```
 ///
 /// ```gleam
-/// > try_map([1, 2, 3], fn(_) { Error(0) })
-/// Error(0)
+/// try_map([1, 2, 3], fn(_) { Error(0) })
+/// // -> Error(0)
 /// ```
 ///
 /// ```gleam
-/// > try_map([[1], [2, 3]], first)
-/// Ok([1, 2])
+/// try_map([[1], [2, 3]], first)
+/// // -> Ok([1, 2])
 /// ```
 ///
 /// ```gleam
-/// > try_map([[1], [], [2]], first)
-/// Error(Nil)
+/// try_map([[1], [], [2]], first)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn try_map(
@@ -533,13 +537,13 @@ pub fn try_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > drop([1, 2, 3, 4], 2)
-/// [3, 4]
+/// drop([1, 2, 3, 4], 2)
+/// // -> [3, 4]
 /// ```
 ///
 /// ```gleam
-/// > drop([1, 2, 3, 4], 9)
-/// []
+/// drop([1, 2, 3, 4], 9)
+/// // -> []
 /// ```
 ///
 pub fn drop(from list: List(a), up_to n: Int) -> List(a) {
@@ -575,13 +579,13 @@ fn do_take(list: List(a), n: Int, acc: List(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > take([1, 2, 3, 4], 2)
-/// [1, 2]
+/// take([1, 2, 3, 4], 2)
+/// // -> [1, 2]
 /// ```
 ///
 /// ```gleam
-/// > take([1, 2, 3, 4], 9)
-/// [1, 2, 3, 4]
+/// take([1, 2, 3, 4], 9)
+/// // -> [1, 2, 3, 4]
 /// ```
 ///
 pub fn take(from list: List(a), up_to n: Int) -> List(a) {
@@ -593,8 +597,8 @@ pub fn take(from list: List(a), up_to n: Int) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > new()
-/// []
+/// new()
+/// // -> []
 /// ```
 ///
 pub fn new() -> List(a) {
@@ -609,8 +613,8 @@ pub fn new() -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > append([1, 2], [3])
-/// [1, 2, 3]
+/// append([1, 2], [3])
+/// // -> [1, 2, 3]
 /// ```
 ///
 pub fn append(first: List(a), second: List(a)) -> List(a) {
@@ -638,7 +642,13 @@ fn do_append_acc(first: List(a), second: List(a)) -> List(a) {
 /// syntax instead
 ///
 /// ```gleam
-/// let new_list = [1, ..existing_list]
+/// let existing_list = [2, 3, 4]
+/// 
+/// [1, ..existing_list]
+/// // -> [1, 2, 3, 4]
+/// 
+/// prepend(to: existing_list, this: 1)
+/// // -> [1, 2, 3, 4]
 /// ```
 ///
 pub fn prepend(to list: List(a), this item: a) -> List(a) {
@@ -668,8 +678,8 @@ fn do_concat(lists: List(List(a)), acc: List(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > concat([[1], [2, 3], []])
-/// [1, 2, 3]
+/// concat([[1], [2, 3], []])
+/// // -> [1, 2, 3]
 /// ```
 ///
 pub fn concat(lists: List(List(a))) -> List(a) {
@@ -684,8 +694,8 @@ pub fn concat(lists: List(List(a))) -> List(a) {
 /// ## Examples
 /// 
 /// ```gleam
-/// > flatten([[1], [2, 3], []])
-/// [1, 2, 3]
+/// flatten([[1], [2, 3], []])
+/// // -> [1, 2, 3]
 /// ```
 /// 
 pub fn flatten(lists: List(List(a))) -> List(a) {
@@ -697,8 +707,8 @@ pub fn flatten(lists: List(List(a))) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > flat_map([2, 4, 6], fn(x) { [x, x + 1] })
-/// [2, 3, 4, 5, 6, 7]
+/// flat_map([2, 4, 6], fn(x) { [x, x + 1] })
+/// // -> [2, 3, 4, 5, 6, 7]
 /// ```
 ///
 pub fn flat_map(over list: List(a), with fun: fn(a) -> List(b)) -> List(b) {
@@ -793,6 +803,7 @@ pub fn index_fold(
 ///     False -> Error(Nil)
 ///   }
 /// })
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn try_fold(
@@ -831,6 +842,7 @@ pub type ContinueOrStop(a) {
 ///     False -> Stop(acc)
 ///   }
 /// })
+/// // -> 6
 /// ```
 ///
 pub fn fold_until(
@@ -856,18 +868,18 @@ pub fn fold_until(
 /// ## Examples
 ///
 /// ```gleam
-/// > find([1, 2, 3], fn(x) { x > 2 })
-/// Ok(3)
+/// find([1, 2, 3], fn(x) { x > 2 })
+/// // -> Ok(3)
 /// ```
 ///
 /// ```gleam
-/// > find([1, 2, 3], fn(x) { x > 4 })
-/// Error(Nil)
+/// find([1, 2, 3], fn(x) { x > 4 })
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > find([], fn(_) { True })
-/// Error(Nil)
+/// find([], fn(_) { True })
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn find(
@@ -892,18 +904,18 @@ pub fn find(
 /// ## Examples
 ///
 /// ```gleam
-/// > find_map([[], [2], [3]], first)
-/// Ok(2)
+/// find_map([[], [2], [3]], first)
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > find_map([[], []], first)
-/// Error(Nil)
+/// find_map([[], []], first)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > find_map([], first)
-/// Error(Nil)
+/// find_map([], first)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn find_map(
@@ -927,18 +939,18 @@ pub fn find_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > all([], fn(x) { x > 3 })
-/// True
+/// all([], fn(x) { x > 3 })
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > all([4, 5], fn(x) { x > 3 })
-/// True
+/// all([4, 5], fn(x) { x > 3 })
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > all([4, 3], fn(x) { x > 3 })
-/// False
+/// all([4, 3], fn(x) { x > 3 })
+/// // -> False
 /// ```
 ///
 pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
@@ -959,23 +971,23 @@ pub fn all(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > any([], fn(x) { x > 3 })
-/// False
+/// any([], fn(x) { x > 3 })
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > any([4, 5], fn(x) { x > 3 })
-/// True
+/// any([4, 5], fn(x) { x > 3 })
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > any([4, 3], fn(x) { x > 4 })
-/// False
+/// any([4, 3], fn(x) { x > 4 })
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > any([3, 4], fn(x) { x > 3 })
-/// True
+/// any([3, 4], fn(x) { x > 3 })
+/// // -> True
 /// ```
 ///
 pub fn any(in list: List(a), satisfying predicate: fn(a) -> Bool) -> Bool {
@@ -1004,23 +1016,23 @@ fn do_zip(xs: List(a), ys: List(b), acc: List(#(a, b))) -> List(#(a, b)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > zip([], [])
-/// []
+/// zip([], [])
+/// // -> []
 /// ```
 ///
 /// ```gleam
-/// > zip([1, 2], [3])
-/// [#(1, 3)]
+/// zip([1, 2], [3])
+/// // -> [#(1, 3)]
 /// ```
 ///
 /// ```gleam
-/// > zip([1], [3, 4])
-/// [#(1, 3)]
+/// zip([1], [3, 4])
+/// // -> [#(1, 3)]
 /// ```
 ///
 /// ```gleam
-/// > zip([1, 2], [3, 4])
-/// [#(1, 3), #(2, 4)]
+/// zip([1, 2], [3, 4])
+/// // -> [#(1, 3), #(2, 4)]
 /// ```
 ///
 pub fn zip(list: List(a), with other: List(b)) -> List(#(a, b)) {
@@ -1034,23 +1046,23 @@ pub fn zip(list: List(a), with other: List(b)) -> List(#(a, b)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > strict_zip([], [])
-/// Ok([])
+/// strict_zip([], [])
+/// // -> Ok([])
 /// ```
 ///
 /// ```gleam
-/// > strict_zip([1, 2], [3])
-/// Error(LengthMismatch)
+/// strict_zip([1, 2], [3])
+/// // -> Error(LengthMismatch)
 /// ```
 ///
 /// ```gleam
-/// > strict_zip([1], [3, 4])
-/// Error(LengthMismatch)
+/// strict_zip([1], [3, 4])
+/// // -> Error(LengthMismatch)
 /// ```
 ///
 /// ```gleam
-/// > strict_zip([1, 2], [3, 4])
-/// Ok([#(1, 3), #(2, 4)])
+/// strict_zip([1, 2], [3, 4])
+/// // -> Ok([#(1, 3), #(2, 4)])
 /// ```
 ///
 pub fn strict_zip(
@@ -1075,13 +1087,13 @@ fn do_unzip(input, xs, ys) {
 /// ## Examples
 ///
 /// ```gleam
-/// > unzip([#(1, 2), #(3, 4)])
-/// #([1, 3], [2, 4])
+/// unzip([#(1, 2), #(3, 4)])
+/// // -> #([1, 3], [2, 4])
 /// ```
 ///
 /// ```gleam
-/// > unzip([])
-/// #([], [])
+/// unzip([])
+/// // -> #([], [])
 /// ```
 ///
 pub fn unzip(input: List(#(a, b))) -> #(List(a), List(b)) {
@@ -1102,13 +1114,13 @@ fn do_intersperse(list: List(a), separator: a, acc: List(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > intersperse([1, 1, 1], 2)
-/// [1, 2, 1, 2, 1]
+/// intersperse([1, 1, 1], 2)
+/// // -> [1, 2, 1, 2, 1]
 /// ```
 ///
 /// ```gleam
-/// > intersperse([], 2)
-/// []
+/// intersperse([], 2)
+/// // -> []
 /// ```
 ///
 pub fn intersperse(list: List(a), with elem: a) -> List(a) {
@@ -1127,13 +1139,13 @@ pub fn intersperse(list: List(a), with elem: a) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > at([1, 2, 3], 1)
-/// Ok(2)
+/// at([1, 2, 3], 1)
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > at([1, 2, 3], 5)
-/// Error(Nil)
+/// at([1, 2, 3], 5)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn at(in list: List(a), get index: Int) -> Result(a, Nil) {
@@ -1153,8 +1165,8 @@ pub fn at(in list: List(a), get index: Int) -> Result(a, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > unique([1, 1, 1, 4, 7, 3, 3, 4])
-/// [1, 4, 7, 3]
+/// unique([1, 1, 1, 4, 7, 3, 3, 4])
+/// // -> [1, 4, 7, 3]
 /// ```
 ///
 pub fn unique(list: List(a)) -> List(a) {
@@ -1265,9 +1277,9 @@ fn merge_sort(
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/int
-/// > list.sort([4, 3, 6, 5, 4, 1, 2], by: int.compare)
-/// [1, 2, 3, 4, 4, 5, 6]
+/// import gleam/int
+/// sort([4, 3, 6, 5, 4, 1, 2], by: int.compare)
+/// // -> [1, 2, 3, 4, 4, 5, 6]
 /// ```
 ///
 pub fn sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
@@ -1279,18 +1291,18 @@ pub fn sort(list: List(a), by compare: fn(a, a) -> Order) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > range(0, 0)
-/// [0]
+/// range(0, 0)
+/// // -> [0]
 /// ```
 ///
 /// ```gleam
-/// > range(0, 5)
-/// [0, 1, 2, 3, 4, 5]
+/// range(0, 5)
+/// // -> [0, 1, 2, 3, 4, 5]
 /// ```
 ///
 /// ```gleam
-/// > range(1, -5)
-/// [1, 0, -1, -2, -3, -4, -5]
+/// range(1, -5)
+/// // -> [1, 0, -1, -2, -3, -4, -5]
 /// ```
 ///
 pub fn range(from start: Int, to stop: Int) -> List(Int) {
@@ -1317,13 +1329,13 @@ fn do_repeat(a: a, times: Int, acc: List(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > repeat("a", times: 0)
-/// []
+/// repeat("a", times: 0)
+/// // -> []
 /// ```
 ///
 /// ```gleam
-/// > repeat("a", times: 5)
-/// ["a", "a", "a", "a", "a"]
+/// repeat("a", times: 5)
+/// // -> ["a", "a", "a", "a", "a"]
 /// ```
 ///
 pub fn repeat(item a: a, times times: Int) -> List(a) {
@@ -1349,18 +1361,18 @@ fn do_split(list: List(a), n: Int, taken: List(a)) -> #(List(a), List(a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > split([6, 7, 8, 9], 0)
-/// #([], [6, 7, 8, 9])
+/// split([6, 7, 8, 9], 0)
+/// // -> #([], [6, 7, 8, 9])
 /// ```
 ///
 /// ```gleam
-/// > split([6, 7, 8, 9], 2)
-/// #([6, 7], [8, 9])
+/// split([6, 7, 8, 9], 2)
+/// // -> #([6, 7], [8, 9])
 /// ```
 ///
 /// ```gleam
-/// > split([6, 7, 8, 9], 4)
-/// #([6, 7, 8, 9], [])
+/// split([6, 7, 8, 9], 4)
+/// // -> #([6, 7, 8, 9], [])
 /// ```
 ///
 pub fn split(list list: List(a), at index: Int) -> #(List(a), List(a)) {
@@ -1391,13 +1403,13 @@ fn do_split_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > split_while([1, 2, 3, 4, 5], fn(x) { x <= 3 })
-/// #([1, 2, 3], [4, 5])
+/// split_while([1, 2, 3, 4, 5], fn(x) { x <= 3 })
+/// // -> #([1, 2, 3], [4, 5])
 /// ```
 ///
 /// ```gleam
-/// > split_while([1, 2, 3, 4, 5], fn(x) { x <= 5 })
-/// #([1, 2, 3, 4, 5], [])
+/// split_while([1, 2, 3, 4, 5], fn(x) { x <= 5 })
+/// // -> #([1, 2, 3, 4, 5], [])
 /// ```
 ///
 pub fn split_while(
@@ -1418,18 +1430,18 @@ pub fn split_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > key_find([#("a", 0), #("b", 1)], "a")
-/// Ok(0)
+/// key_find([#("a", 0), #("b", 1)], "a")
+/// // -> Ok(0)
 /// ```
 ///
 /// ```gleam
-/// > key_find([#("a", 0), #("b", 1)], "b")
-/// Ok(1)
+/// key_find([#("a", 0), #("b", 1)], "b")
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > key_find([#("a", 0), #("b", 1)], "c")
-/// Error(Nil)
+/// key_find([#("a", 0), #("b", 1)], "c")
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn key_find(
@@ -1454,13 +1466,13 @@ pub fn key_find(
 /// ## Examples
 ///
 /// ```gleam
-/// > key_filter([#("a", 0), #("b", 1), #("a", 2)], "a")
-/// [0, 2]
+/// key_filter([#("a", 0), #("b", 1), #("a", 2)], "a")
+/// // -> [0, 2]
 /// ```
 ///
 /// ```gleam
-/// > key_filter([#("a", 0), #("b", 1)], "c")
-/// []
+/// key_filter([#("a", 0), #("b", 1)], "c")
+/// // -> []
 /// ```
 ///
 pub fn key_filter(
@@ -1494,18 +1506,18 @@ fn do_pop(haystack, predicate, checked) {
 /// ## Examples
 ///
 /// ```gleam
-/// > pop([1, 2, 3], fn(x) { x > 2 })
-/// Ok(#(3, [1, 2]))
+/// pop([1, 2, 3], fn(x) { x > 2 })
+/// // -> Ok(#(3, [1, 2]))
 /// ```
 ///
 /// ```gleam
-/// > pop([1, 2, 3], fn(x) { x > 4 })
-/// Error(Nil)
+/// pop([1, 2, 3], fn(x) { x > 4 })
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > pop([], fn(_) { True })
-/// Error(Nil)
+/// pop([], fn(_) { True })
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn pop(
@@ -1534,18 +1546,18 @@ fn do_pop_map(haystack, mapper, checked) {
 /// ## Examples
 ///
 /// ```gleam
-/// > pop_map([[], [2], [3]], first)
-/// Ok(#(2, [[], [3]]))
+/// pop_map([[], [2], [3]], first)
+/// // -> Ok(#(2, [[], [3]]))
 /// ```
 ///
 /// ```gleam
-/// > pop_map([[], []], first)
-/// Error(Nil)
+/// pop_map([[], []], first)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > pop_map([], first)
-/// Error(Nil)
+/// pop_map([], first)
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn pop_map(
@@ -1564,18 +1576,18 @@ pub fn pop_map(
 /// ## Examples
 ///
 /// ```gleam
-/// > key_pop([#("a", 0), #("b", 1)], "a")
-/// Ok(#(0, [#("b", 1)]))
+/// key_pop([#("a", 0), #("b", 1)], "a")
+/// // -> Ok(#(0, [#("b", 1)]))
 /// ```
 ///
 /// ```gleam
-/// > key_pop([#("a", 0), #("b", 1)], "b")
-/// Ok(#(1, [#("a", 0)]))
+/// key_pop([#("a", 0), #("b", 1)], "b")
+/// // -> Ok(#(1, [#("a", 0)]))
 /// ```
 ///
 /// ```gleam
-/// > key_pop([#("a", 0), #("b", 1)], "c")
-/// Error(Nil)
+/// key_pop([#("a", 0), #("b", 1)], "c")
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn key_pop(
@@ -1599,13 +1611,13 @@ pub fn key_pop(
 /// ## Examples
 ///
 /// ```gleam
-/// > key_set([#(5, 0), #(4, 1)], 4, 100)
-/// [#(5, 0), #(4, 100)]
+/// key_set([#(5, 0), #(4, 1)], 4, 100)
+/// // -> [#(5, 0), #(4, 100)]
 /// ```
 ///
 /// ```gleam
-/// > key_set([#(5, 0), #(4, 1)], 1, 100)
-/// [#(5, 0), #(4, 1), #(1, 100)]
+/// key_set([#(5, 0), #(4, 1)], 1, 100)
+/// // -> [#(5, 0), #(4, 1), #(1, 100)]
 /// ```
 ///
 pub fn key_set(list: List(#(a, b)), key: a, value: b) -> List(#(a, b)) {
@@ -1621,8 +1633,12 @@ pub fn key_set(list: List(#(a, b)), key: a, value: b) -> List(#(a, b)) {
 /// Useful for calling a side effect for every item of a list.
 ///
 /// ```gleam
-/// > list.each([1, 2, 3], io.println)
-/// Nil
+/// import gleam/io
+/// each(["1", "2", "3"], io.println)
+/// // -> Nil
+/// // 1
+/// // 2
+/// // 3
 /// ```
 ///
 pub fn each(list: List(a), f: fn(a) -> b) -> Nil {
@@ -1644,11 +1660,11 @@ pub fn each(list: List(a), f: fn(a) -> b) -> Nil {
 /// ## Examples
 ///
 /// ```gleam
-/// > try_each(
-/// >   over: [1, 2, 3],
-/// >   with: function_that_might_fail,
-/// > )
-/// Ok(Nil)
+/// try_each(
+///   over: [1, 2, 3],
+///   with: function_that_might_fail,
+/// )
+/// // -> Ok(Nil)
 /// ```
 ///
 pub fn try_each(
@@ -1682,8 +1698,9 @@ fn do_partition(list, categorise, trues, falses) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5] |> list.partition(int.is_odd)
-/// #([1, 3, 5], [2, 4])
+/// import gleam/int
+/// [1, 2, 3, 4, 5] |> partition(int.is_odd)
+/// // -> #([1, 3, 5], [2, 4])
 /// ```
 ///
 pub fn partition(
@@ -1698,8 +1715,8 @@ pub fn partition(
 /// ## Examples
 ///
 /// ```gleam
-/// > permutations([1, 2])
-/// [[1, 2], [2, 1]]
+/// permutations([1, 2])
+/// // -> [[1, 2], [2, 1]]
 /// ```
 ///
 pub fn permutations(l: List(a)) -> List(List(a)) {
@@ -1737,13 +1754,13 @@ fn do_window(acc: List(List(a)), l: List(a), n: Int) -> List(List(a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > window([1,2,3,4,5], 3)
-/// [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+/// window([1,2,3,4,5], 3)
+/// // -> [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
 /// ```
 ///
 /// ```gleam
-/// > window([1, 2], 4)
-/// []
+/// window([1, 2], 4)
+/// // -> []
 /// ```
 ///
 pub fn window(l: List(a), by n: Int) -> List(List(a)) {
@@ -1756,13 +1773,13 @@ pub fn window(l: List(a), by n: Int) -> List(List(a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > window_by_2([1,2,3,4])
-/// [#(1, 2), #(2, 3), #(3, 4)]
+/// window_by_2([1,2,3,4])
+/// // -> [#(1, 2), #(2, 3), #(3, 4)]
 /// ```
 ///
 /// ```gleam
-/// > window_by_2([1])
-/// []
+/// window_by_2([1])
+/// // -> []
 /// ```
 ///
 pub fn window_by_2(l: List(a)) -> List(#(a, a)) {
@@ -1774,8 +1791,8 @@ pub fn window_by_2(l: List(a)) -> List(#(a, a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > drop_while([1, 2, 3, 4], fn (x) { x < 3 })
-/// [3, 4]
+/// drop_while([1, 2, 3, 4], fn (x) { x < 3 })
+/// // -> [3, 4]
 /// ```
 ///
 pub fn drop_while(
@@ -1812,8 +1829,8 @@ fn do_take_while(
 /// ## Examples
 ///
 /// ```gleam
-/// > take_while([1, 2, 3, 2, 4], fn (x) { x < 3 })
-/// [1, 2]
+/// take_while([1, 2, 3, 2, 4], fn (x) { x < 3 })
+/// // -> [1, 2]
 /// ```
 ///
 pub fn take_while(
@@ -1851,8 +1868,8 @@ fn do_chunk(
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 2, 3, 4, 4, 6, 7, 7] |> chunk(by: fn(n) { n % 2 })
-/// [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
+/// [1, 2, 2, 3, 4, 4, 6, 7, 7] |> chunk(by: fn(n) { n % 2 })
+/// // -> [[1], [2, 2], [3], [4, 4, 6], [7, 7]]
 /// ```
 ///
 pub fn chunk(in list: List(a), by f: fn(a) -> key) -> List(List(a)) {
@@ -1895,13 +1912,13 @@ fn do_sized_chunk(
 /// ## Examples
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5, 6] |> sized_chunk(into: 2)
-/// [[1, 2], [3, 4], [5, 6]]
+/// [1, 2, 3, 4, 5, 6] |> sized_chunk(into: 2)
+/// // -> [[1, 2], [3, 4], [5, 6]]
 /// ```
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5, 6, 7, 8] |> sized_chunk(into: 3)
-/// [[1, 2, 3], [4, 5, 6], [7, 8]]
+/// [1, 2, 3, 4, 5, 6, 7, 8] |> sized_chunk(into: 3)
+/// // -> [[1, 2, 3], [4, 5, 6], [7, 8]]
 /// ```
 ///
 pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
@@ -1919,13 +1936,13 @@ pub fn sized_chunk(in list: List(a), into count: Int) -> List(List(a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [] |> reduce(fn(acc, x) { acc + x })
-/// Error(Nil)
+/// [] |> reduce(fn(acc, x) { acc + x })
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > [1, 2, 3, 4, 5] |> reduce(fn(acc, x) { acc + x })
-/// Ok(15)
+/// [1, 2, 3, 4, 5] |> reduce(fn(acc, x) { acc + x })
+/// // -> Ok(15)
 /// ```
 ///
 pub fn reduce(over list: List(a), with fun: fn(a, a) -> a) -> Result(a, Nil) {
@@ -1955,8 +1972,8 @@ fn do_scan(
 /// ## Examples
 ///
 /// ```gleam
-/// > scan(over: [1, 2, 3], from: 100, with: fn(acc, i) { acc + i })
-/// [101, 103, 106]
+/// scan(over: [1, 2, 3], from: 100, with: fn(acc, i) { acc + i })
+/// // -> [101, 103, 106]
 /// ```
 ///
 pub fn scan(
@@ -1978,13 +1995,13 @@ pub fn scan(
 /// ## Examples
 ///
 /// ```gleam
-/// > last([])
-/// Error(Nil)
+/// last([])
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > last([1, 2, 3, 4, 5])
-/// Ok(5)
+/// last([1, 2, 3, 4, 5])
+/// // -> Ok(5)
 /// ```
 ///
 pub fn last(list: List(a)) -> Result(a, Nil) {
@@ -1997,13 +2014,13 @@ pub fn last(list: List(a)) -> Result(a, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > combinations([1, 2, 3], 2)
-/// [[1, 2], [1, 3], [2, 3]]
+/// combinations([1, 2, 3], 2)
+/// // -> [[1, 2], [1, 3], [2, 3]]
 /// ```
 ///
 /// ```gleam
-/// > combinations([1, 2, 3, 4], 3)
-/// [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
+/// combinations([1, 2, 3, 4], 3)
+/// // -> [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
 /// ```
 ///
 pub fn combinations(items: List(a), by n: Int) -> List(List(a)) {
@@ -2039,8 +2056,8 @@ fn do_combination_pairs(items: List(a)) -> List(List(#(a, a))) {
 /// ## Examples
 ///
 /// ```gleam
-/// > combination_pairs([1, 2, 3])
-/// [#(1, 2), #(1, 3), #(2, 3)]
+/// combination_pairs([1, 2, 3])
+/// // -> [#(1, 2), #(1, 3), #(2, 3)]
 /// ```
 ///
 pub fn combination_pairs(items: List(a)) -> List(#(a, a)) {
@@ -2053,8 +2070,8 @@ pub fn combination_pairs(items: List(a)) -> List(#(a, a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > list.interleave([[1, 2], [101, 102], [201, 202]])
-/// [1, 101, 201, 2, 102, 202]
+/// interleave([[1, 2], [101, 102], [201, 202]])
+/// // -> [1, 101, 201, 2, 102, 202]
 /// ```
 ///
 pub fn interleave(list: List(List(a))) -> List(a) {
@@ -2071,8 +2088,8 @@ pub fn interleave(list: List(List(a))) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > transpose([[1, 2, 3], [101, 102, 103]])
-/// [[1, 101], [2, 102], [3, 103]]
+/// transpose([[1, 2, 3], [101, 102, 103]])
+/// // -> [[1, 101], [2, 102], [3, 103]]
 /// ```
 ///
 pub fn transpose(list_of_list: List(List(a))) -> List(List(a)) {
@@ -2121,9 +2138,8 @@ fn do_shuffle_by_pair_indexes(
 /// ## Example
 ///
 /// ```gleam
-/// > range(1, 10)
-/// > |> shuffle()
-/// [1, 6, 9, 10, 3, 8, 4, 2, 7, 5]
+/// range(1, 10) |> shuffle()
+/// // -> [1, 6, 9, 10, 3, 8, 4, 2, 7, 5]
 /// ```
 ///
 pub fn shuffle(list: List(a)) -> List(a) {

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -31,13 +31,13 @@ fn do_all(list: List(Option(a)), acc: List(a)) -> Option(List(a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > all([Some(1), Some(2)])
-/// Some([1, 2])
+/// all([Some(1), Some(2)])
+/// // -> Some([1, 2])
 /// ```
 ///
 /// ```gleam
-/// > all([Some(1), None])
-/// None
+/// all([Some(1), None])
+/// // -> None
 /// ```
 ///
 pub fn all(list: List(Option(a))) -> Option(List(a)) {
@@ -49,13 +49,13 @@ pub fn all(list: List(Option(a))) -> Option(List(a)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > is_some(Some(1))
-/// True
+/// is_some(Some(1))
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > is_some(None)
-/// False
+/// is_some(None)
+/// // -> False
 /// ```
 ///
 pub fn is_some(option: Option(a)) -> Bool {
@@ -67,13 +67,13 @@ pub fn is_some(option: Option(a)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > is_none(Some(1))
-/// False
+/// is_none(Some(1))
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > is_none(None)
-/// True
+/// is_none(None)
+/// // -> True
 /// ```
 ///
 pub fn is_none(option: Option(a)) -> Bool {
@@ -85,13 +85,13 @@ pub fn is_none(option: Option(a)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_result(Some(1), "some_error")
-/// Ok(1)
+/// to_result(Some(1), "some_error")
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > to_result(None, "some_error")
-/// Error("some_error")
+/// to_result(None, "some_error")
+/// // -> Error("some_error")
 /// ```
 ///
 pub fn to_result(option: Option(a), e) -> Result(a, e) {
@@ -106,13 +106,13 @@ pub fn to_result(option: Option(a), e) -> Result(a, e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > from_result(Ok(1))
-/// Some(1)
+/// from_result(Ok(1))
+/// // -> Some(1)
 /// ```
 ///
 /// ```gleam
-/// > from_result(Error("some_error"))
-/// None
+/// from_result(Error("some_error"))
+/// // -> None
 /// ```
 ///
 pub fn from_result(result: Result(a, e)) -> Option(a) {
@@ -127,13 +127,13 @@ pub fn from_result(result: Result(a, e)) -> Option(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > unwrap(Some(1), 0)
-/// 1
+/// unwrap(Some(1), 0)
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > unwrap(None, 0)
-/// 0
+/// unwrap(None, 0)
+/// // -> 0
 /// ```
 ///
 pub fn unwrap(option: Option(a), or default: a) -> a {
@@ -148,13 +148,13 @@ pub fn unwrap(option: Option(a), or default: a) -> a {
 /// ## Examples
 ///
 /// ```gleam
-/// > lazy_unwrap(Some(1), fn() { 0 })
-/// 1
+/// lazy_unwrap(Some(1), fn() { 0 })
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > lazy_unwrap(None, fn() { 0 })
-/// 0
+/// lazy_unwrap(None, fn() { 0 })
+/// // -> 0
 /// ```
 ///
 pub fn lazy_unwrap(option: Option(a), or default: fn() -> a) -> a {
@@ -173,13 +173,13 @@ pub fn lazy_unwrap(option: Option(a), or default: fn() -> a) -> a {
 /// ## Examples
 ///
 /// ```gleam
-/// > map(over: Some(1), with: fn(x) { x + 1 })
-/// Some(2)
+/// map(over: Some(1), with: fn(x) { x + 1 })
+/// // -> Some(2)
 /// ```
 ///
 /// ```gleam
-/// > map(over: None, with: fn(x) { x + 1 })
-/// None
+/// map(over: None, with: fn(x) { x + 1 })
+/// // -> None
 /// ```
 ///
 pub fn map(over option: Option(a), with fun: fn(a) -> b) -> Option(b) {
@@ -194,18 +194,18 @@ pub fn map(over option: Option(a), with fun: fn(a) -> b) -> Option(b) {
 /// ## Examples
 ///
 /// ```gleam
-/// > flatten(Some(Some(1)))
-/// Some(1)
+/// flatten(Some(Some(1)))
+/// // -> Some(1)
 /// ```
 ///
 /// ```gleam
-/// > flatten(Some(None))
-/// None
+/// flatten(Some(None))
+/// // -> None
 /// ```
 ///
 /// ```gleam
-/// > flatten(None)
-/// None
+/// flatten(None)
+/// // -> None
 /// ```
 ///
 pub fn flatten(option: Option(Option(a))) -> Option(a) {
@@ -228,23 +228,23 @@ pub fn flatten(option: Option(Option(a))) -> Option(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > then(Some(1), fn(x) { Some(x + 1) })
-/// Some(2)
+/// then(Some(1), fn(x) { Some(x + 1) })
+/// // -> Some(2)
 /// ```
 ///
 /// ```gleam
-/// > then(Some(1), fn(x) { Some(#("a", x)) })
-/// Some(#("a", 1))
+/// then(Some(1), fn(x) { Some(#("a", x)) })
+/// // -> Some(#("a", 1))
 /// ```
 ///
 /// ```gleam
-/// > then(Some(1), fn(_) { None })
-/// None
+/// then(Some(1), fn(_) { None })
+/// // -> None
 /// ```
 ///
 /// ```gleam
-/// > then(None, fn(x) { Some(x + 1) })
-/// None
+/// then(None, fn(x) { Some(x + 1) })
+/// // -> None
 /// ```
 ///
 pub fn then(option: Option(a), apply fun: fn(a) -> Option(b)) -> Option(b) {
@@ -259,23 +259,23 @@ pub fn then(option: Option(a), apply fun: fn(a) -> Option(b)) -> Option(b) {
 /// ## Examples
 ///
 /// ```gleam
-/// > or(Some(1), Some(2))
-/// Some(1)
+/// or(Some(1), Some(2))
+/// // -> Some(1)
 /// ```
 ///
 /// ```gleam
-/// > or(Some(1), None)
-/// Some(1)
+/// or(Some(1), None)
+/// // -> Some(1)
 /// ```
 ///
 /// ```gleam
-/// > or(None, Some(2))
-/// Some(2)
+/// or(None, Some(2))
+/// // -> Some(2)
 /// ```
 ///
 /// ```gleam
-/// > or(None, None)
-/// None
+/// or(None, None)
+/// // -> None
 /// ```
 ///
 pub fn or(first: Option(a), second: Option(a)) -> Option(a) {
@@ -290,23 +290,23 @@ pub fn or(first: Option(a), second: Option(a)) -> Option(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > lazy_or(Some(1), fn() { Some(2) })
-/// Some(1)
+/// lazy_or(Some(1), fn() { Some(2) })
+/// // -> Some(1)
 /// ```
 ///
 /// ```gleam
-/// > lazy_or(Some(1), fn() { None })
-/// Some(1)
+/// lazy_or(Some(1), fn() { None })
+/// // -> Some(1)
 /// ```
 ///
 /// ```gleam
-/// > lazy_or(None, fn() { Some(2) })
-/// Some(2)
+/// lazy_or(None, fn() { Some(2) })
+/// // -> Some(2)
 /// ```
 ///
 /// ```gleam
-/// > lazy_or(None, fn() { None })
-/// None
+/// lazy_or(None, fn() { None })
+/// // -> None
 /// ```
 ///
 pub fn lazy_or(first: Option(a), second: fn() -> Option(a)) -> Option(a) {
@@ -337,8 +337,8 @@ fn do_values(list: List(Option(a)), acc: List(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > values([Some(1), None, Some(3)])
-/// [1, 3]
+/// values([Some(1), None, Some(3)])
+/// // -> [1, 3]
 /// ```
 ///
 pub fn values(options: List(Option(a))) -> List(a) {

--- a/src/gleam/order.gleam
+++ b/src/gleam/order.gleam
@@ -18,18 +18,18 @@ pub type Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > negate(Lt)
-/// Gt
+/// negate(Lt)
+/// // -> Gt
 /// ```
 ///
 /// ```gleam
-/// > negate(Eq)
-/// Eq
+/// negate(Eq)
+/// // -> Eq
 /// ```
 ///
 /// ```gleam
-/// > negate(Lt)
-/// Gt
+/// negate(Lt)
+/// // -> Gt
 /// ```
 ///
 pub fn negate(order: Order) -> Order {
@@ -45,18 +45,18 @@ pub fn negate(order: Order) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > to_int(Lt)
-/// -1
+/// to_int(Lt)
+/// // -> -1
 /// ```
 ///
 /// ```gleam
-/// > to_int(Eq)
-/// 0
+/// to_int(Eq)
+/// // -> 0
 /// ```
 ///
 /// ```gleam
-/// > to_int(Gt)
-/// 1
+/// to_int(Gt)
+/// // -> 1
 /// ```
 ///
 pub fn to_int(order: Order) -> Int {
@@ -72,8 +72,8 @@ pub fn to_int(order: Order) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > compare(Eq, with: Lt)
-/// Gt
+/// compare(Eq, with: Lt)
+/// // -> Gt
 /// ```
 ///
 pub fn compare(a: Order, with b: Order) -> Order {
@@ -89,8 +89,8 @@ pub fn compare(a: Order, with b: Order) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > max(Eq, Lt)
-/// Eq
+/// max(Eq, Lt)
+/// // -> Eq
 /// ```
 ///
 pub fn max(a: Order, b: Order) -> Order {
@@ -106,8 +106,8 @@ pub fn max(a: Order, b: Order) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > min(Eq, Lt)
-/// Lt
+/// min(Eq, Lt)
+/// // -> Lt
 /// ```
 ///
 pub fn min(a: Order, b: Order) -> Order {
@@ -124,8 +124,10 @@ pub fn min(a: Order, b: Order) -> Order {
 /// ## Examples
 ///
 /// ```gleam
-/// > list.sort([1, 5, 4], by: reverse(int.compare))
-/// [5, 4, 1]
+/// import gleam/int
+/// import gleam/list
+/// list.sort([1, 5, 4], by: reverse(int.compare))
+/// // -> [5, 4, 1]
 /// ```
 ///
 pub fn reverse(orderer: fn(a, a) -> Order) -> fn(a, a) -> Order {

--- a/src/gleam/pair.gleam
+++ b/src/gleam/pair.gleam
@@ -3,8 +3,8 @@
 /// ## Examples
 ///
 /// ```gleam
-/// > first(#(1, 2))
-/// 1
+/// first(#(1, 2))
+/// // -> 1
 /// ```
 ///
 pub fn first(pair: #(a, b)) -> a {
@@ -17,8 +17,8 @@ pub fn first(pair: #(a, b)) -> a {
 /// ## Examples
 ///
 /// ```gleam
-/// > second(#(1, 2))
-/// 2
+/// second(#(1, 2))
+/// // -> 2
 /// ```
 ///
 pub fn second(pair: #(a, b)) -> b {
@@ -31,8 +31,8 @@ pub fn second(pair: #(a, b)) -> b {
 /// ## Examples
 ///
 /// ```gleam
-/// > swap(#(1, 2))
-/// #(2, 1)
+/// swap(#(1, 2))
+/// // -> #(2, 1)
 /// ```
 ///
 pub fn swap(pair: #(a, b)) -> #(b, a) {
@@ -46,8 +46,8 @@ pub fn swap(pair: #(a, b)) -> #(b, a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > #(1, 2) |> map_first(fn(n) { n * 2 })
-/// #(2, 2)
+/// #(1, 2) |> map_first(fn(n) { n * 2 })
+/// // -> #(2, 2)
 /// ```
 ///
 pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
@@ -61,8 +61,8 @@ pub fn map_first(of pair: #(a, b), with fun: fn(a) -> c) -> #(c, b) {
 /// ## Examples
 ///
 /// ```gleam
-/// > #(1, 2) |> map_second(fn(n) { n * 2 })
-/// #(1, 4)
+/// #(1, 2) |> map_second(fn(n) { n * 2 })
+/// // -> #(1, 4)
 /// ```
 ///
 pub fn map_second(of pair: #(a, b), with fun: fn(b) -> c) -> #(a, c) {
@@ -76,8 +76,8 @@ pub fn map_second(of pair: #(a, b), with fun: fn(b) -> c) -> #(a, c) {
 /// ## Examples
 /// 
 /// ```gleam
-/// > new(1, 2)
-/// #(1, 2)
+/// new(1, 2)
+/// // -> #(1, 2)
 /// ```
 /// 
 pub fn new(first: a, second: b) -> #(a, b) {

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -31,8 +31,8 @@ pub fn new() -> Queue(a) {
 /// # Examples
 ///
 /// ```gleam
-/// > [1, 2, 3] |> from_list |> length
-/// 3
+/// [1, 2, 3] |> from_list |> length
+/// // -> 3
 /// ```
 ///
 pub fn from_list(list: List(a)) -> Queue(a) {
@@ -47,8 +47,8 @@ pub fn from_list(list: List(a)) -> Queue(a) {
 /// # Examples
 ///
 /// ```gleam
-/// > new() |> push_back(1) |> push_back(2) |> to_list
-/// [1, 2]
+/// new() |> push_back(1) |> push_back(2) |> to_list
+/// // -> [1, 2]
 /// ```
 ///
 pub fn to_list(queue: Queue(a)) -> List(a) {
@@ -63,18 +63,18 @@ pub fn to_list(queue: Queue(a)) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [] |> from_list |> is_empty
-/// True
+/// [] |> from_list |> is_empty
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > [1] |> from_list |> is_empty
-/// False
+/// [1] |> from_list |> is_empty
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > [1, 2] |> from_list |> is_empty
-/// False
+/// [1, 2] |> from_list |> is_empty
+/// // -> False
 /// ```
 ///
 pub fn is_empty(queue: Queue(a)) -> Bool {
@@ -89,18 +89,18 @@ pub fn is_empty(queue: Queue(a)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > length(from_list([]))
-/// 0
+/// length(from_list([]))
+/// // -> 0
 /// ```
 ///
 /// ```gleam
-/// > length(from_list([1]))
-/// 1
+/// length(from_list([1]))
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > length(from_list([1, 2]))
-/// 2
+/// length(from_list([1, 2]))
+/// // -> 2
 /// ```
 ///
 pub fn length(queue: Queue(a)) -> Int {
@@ -112,8 +112,8 @@ pub fn length(queue: Queue(a)) -> Int {
 /// # Examples
 ///
 /// ```gleam
-/// > [1, 2] |> from_list |> push_back(3) |> to_list
-/// [1, 2, 3]
+/// [1, 2] |> from_list |> push_back(3) |> to_list
+/// // -> [1, 2, 3]
 /// ```
 ///
 pub fn push_back(onto queue: Queue(a), this item: a) -> Queue(a) {
@@ -125,8 +125,8 @@ pub fn push_back(onto queue: Queue(a), this item: a) -> Queue(a) {
 /// # Examples
 ///
 /// ```gleam
-/// > [0, 0] |> from_list |> push_front(1) |> to_list
-/// [1, 0, 0]
+/// [0, 0] |> from_list |> push_front(1) |> to_list
+/// // -> [1, 0, 0]
 /// ```
 ///
 pub fn push_front(onto queue: Queue(a), this item: a) -> Queue(a) {
@@ -142,24 +142,23 @@ pub fn push_front(onto queue: Queue(a), this item: a) -> Queue(a) {
 /// # Examples
 ///
 /// ```gleam
-/// > new()
-/// > |> push_back(0)
-/// > |> push_back(1)
-/// > |> pop_back()
-/// Ok(#(1, push_front(new(), 0)))
+/// new()
+/// |> push_back(0)
+/// |> push_back(1)
+/// |> pop_back
+/// // -> Ok(#(1, push_front(new(), 0)))
 /// ```
 ///
 /// ```gleam
-/// > new()
-/// > |> push_front(0)
-/// > |> pop_back()
-/// Ok(#(0, new()))
+/// new()
+/// |> push_front(0)
+/// |> pop_back
+/// // -> Ok(#(0, new()))
 /// ```
 ///
 /// ```gleam
-/// > new()
-/// > |> pop_back()
-/// Error(Nil)
+/// new() |> pop_back
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn pop_back(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
@@ -182,24 +181,23 @@ pub fn pop_back(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
 /// # Examples
 ///
 /// ```gleam
-/// > queue.new()
-/// > |> queue.push_front(1)
-/// > |> queue.push_front(0)
-/// > |> queue.pop_front()
-/// Ok(#(0, queue.push_back(queue.new(), 1)))
+/// new()
+/// |> push_front(1)
+/// |> push_front(0)
+/// |> pop_front
+/// // -> Ok(#(0, push_back(new(), 1)))
 /// ```
 ///
 /// ```gleam
-/// > queue.new()
-/// > |> queue.push_back(0)
-/// > |> queue.pop_front()
-/// Ok(#(0, queue.new()))
+/// new()
+/// |> push_back(0)
+/// |> pop_front
+/// // -> Ok(#(0, new()))
 /// ```
 ///
 /// ```gleam
-/// > queue.new()
-/// > |> queue.pop_back()
-/// Error(Nil)
+/// new() |> pop_back
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn pop_front(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
@@ -221,18 +219,18 @@ pub fn pop_front(from queue: Queue(a)) -> Result(#(a, Queue(a)), Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > [] |> from_list |> reverse |> to_list
-/// []
+/// [] |> from_list |> reverse |> to_list
+/// // -> []
 /// ```
 ///
 /// ```gleam
-/// > [1] |> from_list |> reverse |> to_list
-/// [1]
+/// [1] |> from_list |> reverse |> to_list
+/// // -> [1]
 /// ```
 ///
 /// ```gleam
-/// > [1, 2] |> from_list |> reverse |> to_list
-/// [2, 1]
+/// [1, 2] |> from_list |> reverse |> to_list
+/// // -> [2, 1]
 /// ```
 ///
 pub fn reverse(queue: Queue(a)) -> Queue(a) {

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -39,17 +39,17 @@ pub type Options {
 /// ## Examples
 ///
 /// ```gleam
-/// > let options = Options(case_insensitive: False, multi_line: True)
-/// > let assert Ok(re) = compile("^[0-9]", with: options)
-/// > check(re, "abc\n123")
-/// True
+/// let options = Options(case_insensitive: False, multi_line: True)
+/// let assert Ok(re) = compile("^[0-9]", with: options)
+/// check(re, "abc\n123")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > let options = Options(case_insensitive: True, multi_line: False)
-/// > let assert Ok(re) = compile("[A-Z]", with: options)
-/// > check(re, "abc123")
-/// True
+/// let options = Options(case_insensitive: True, multi_line: False)
+/// let assert Ok(re) = compile("[A-Z]", with: options)
+/// check(re, "abc123")
+/// // -> True
 /// ```
 ///
 pub fn compile(
@@ -68,24 +68,22 @@ fn do_compile(a: String, with with: Options) -> Result(Regex, CompileError)
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Ok(re) = from_string("[0-9]")
-/// > check(re, "abc123")
-/// True
+/// let assert Ok(re) = from_string("[0-9]")
+/// check(re, "abc123")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > check(re, "abcxyz")
-/// False
+/// check(re, "abcxyz")
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > from_string("[0-9")
-/// Error(
-///   CompileError(
-///     error: "missing terminating ] for character class",
-///     byte_index: 4
-///   )
-/// )
+/// from_string("[0-9")
+/// // -> Error(CompileError(
+/// //   error: "missing terminating ] for character class",
+/// //   byte_index: 4
+/// // ))
 /// ```
 ///
 pub fn from_string(pattern: String) -> Result(Regex, CompileError) {
@@ -97,14 +95,14 @@ pub fn from_string(pattern: String) -> Result(Regex, CompileError) {
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Ok(re) = from_string("^f.o.?")
-/// > check(with: re, content: "foo")
-/// True
+/// let assert Ok(re) = from_string("^f.o.?")
+/// check(with: re, content: "foo")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > check(with: re, content: "boo")
-/// False
+/// check(with: re, content: "boo")
+/// // -> False
 /// ```
 ///
 pub fn check(with regex: Regex, content content: String) -> Bool {
@@ -120,9 +118,9 @@ fn do_check(a: Regex, b: String) -> Bool
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Ok(re) = from_string(" *, *")
-/// > split(with: re, content: "foo,32, 4, 9  ,0")
-/// ["foo", "32", "4", "9", "0"]
+/// let assert Ok(re) = from_string(" *, *")
+/// split(with: re, content: "foo,32, 4, 9  ,0")
+/// // -> ["foo", "32", "4", "9", "0"]
 /// ```
 ///
 pub fn split(with regex: Regex, content string: String) -> List(String) {
@@ -147,62 +145,51 @@ fn js_split(a: String, b: Regex) -> List(String)
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Ok(re) = from_string("[oi]n a (\\w+)")
-/// > scan(with: re, content: "I am on a boat in a lake.")
-/// [
-///   Match(
-///     content: "on a boat",
-///     submatches: [Some("boat")]
-///   ),
-///   Match(
-///     content: "in a lake",
-///     submatches: [Some("lake")]
-///   )
-/// ]
+/// let assert Ok(re) = from_string("[oi]n a (\\w+)")
+/// scan(with: re, content: "I am on a boat in a lake.")
+/// // -> [
+/// //   Match(content: "on a boat", submatches: [Some("boat")]),
+/// //   Match(content: "in a lake", submatches: [Some("lake")]),
+/// // ]
 /// ```
 ///
 /// ```gleam
-/// > let assert Ok(re) = regex.from_string("([+|\\-])?(\\d+)(\\w+)?")
-/// > scan(with: re, content: "-36")
-/// [
-///   Match(
-///     content: "-36",
-///     submatches: [Some("-"), Some("36")]
-///   )
-/// ]
+/// let assert Ok(re) = regex.from_string("([+|\\-])?(\\d+)(\\w+)?")
+/// scan(with: re, content: "-36")
+/// // -> [
+/// //   Match(content: "-36", submatches: [Some("-"), Some("36")])
+/// // ]
 ///
-/// > scan(with: re, content: "36")
-/// [
-///   Match(
-///     content: "36",
-///     submatches: [None, Some("36")]
-///   )
-/// ]
+/// scan(with: re, content: "36")
+/// // -> [
+/// //   Match(content: "36", submatches: [None, Some("36")])
+/// // ]
 /// ```
 ///
 /// ```gleam
-/// > let assert Ok(re) = regex.from_string("var\\s*(\\w+)\\s*(int|string)?\\s*=\\s*(.*)")
-/// > scan(with: re, content: "var age = 32")
-/// [
-///   Match(
-///     content: "var age = 32",
-///     submatches: [Some("age"), None, Some("32")]
-///   )
-/// ]
+/// let assert Ok(re) =
+///   regex.from_string("var\\s*(\\w+)\\s*(int|string)?\\s*=\\s*(.*)")
+/// scan(with: re, content: "var age = 32")
+/// // -> [
+/// //   Match(
+/// //     content: "var age = 32",
+/// //     submatches: [Some("age"), None, Some("32")],
+/// //   ),
+/// // ]
 /// ```
 ///
 /// ```gleam
-/// > let assert Ok(re) = regex.from_string("let (\\w+) = (\\w+)")
-/// > scan(with: re, content: "let age = 32")
-/// [
-///   Match(
-///     content: "let age = 32",
-///     submatches: [Some("age"), Some("32")]
-///   )
-/// ]
+/// let assert Ok(re) = regex.from_string("let (\\w+) = (\\w+)")
+/// scan(with: re, content: "let age = 32")
+/// // -> [
+/// //   Match(
+/// //     content: "let age = 32",
+/// //     submatches: [Some("age"), Some("32")],
+/// //   ),
+/// // ]
 ///
-/// > scan(with: re, content: "const age = 32")
-/// []
+/// scan(with: re, content: "const age = 32")
+/// // -> []
 /// ```
 ///
 pub fn scan(with regex: Regex, content string: String) -> List(Match) {

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -8,13 +8,13 @@ import gleam/list
 /// ## Examples
 ///
 /// ```gleam
-/// > is_ok(Ok(1))
-/// True
+/// is_ok(Ok(1))
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > is_ok(Error(Nil))
-/// False
+/// is_ok(Error(Nil))
+/// // -> False
 /// ```
 ///
 pub fn is_ok(result: Result(a, e)) -> Bool {
@@ -29,13 +29,13 @@ pub fn is_ok(result: Result(a, e)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > is_error(Ok(1))
-/// False
+/// is_error(Ok(1))
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > is_error(Error(Nil))
-/// True
+/// is_error(Error(Nil))
+/// // -> True
 /// ```
 ///
 pub fn is_error(result: Result(a, e)) -> Bool {
@@ -54,13 +54,13 @@ pub fn is_error(result: Result(a, e)) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > map(over: Ok(1), with: fn(x) { x + 1 })
-/// Ok(2)
+/// map(over: Ok(1), with: fn(x) { x + 1 })
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > map(over: Error(1), with: fn(x) { x + 1 })
-/// Error(1)
+/// map(over: Error(1), with: fn(x) { x + 1 })
+/// // -> Error(1)
 /// ```
 ///
 pub fn map(over result: Result(a, e), with fun: fn(a) -> b) -> Result(b, e) {
@@ -79,13 +79,13 @@ pub fn map(over result: Result(a, e), with fun: fn(a) -> b) -> Result(b, e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > map_error(over: Error(1), with: fn(x) { x + 1 })
-/// Error(2)
+/// map_error(over: Error(1), with: fn(x) { x + 1 })
+/// // -> Error(2)
 /// ```
 ///
 /// ```gleam
-/// > map_error(over: Ok(1), with: fn(x) { x + 1 })
-/// Ok(1)
+/// map_error(over: Ok(1), with: fn(x) { x + 1 })
+/// // -> Ok(1)
 /// ```
 ///
 pub fn map_error(
@@ -103,18 +103,18 @@ pub fn map_error(
 /// ## Examples
 ///
 /// ```gleam
-/// > flatten(Ok(Ok(1)))
-/// Ok(1)
+/// flatten(Ok(Ok(1)))
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > flatten(Ok(Error("")))
-/// Error("")
+/// flatten(Ok(Error("")))
+/// // -> Error("")
 /// ```
 ///
 /// ```gleam
-/// > flatten(Error(Nil))
-/// Error(Nil)
+/// flatten(Error(Nil))
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn flatten(result: Result(Result(a, e), e)) -> Result(a, e) {
@@ -136,23 +136,23 @@ pub fn flatten(result: Result(Result(a, e), e)) -> Result(a, e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > try(Ok(1), fn(x) { Ok(x + 1) })
-/// Ok(2)
+/// try(Ok(1), fn(x) { Ok(x + 1) })
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > try(Ok(1), fn(x) { Ok(#("a", x)) })
-/// Ok(#("a", 1))
+/// try(Ok(1), fn(x) { Ok(#("a", x)) })
+/// // -> Ok(#("a", 1))
 /// ```
 ///
 /// ```gleam
-/// > try(Ok(1), fn(_) { Error("Oh no") })
-/// Error("Oh no")
+/// try(Ok(1), fn(_) { Error("Oh no") })
+/// // -> Error("Oh no")
 /// ```
 ///
 /// ```gleam
-/// > try(Error(Nil), fn(x) { Ok(x + 1) })
-/// Error(Nil)
+/// try(Error(Nil), fn(x) { Ok(x + 1) })
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn try(
@@ -180,13 +180,13 @@ pub fn then(
 /// ## Examples
 ///
 /// ```gleam
-/// > unwrap(Ok(1), 0)
-/// 1
+/// unwrap(Ok(1), 0)
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > unwrap(Error(""), 0)
-/// 0
+/// unwrap(Error(""), 0)
+/// // -> 0
 /// ```
 ///
 pub fn unwrap(result: Result(a, e), or default: a) -> a {
@@ -202,13 +202,13 @@ pub fn unwrap(result: Result(a, e), or default: a) -> a {
 /// ## Examples
 ///
 /// ```gleam
-/// > lazy_unwrap(Ok(1), fn() { 0 })
-/// 1
+/// lazy_unwrap(Ok(1), fn() { 0 })
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > lazy_unwrap(Error(""), fn() { 0 })
-/// 0
+/// lazy_unwrap(Error(""), fn() { 0 })
+/// // -> 0
 /// ```
 ///
 pub fn lazy_unwrap(result: Result(a, e), or default: fn() -> a) -> a {
@@ -224,13 +224,13 @@ pub fn lazy_unwrap(result: Result(a, e), or default: fn() -> a) -> a {
 /// ## Examples
 ///
 /// ```gleam
-/// > unwrap_error(Error(1), 0)
-/// 1
+/// unwrap_error(Error(1), 0)
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > unwrap_error(Ok(""), 0)
-/// 0
+/// unwrap_error(Ok(""), 0)
+/// // -> 0
 /// ```
 ///
 pub fn unwrap_error(result: Result(a, e), or default: e) -> e {
@@ -246,13 +246,13 @@ pub fn unwrap_error(result: Result(a, e), or default: e) -> e {
 /// ## Examples
 ///
 /// ```gleam
-/// > unwrap_both(Error(1))
-/// 1
+/// unwrap_both(Error(1))
+/// // -> 1
 /// ```
 ///
 /// ```gleam
-/// > unwrap_both(Ok(2))
-/// 2
+/// unwrap_both(Ok(2))
+/// // -> 2
 /// ```
 ///
 pub fn unwrap_both(result: Result(a, a)) -> a {
@@ -267,13 +267,13 @@ pub fn unwrap_both(result: Result(a, a)) -> a {
 /// ## Examples
 ///
 /// ```gleam
-/// > nil_error(Error(1))
-/// Error(Nil)
+/// nil_error(Error(1))
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > nil_error(Ok(1))
-/// Ok(1)
+/// nil_error(Ok(1))
+/// // -> Ok(1)
 /// ```
 ///
 pub fn nil_error(result: Result(a, e)) -> Result(a, Nil) {
@@ -285,23 +285,23 @@ pub fn nil_error(result: Result(a, e)) -> Result(a, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > or(Ok(1), Ok(2))
-/// Ok(1)
+/// or(Ok(1), Ok(2))
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > or(Ok(1), Error("Error 2"))
-/// Ok(1)
+/// or(Ok(1), Error("Error 2"))
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > or(Error("Error 1"), Ok(2))
-/// Ok(2)
+/// or(Error("Error 1"), Ok(2))
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > or(Error("Error 1"), Error("Error 2"))
-/// Error("Error 2")
+/// or(Error("Error 1"), Error("Error 2"))
+/// // -> Error("Error 2")
 /// ```
 ///
 pub fn or(first: Result(a, e), second: Result(a, e)) -> Result(a, e) {
@@ -316,23 +316,23 @@ pub fn or(first: Result(a, e), second: Result(a, e)) -> Result(a, e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > lazy_or(Ok(1), fn() { Ok(2) })
-/// Ok(1)
+/// lazy_or(Ok(1), fn() { Ok(2) })
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > lazy_or(Ok(1), fn() { Error("Error 2") })
-/// Ok(1)
+/// lazy_or(Ok(1), fn() { Error("Error 2") })
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > lazy_or(Error("Error 1"), fn() { Ok(2) })
-/// Ok(2)
+/// lazy_or(Error("Error 1"), fn() { Ok(2) })
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > lazy_or(Error("Error 1"), fn() { Error("Error 2") })
-/// Error("Error 2")
+/// lazy_or(Error("Error 1"), fn() { Error("Error 2") })
+/// // -> Error("Error 2")
 /// ```
 ///
 pub fn lazy_or(
@@ -352,13 +352,13 @@ pub fn lazy_or(
 /// ## Examples
 ///
 /// ```gleam
-/// > all([Ok(1), Ok(2)])
-/// Ok([1, 2])
+/// all([Ok(1), Ok(2)])
+/// // -> Ok([1, 2])
 /// ```
 ///
 /// ```gleam
-/// > all([Ok(1), Error("e")])
-/// Error("e")
+/// all([Ok(1), Error("e")])
+/// // -> Error("e")
 /// ```
 ///
 pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
@@ -373,8 +373,8 @@ pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > partition([Ok(1), Error("a"), Error("b"), Ok(2)])
-/// #([2, 1], ["b", "a"])
+/// partition([Ok(1), Error("a"), Error("b"), Ok(2)])
+/// // -> #([2, 1], ["b", "a"])
 /// ```
 ///
 pub fn partition(results: List(Result(a, e))) -> #(List(a), List(e)) {
@@ -394,13 +394,13 @@ fn do_partition(results: List(Result(a, e)), oks: List(a), errors: List(e)) {
 /// ## Examples
 ///
 /// ```gleam
-/// > replace(Ok(1), Nil)
-/// Ok(Nil)
+/// replace(Ok(1), Nil)
+/// // -> Ok(Nil)
 /// ```
 ///
 /// ```gleam
-/// > replace(Error(1), Nil)
-/// Error(1)
+/// replace(Error(1), Nil)
+/// // -> Error(1)
 /// ```
 ///
 pub fn replace(result: Result(a, e), value: b) -> Result(b, e) {
@@ -415,13 +415,13 @@ pub fn replace(result: Result(a, e), value: b) -> Result(b, e) {
 /// ## Examples
 ///
 /// ```gleam
-/// > replace_error(Error(1), Nil)
-/// Error(Nil)
+/// replace_error(Error(1), Nil)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > replace_error(Ok(1), Nil)
-/// Ok(1)
+/// replace_error(Ok(1), Nil)
+/// // -> Ok(1)
 /// ```
 ///
 pub fn replace_error(result: Result(a, e1), error: e2) -> Result(a, e2) {
@@ -436,8 +436,8 @@ pub fn replace_error(result: Result(a, e1), error: e2) -> Result(a, e2) {
 /// ## Examples
 ///
 /// ```gleam
-/// > values([Ok(1), Error("a"), Ok(3)])
-/// [1, 3]
+/// values([Ok(1), Error("a"), Ok(3)])
+/// // -> [1, 3]
 /// ```
 ///
 pub fn values(results: List(Result(a, e))) -> List(a) {
@@ -457,18 +457,18 @@ pub fn values(results: List(Result(a, e))) -> List(a) {
 /// ## Examples
 ///
 /// ```gleam
-/// > Ok(1) |> try_recover(with: fn(_) { Error("failed to recover") })
-/// Ok(1)
+/// Ok(1) |> try_recover(with: fn(_) { Error("failed to recover") })
+/// // -> Ok(1)
 /// ```
 ///
 /// ```gleam
-/// > Error(1) |> try_recover(with: fn(error) { Ok(error + 1) })
-/// Ok(2)
+/// Error(1) |> try_recover(with: fn(error) { Ok(error + 1) })
+/// // -> Ok(2)
 /// ```
 ///
 /// ```gleam
-/// > Error(1) |> try_recover(with: fn(error) { Error("failed to recover") })
-/// Error("failed to recover")
+/// Error(1) |> try_recover(with: fn(error) { Error("failed to recover") })
+/// // -> Error("failed to recover")
 /// ```
 ///
 pub fn try_recover(

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -40,11 +40,11 @@ pub fn new() -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > new()
-/// > |> insert(1)
-/// > |> insert(2)
-/// > |> size
-/// 2
+/// new()
+/// |> insert(1)
+/// |> insert(2)
+/// |> size
+/// // -> 2
 /// ```
 ///
 pub fn size(set: Set(member)) -> Int {
@@ -58,11 +58,11 @@ pub fn size(set: Set(member)) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > new()
-/// > |> insert(1)
-/// > |> insert(2)
-/// > |> size
-/// 2
+/// new()
+/// |> insert(1)
+/// |> insert(2)
+/// |> size
+/// // -> 2
 /// ```
 ///
 pub fn insert(into set: Set(member), this member: member) -> Set(member) {
@@ -76,17 +76,17 @@ pub fn insert(into set: Set(member), this member: member) -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > new()
-/// > |> insert(2)
-/// > |> contains(2)
-/// True
+/// new()
+/// |> insert(2)
+/// |> contains(2)
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > new()
-/// > |> insert(2)
-/// > |> contains(1)
-/// False
+/// new()
+/// |> insert(2)
+/// |> contains(1)
+/// // -> False
 /// ```
 ///
 pub fn contains(in set: Set(member), this member: member) -> Bool {
@@ -103,11 +103,11 @@ pub fn contains(in set: Set(member), this member: member) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > new()
-/// > |> insert(2)
-/// > |> delete(2)
-/// > |> contains(1)
-/// False
+/// new()
+/// |> insert(2)
+/// |> delete(2)
+/// |> contains(1)
+/// // -> False
 /// ```
 ///
 pub fn delete(from set: Set(member), this member: member) -> Set(member) {
@@ -124,8 +124,8 @@ pub fn delete(from set: Set(member), this member: member) -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > new() |> insert(2) |> to_list
-/// [2]
+/// new() |> insert(2) |> to_list
+/// // -> [2]
 /// ```
 ///
 pub fn to_list(set: Set(member)) -> List(member) {
@@ -139,9 +139,9 @@ pub fn to_list(set: Set(member)) -> List(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/list
-/// > [1, 1, 2, 4, 3, 2] |> from_list |> to_list |> list.sort
-/// [1, 3, 3, 4]
+/// import gleam/list
+/// [1, 1, 2, 4, 3, 2] |> from_list |> to_list |> list.sort
+/// // -> [1, 3, 3, 4]
 /// ```
 ///
 pub fn from_list(members: List(member)) -> Set(member) {
@@ -162,9 +162,9 @@ pub fn from_list(members: List(member)) -> Set(member) {
 /// # Examples
 ///
 /// ```gleam
-/// > from_list([1, 3, 9])
-/// > |> fold(0, fn(accumulator, member) { accumulator + member })
-/// 13
+/// from_list([1, 3, 9])
+/// |> fold(0, fn(accumulator, member) { accumulator + member })
+/// // -> 13
 /// ```
 ///
 pub fn fold(
@@ -183,11 +183,11 @@ pub fn fold(
 /// ## Examples
 ///
 /// ```gleam
-/// > import gleam/int
-/// > from_list([1, 4, 6, 3, 675, 44, 67])
-/// > |> filter(for: int.is_even)
-/// > |> to_list
-/// [4, 6, 44]
+/// import gleam/int
+/// from_list([1, 4, 6, 3, 675, 44, 67])
+/// |> filter(for: int.is_even)
+/// |> to_list
+/// // -> [4, 6, 44]
 /// ```
 ///
 pub fn filter(
@@ -209,10 +209,10 @@ pub fn drop(from set: Set(member), drop disallowed: List(member)) -> Set(member)
 /// ## Examples
 ///
 /// ```gleam
-/// > from_list([1, 2, 3])
-/// > |> take([1, 3, 5])
-/// > |> to_list
-/// [1, 3]
+/// from_list([1, 2, 3])
+/// |> take([1, 3, 5])
+/// |> to_list
+/// // -> [1, 3]
 /// ```
 ///
 pub fn take(from set: Set(member), keeping desired: List(member)) -> Set(member) {
@@ -233,8 +233,8 @@ fn order(first: Set(member), second: Set(member)) -> #(Set(member), Set(member))
 /// ## Examples
 ///
 /// ```gleam
-/// > union(from_list([1, 2]), from_list([2, 3])) |> to_list
-/// [1, 2, 3]
+/// union(from_list([1, 2]), from_list([2, 3])) |> to_list
+/// // -> [1, 2, 3]
 /// ```
 ///
 pub fn union(of first: Set(member), and second: Set(member)) -> Set(member) {
@@ -249,8 +249,8 @@ pub fn union(of first: Set(member), and second: Set(member)) -> Set(member) {
 /// ## Examples
 ///
 /// ```gleam
-/// > intersection(from_list([1, 2]), from_list([2, 3])) |> to_list
-/// [2]
+/// intersection(from_list([1, 2]), from_list([2, 3])) |> to_list
+/// // -> [2]
 /// ```
 ///
 pub fn intersection(

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -12,13 +12,13 @@ import gleam/string_builder.{type StringBuilder}
 /// ## Examples
 ///
 /// ```gleam
-/// > is_empty("")
-/// True
+/// is_empty("")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > is_empty("the world")
-/// False
+/// is_empty("the world")
+/// // -> False
 /// ```
 ///
 pub fn is_empty(str: String) -> Bool {
@@ -33,18 +33,18 @@ pub fn is_empty(str: String) -> Bool {
 /// ## Examples
 ///
 /// ```gleam
-/// > length("Gleam")
-/// 5
+/// length("Gleam")
+/// // -> 5
 /// ```
 ///
 /// ```gleam
-/// > length("ß↑e̊")
-/// 3
+/// length("ß↑e̊")
+/// // -> 3
 /// ```
 ///
 /// ```gleam
-/// > length("")
-/// 0
+/// length("")
+/// // -> 0
 /// ```
 ///
 pub fn length(string: String) -> Int {
@@ -63,8 +63,8 @@ fn do_length(a: String) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// > reverse("stressed")
-/// "desserts"
+/// reverse("stressed")
+/// // -> "desserts"
 /// ```
 ///
 pub fn reverse(string: String) -> String {
@@ -92,13 +92,13 @@ fn do_reverse(string: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > replace("www.example.com", each: ".", with: "-")
-/// "www-example-com"
+/// replace("www.example.com", each: ".", with: "-")
+/// // -> "www-example-com"
 /// ```
 ///
 /// ```gleam
-/// > replace("a,b,c,d,e", each: ",", with: "/")
-/// "a/b/c/d/e"
+/// replace("a,b,c,d,e", each: ",", with: "/")
+/// // -> "a/b/c/d/e"
 /// ```
 ///
 pub fn replace(
@@ -120,8 +120,8 @@ pub fn replace(
 /// ## Examples
 ///
 /// ```gleam
-/// > lowercase("X-FILES")
-/// "x-files"
+/// lowercase("X-FILES")
+/// // -> "x-files"
 /// ```
 ///
 pub fn lowercase(string: String) -> String {
@@ -140,8 +140,8 @@ fn do_lowercase(a: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > uppercase("skinner")
-/// "SKINNER"
+/// uppercase("skinner")
+/// // -> "SKINNER"
 /// ```
 ///
 pub fn uppercase(string: String) -> String {
@@ -159,13 +159,13 @@ fn do_uppercase(a: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > compare("Anthony", "Anthony")
-/// order.Eq
+/// compare("Anthony", "Anthony")
+/// // -> order.Eq
 /// ```
 ///
 /// ```gleam
-/// > compare("A", "B")
-/// order.Lt
+/// compare("A", "B")
+/// // -> order.Lt
 /// ```
 ///
 pub fn compare(a: String, b: String) -> order.Order {
@@ -189,28 +189,28 @@ fn less_than(a: String, b: String) -> Bool
 /// ## Examples
 ///
 /// ```gleam
-/// > slice(from: "gleam", at_index: 1, length: 2)
-/// "le"
+/// slice(from: "gleam", at_index: 1, length: 2)
+/// // -> "le"
 /// ```
 ///
 /// ```gleam
-/// > slice(from: "gleam", at_index: 1, length: 10)
-/// "leam"
+/// slice(from: "gleam", at_index: 1, length: 10)
+/// // -> "leam"
 /// ```
 ///
 /// ```gleam
-/// > slice(from: "gleam", at_index: 10, length: 3)
-/// ""
+/// slice(from: "gleam", at_index: 10, length: 3)
+/// // -> ""
 /// ```
 ///
 /// ```gleam
-/// > slice(from: "gleam", at_index: -2, length: 2)
-/// "am"
+/// slice(from: "gleam", at_index: -2, length: 2)
+/// // -> "am"
 /// ```
 ///
 /// ```gleam
-/// > slice(from: "gleam", at_index: -12, length: 2)
-/// ""
+/// slice(from: "gleam", at_index: -12, length: 2)
+/// // -> ""
 /// ```
 ///
 pub fn slice(from string: String, at_index idx: Int, length len: Int) -> String {
@@ -245,8 +245,8 @@ fn do_slice(string: String, idx: Int, len: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > crop(from: "The Lone Gunmen", before: "Lone")
-/// "Lone Gunmen"
+/// crop(from: "The Lone Gunmen", before: "Lone")
+/// // -> "Lone Gunmen"
 /// ```
 ///
 @external(erlang, "gleam_stdlib", "crop_string")
@@ -258,8 +258,8 @@ pub fn crop(from string: String, before substring: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > drop_left(from: "The Lone Gunmen", up_to: 2)
-/// "e Lone Gunmen"
+/// drop_left(from: "The Lone Gunmen", up_to: 2)
+/// // -> "e Lone Gunmen"
 /// ```
 ///
 pub fn drop_left(from string: String, up_to num_graphemes: Int) -> String {
@@ -274,8 +274,8 @@ pub fn drop_left(from string: String, up_to num_graphemes: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > drop_right(from: "Cigarette Smoking Man", up_to: 2)
-/// "Cigarette Smoking M"
+/// drop_right(from: "Cigarette Smoking Man", up_to: 2)
+/// // -> "Cigarette Smoking M"
 /// ```
 ///
 pub fn drop_right(from string: String, up_to num_graphemes: Int) -> String {
@@ -290,18 +290,18 @@ pub fn drop_right(from string: String, up_to num_graphemes: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > contains(does: "theory", contain: "ory")
-/// True
+/// contains(does: "theory", contain: "ory")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > contains(does: "theory", contain: "the")
-/// True
+/// contains(does: "theory", contain: "the")
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > contains(does: "theory", contain: "THE")
-/// False
+/// contains(does: "theory", contain: "THE")
+/// // -> False
 /// ```
 ///
 @external(erlang, "gleam_stdlib", "contains_string")
@@ -313,8 +313,8 @@ pub fn contains(does haystack: String, contain needle: String) -> Bool
 /// ## Examples
 ///
 /// ```gleam
-/// > starts_with("theory", "ory")
-/// False
+/// starts_with("theory", "ory")
+/// // -> False
 /// ```
 ///
 pub fn starts_with(string: String, prefix: String) -> Bool {
@@ -330,8 +330,8 @@ fn do_starts_with(a: String, b: String) -> Bool
 /// ## Examples
 ///
 /// ```gleam
-/// > ends_with("theory", "ory")
-/// True
+/// ends_with("theory", "ory")
+/// // -> True
 /// ```
 ///
 pub fn ends_with(string: String, suffix: String) -> Bool {
@@ -347,8 +347,8 @@ fn do_ends_with(a: String, b: String) -> Bool
 /// ## Examples
 ///
 /// ```gleam
-/// > split("home/gleam/desktop/", on: "/")
-/// ["home", "gleam", "desktop", ""]
+/// split("home/gleam/desktop/", on: "/")
+/// // -> ["home", "gleam", "desktop", ""]
 /// ```
 ///
 pub fn split(x: String, on substring: String) -> List(String) {
@@ -369,13 +369,13 @@ pub fn split(x: String, on substring: String) -> List(String) {
 /// ## Examples
 ///
 /// ```gleam
-/// > split_once("home/gleam/desktop/", on: "/")
-/// Ok(#("home", "gleam/desktop/"))
+/// split_once("home/gleam/desktop/", on: "/")
+/// // -> Ok(#("home", "gleam/desktop/"))
 /// ```
 ///
 /// ```gleam
-/// > split_once("home/gleam/desktop/", on: "?")
-/// Error(Nil)
+/// split_once("home/gleam/desktop/", on: "?")
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn split_once(
@@ -413,8 +413,8 @@ fn do_split_once(
 /// ## Examples
 ///
 /// ```gleam
-/// > append(to: "butter", suffix: "fly")
-/// "butterfly"
+/// append(to: "butter", suffix: "fly")
+/// // -> "butterfly"
 /// ```
 ///
 pub fn append(to first: String, suffix second: String) -> String {
@@ -433,8 +433,8 @@ pub fn append(to first: String, suffix second: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > concat(["never", "the", "less"])
-/// "nevertheless"
+/// concat(["never", "the", "less"])
+/// // -> "nevertheless"
 /// ```
 ///
 pub fn concat(strings: List(String)) -> String {
@@ -450,8 +450,8 @@ pub fn concat(strings: List(String)) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > repeat("ha", times: 3)
-/// "hahaha"
+/// repeat("ha", times: 3)
+/// // -> "hahaha"
 /// ```
 ///
 pub fn repeat(string: String, times times: Int) -> String {
@@ -468,8 +468,8 @@ pub fn repeat(string: String, times times: Int) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > join(["home","evan","Desktop"], with: "/")
-/// "home/evan/Desktop"
+/// join(["home","evan","Desktop"], with: "/")
+/// // -> "home/evan/Desktop"
 /// ```
 ///
 pub fn join(strings: List(String), with separator: String) -> String {
@@ -488,18 +488,18 @@ fn do_join(strings: List(String), separator: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > pad_left("121", to: 5, with: ".")
-/// "..121"
+/// pad_left("121", to: 5, with: ".")
+/// // -> "..121"
 /// ```
 ///
 /// ```gleam
-/// > pad_left("121", to: 3, with: ".")
-/// "121"
+/// pad_left("121", to: 3, with: ".")
+/// // -> "121"
 /// ```
 ///
 /// ```gleam
-/// > pad_left("121", to: 2, with: ".")
-/// "121"
+/// pad_left("121", to: 2, with: ".")
+/// // -> "121"
 /// ```
 ///
 pub fn pad_left(string: String, to desired_length: Int, with pad_string: String) {
@@ -516,18 +516,18 @@ pub fn pad_left(string: String, to desired_length: Int, with pad_string: String)
 /// ## Examples
 ///
 /// ```gleam
-/// > pad_right("123", to: 5, with: ".")
-/// "123.."
+/// pad_right("123", to: 5, with: ".")
+/// // -> "123.."
 /// ```
 ///
 /// ```gleam
-/// > pad_right("123", to: 3, with: ".")
-/// "123"
+/// pad_right("123", to: 3, with: ".")
+/// // -> "123"
 /// ```
 ///
 /// ```gleam
-/// > pad_right("123", to: 2, with: ".")
-/// "123"
+/// pad_right("123", to: 2, with: ".")
+/// // -> "123"
 /// ```
 ///
 pub fn pad_right(
@@ -557,8 +557,8 @@ fn padding(size: Int, pad_string: String) -> Iterator(String) {
 /// ## Examples
 ///
 /// ```gleam
-/// > trim("  hats  \n")
-/// "hats"
+/// trim("  hats  \n")
+/// // -> "hats"
 /// ```
 ///
 pub fn trim(string: String) -> String {
@@ -590,8 +590,8 @@ fn do_trim(string string: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > trim_left("  hats  \n")
-/// "hats  \n"
+/// trim_left("  hats  \n")
+/// // -> "hats  \n"
 /// ```
 ///
 pub fn trim_left(string: String) -> String {
@@ -612,8 +612,8 @@ fn do_trim_left(string string: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > trim_right("  hats  \n")
-/// "  hats"
+/// trim_right("  hats  \n")
+/// // -> "  hats"
 /// ```
 ///
 pub fn trim_right(string: String) -> String {
@@ -639,13 +639,13 @@ fn do_trim_right(string string: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > pop_grapheme("gleam")
-/// Ok(#("g", "leam"))
+/// pop_grapheme("gleam")
+/// // -> Ok(#("g", "leam"))
 /// ```
 ///
 /// ```gleam
-/// > pop_grapheme("")
-/// Error(Nil)
+/// pop_grapheme("")
+/// // -> Error(Nil)
 /// ```
 ///
 pub fn pop_grapheme(string: String) -> Result(#(String, String), Nil) {
@@ -660,8 +660,8 @@ fn do_pop_grapheme(string string: String) -> Result(#(String, String), Nil)
 /// [graphemes](https://en.wikipedia.org/wiki/Grapheme).
 ///
 /// ```gleam
-/// > to_graphemes("abc")
-/// ["a", "b", "c"]
+/// to_graphemes("abc")
+/// // -> ["a", "b", "c"]
 /// ```
 ///
 @external(javascript, "../gleam_stdlib.mjs", "graphemes")
@@ -690,16 +690,21 @@ fn unsafe_int_to_utf_codepoint(a: Int) -> UtfCodepoint
 /// ## Examples
 ///
 /// ```gleam
-/// > "a" |> to_utf_codepoints
-/// [UtfCodepoint(97)]
+/// "a" |> to_utf_codepoints
+/// // -> [UtfCodepoint(97)]
 /// ```
 ///
 /// ```gleam
 /// // Semantically the same as:
 /// // ["🏳", "️", "‍", "🌈"] or:
 /// // [waving_white_flag, variant_selector_16, zero_width_joiner, rainbow]
-/// > "🏳️‍🌈" |> to_utf_codepoints
-/// [UtfCodepoint(127987), UtfCodepoint(65039), UtfCodepoint(8205), UtfCodepoint(127752)]
+/// "🏳️‍🌈" |> to_utf_codepoints
+/// // -> [
+/// //   UtfCodepoint(127987),
+/// //   UtfCodepoint(65039),
+/// //   UtfCodepoint(8205),
+/// //   UtfCodepoint(127752),
+/// // ]
 /// ```
 ///
 pub fn to_utf_codepoints(string: String) -> List(UtfCodepoint) {
@@ -744,16 +749,11 @@ fn string_to_codepoint_integer_list(a: String) -> List(Int)
 /// ## Examples
 ///
 /// ```gleam
-/// > {
-/// >   let assert #(Ok(a), Ok(b), Ok(c)) = #(
-/// >     utf_codepoint(97),
-/// >     utf_codepoint(98),
-/// >     utf_codepoint(99),
-/// >   )
-/// >   [a, b, c]
-/// > }
-/// > |> from_utf_codepoints
-/// "abc"
+/// let assert Ok(a) = utf_codepoint(97)
+/// let assert Ok(b) = utf_codepoint(98)
+/// let assert Ok(c) = utf_codepoint(99)
+/// from_utf_codepoints([a, b, c])
+/// // -> "abc"
 /// ```
 ///
 @external(erlang, "gleam_stdlib", "utf_codepoint_list_to_string")
@@ -778,9 +778,9 @@ pub fn utf_codepoint(value: Int) -> Result(UtfCodepoint, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert [utf_codepoint, ..] = to_utf_codepoints("💜")
-/// > utf_codepoint_to_int(utf_codepoint)
-/// 128156
+/// let assert [utf_codepoint, ..] = to_utf_codepoints("💜")
+/// utf_codepoint_to_int(utf_codepoint)
+/// // -> 128156
 /// ```
 ///
 pub fn utf_codepoint_to_int(cp: UtfCodepoint) -> Int {
@@ -797,13 +797,13 @@ fn do_utf_codepoint_to_int(cp cp: UtfCodepoint) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// > to_option("")
-/// None
+/// to_option("")
+/// // -> None
 /// ```
 ///
 /// ```gleam
-/// > to_option("hats")
-/// Some("hats")
+/// to_option("hats")
+/// // -> Some("hats")
 /// ```
 ///
 pub fn to_option(s: String) -> Option(String) {
@@ -820,13 +820,13 @@ pub fn to_option(s: String) -> Option(String) {
 /// ## Examples
 ///
 /// ```gleam
-/// > first("")
-/// Error(Nil)
+/// first("")
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > first("icecream")
-/// Ok("i")
+/// first("icecream")
+/// // -> Ok("i")
 /// ```
 ///
 pub fn first(s: String) -> Result(String, Nil) {
@@ -843,13 +843,13 @@ pub fn first(s: String) -> Result(String, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > last("")
-/// Error(Nil)
+/// last("")
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam
-/// > last("icecream")
-/// Ok("m")
+/// last("icecream")
+/// // -> Ok("m")
 /// ```
 ///
 pub fn last(s: String) -> Result(String, Nil) {
@@ -866,8 +866,8 @@ pub fn last(s: String) -> Result(String, Nil) {
 /// ## Examples
 ///
 /// ```gleam
-/// > capitalise("mamouna")
-/// "Mamouna"
+/// capitalise("mamouna")
+/// // -> "Mamouna"
 /// ```
 ///
 pub fn capitalise(s: String) -> String {
@@ -896,8 +896,8 @@ fn do_inspect(term term: anything) -> StringBuilder
 /// ## Examples
 /// 
 /// ```gleam
-/// > byte_size("🏳️‍⚧️🏳️‍🌈👩🏾‍❤️‍👨🏻")
-/// 58
+/// byte_size("🏳️‍⚧️🏳️‍🌈👩🏾‍❤️‍👨🏻")
+/// // -> 58
 /// ```
 ///
 @external(erlang, "erlang", "byte_size")

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -248,13 +248,13 @@ fn do_replace(a: StringBuilder, b: String, c: String) -> StringBuilder
 /// ## Examples
 ///
 /// ```gleam
-/// > from_strings(["a", "b"]) == from_string("ab")
-/// False
+/// from_strings(["a", "b"]) == from_string("ab")
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > is_equal(from_strings(["a", "b"]), from_string("ab"))
-/// True
+/// is_equal(from_strings(["a", "b"]), from_string("ab"))
+/// // -> True
 /// ```
 ///
 pub fn is_equal(a: StringBuilder, b: StringBuilder) -> Bool {
@@ -270,18 +270,18 @@ fn do_is_equal(a: StringBuilder, b: StringBuilder) -> Bool
 /// ## Examples
 ///
 /// ```gleam
-/// > from_string("ok") |> is_empty
-/// False
+/// from_string("ok") |> is_empty
+/// // -> False
 /// ```
 ///
 /// ```gleam
-/// > from_string("") |> is_empty
-/// True
+/// from_string("") |> is_empty
+/// // -> True
 /// ```
 ///
 /// ```gleam
-/// > from_strings([]) |> is_empty
-/// True
+/// from_strings([]) |> is_empty
+/// // -> True
 /// ```
 ///
 pub fn is_empty(builder: StringBuilder) -> Bool {

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -42,18 +42,18 @@ pub type Uri {
 /// ## Examples
 ///
 /// ```gleam
-/// > parse("https://example.com:1234/a/b?query=true#fragment")
-/// Ok(
-///   Uri(
-///     scheme: Some("https"),
-///     userinfo: None,
-///     host: Some("example.com"),
-///     port: Some(1234),
-///     path: "/a/b",
-///     query: Some("query=true"),
-///     fragment: Some("fragment")
-///   )
-/// )
+/// parse("https://example.com:1234/a/b?query=true#fragment")
+/// // -> Ok(
+/// //   Uri(
+/// //     scheme: Some("https"),
+/// //     userinfo: None,
+/// //     host: Some("example.com"),
+/// //     port: Some(1234),
+/// //     path: "/a/b",
+/// //     query: Some("query=true"),
+/// //     fragment: Some("fragment")
+/// //   )
+/// // )
 /// ```
 ///
 pub fn parse(uri_string: String) -> Result(Uri, Nil) {
@@ -204,8 +204,8 @@ fn extra_required(list: List(a), remaining: Int) -> Int {
 /// ## Examples
 ///
 /// ```gleam
-/// > parse_query("a=1&b=2")
-/// Ok([#("a", "1"), #("b", "2")])
+/// parse_query("a=1&b=2")
+/// // -> Ok([#("a", "1"), #("b", "2")])
 /// ```
 ///
 pub fn parse_query(query: String) -> Result(List(#(String, String)), Nil) {
@@ -223,8 +223,8 @@ fn do_parse_query(a: String) -> Result(List(#(String, String)), Nil)
 /// ## Examples
 ///
 /// ```gleam
-/// > query_to_string([#("a", "1"), #("b", "2")])
-/// "a=1&b=2"
+/// query_to_string([#("a", "1"), #("b", "2")])
+/// // -> "a=1&b=2"
 /// ```
 ///
 pub fn query_to_string(query: List(#(String, String))) -> String {
@@ -248,8 +248,8 @@ fn query_pair(pair: #(String, String)) -> StringBuilder {
 /// ## Examples
 ///
 /// ```gleam
-/// > percent_encode("100% great")
-/// "100%25%20great"
+/// percent_encode("100% great")
+/// // -> "100%25%20great"
 /// ```
 ///
 pub fn percent_encode(value: String) -> String {
@@ -265,8 +265,8 @@ fn do_percent_encode(a: String) -> String
 /// ## Examples
 ///
 /// ```gleam
-/// > percent_decode("100%25+great")
-/// Ok("100% great")
+/// percent_decode("100%25+great")
+/// // -> Ok("100% great")
 /// ```
 ///
 pub fn percent_decode(value: String) -> Result(String, Nil) {
@@ -308,8 +308,8 @@ fn remove_dot_segments(input: List(String)) -> List(String) {
 /// ## Examples
 ///
 /// ```gleam
-/// > path_segments("/users/1")
-/// ["users" ,"1"]
+/// path_segments("/users/1")
+/// // -> ["users" ,"1"]
 /// ```
 ///
 pub fn path_segments(path: String) -> List(String) {
@@ -323,9 +323,9 @@ pub fn path_segments(path: String) -> List(String) {
 /// ## Examples
 ///
 /// ```gleam
-/// > let uri = Uri(Some("http"), None, Some("example.com"), ...)
-/// > to_string(uri)
-/// "http://example.com"
+/// let uri = Uri(Some("http"), None, Some("example.com"), ...)
+/// to_string(uri)
+/// // -> "http://example.com"
 /// ```
 ///
 pub fn to_string(uri: Uri) -> String {
@@ -367,9 +367,9 @@ pub fn to_string(uri: Uri) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// > let assert Ok(uri) = parse("http://example.com/path?foo#bar")
-/// > origin(uri)
-/// Ok("http://example.com")
+/// let assert Ok(uri) = parse("http://example.com/path?foo#bar")
+/// origin(uri)
+/// // -> Ok("http://example.com")
 /// ```
 ///
 pub fn origin(uri: Uri) -> Result(String, Nil) {


### PR DESCRIPTION
Right now all examples are like this:
```gleam
> fold(over: [1, 2, 3], from: 0, with: fn(x, y) {
>   x + y
> }
6
```
This is a bit frustrating since it messes with syntax highlighting and one cannot simply copy and paste the code to try it.

In this PR I've changed all code examples to follow the style suggested in #490;
I think it is a nice quality of life improvement while we wait for doc tests.

I've also fixed a couple of doc examples that wouldn't compile.