### PR TITLE
Change doc example style

### DIFF
--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -267,8 +267,8 @@ pub fn intersection(
 /// ## Examples
 ///
 /// ```gleam
-/// > difference(from_list([1, 2]), from_list([2, 3, 4])) |> to_list
-/// [1]
+/// difference(from_list([1, 2]), from_list([2, 3, 4])) |> to_list
+/// // -> [1]
 /// ```
 ///
 pub fn difference(


### PR DESCRIPTION
There's a recently merged example which is using the previous style for doc example, I changed it to make it consistent with the rest of the documentation examples