### PR TITLE
Add bit_array.inspect function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `bit_array` module gains the `inspect` and `inspect_base16` functions.
 - The `set` module gains the `difference` function.
 - The deprecated `bit_string`, `bit_builder`, `base`, and `map` modules have
   been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- The `bit_array` module gains the `inspect` and `inspect_base16` functions.
+- The `bit_array` module gains the `inspect` function.
 - The `set` module gains the `difference` function.
 - The deprecated `bit_string`, `bit_builder`, `base`, and `map` modules have
   been removed.

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -1,5 +1,6 @@
 //// BitArrays are a sequence of binary data of any length.
 
+import gleam/int
 import gleam/string
 
 /// Converts a UTF-8 `String` type into a `BitArray`.
@@ -155,3 +156,54 @@ pub fn base16_encode(input: BitArray) -> String
 @external(erlang, "gleam_stdlib", "base16_decode")
 @external(javascript, "../gleam_stdlib.mjs", "base16_decode")
 pub fn base16_decode(input: String) -> Result(BitArray, Nil)
+
+/// Converts a bit array to a string containing the decimal value of each byte.
+///
+/// ## Examples
+///
+/// ```gleam
+/// inspect(<<0, 20, 0x20, 255>>)
+/// // -> "<<0, 20, 32, 255>>"
+/// ```
+/// 
+pub fn inspect(input: BitArray) -> String {
+  "<<"
+  <> input
+  |> do_inspect(int.to_string)
+  |> string.join(", ")
+  <> ">>"
+}
+
+/// Converts a bit array to a string containing the hexadecimal value of each
+/// byte.
+///
+/// ## Examples
+///
+/// ```gleam
+/// inspect(<<0, 20, 0x20, 255>>)
+/// // -> "<<00 14 20 FF>>"
+/// ```
+/// 
+pub fn inspect_base16(input: BitArray) -> String {
+  let byte_to_hex_string = fn(b) {
+    b
+    |> int.to_base16
+    |> string.pad_left(2, "0")
+  }
+
+  "<<"
+  <> input
+  |> do_inspect(byte_to_hex_string)
+  |> string.join(" ")
+  <> ">>"
+}
+
+fn do_inspect(
+  input: BitArray,
+  byte_to_string: fn(Int) -> String,
+) -> List(String) {
+  case input {
+    <<b, rest:bytes>> -> [byte_to_string(b), ..do_inspect(rest, byte_to_string)]
+    _ -> []
+  }
+}

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -157,6 +157,7 @@ pub fn base16_encode(input: BitArray) -> String
 @external(javascript, "../gleam_stdlib.mjs", "base16_decode")
 pub fn base16_decode(input: String) -> Result(BitArray, Nil)
 
+@target(javascript)
 /// Converts a bit array to a string containing the decimal value of each byte.
 ///
 /// ## Examples
@@ -168,12 +169,17 @@ pub fn base16_decode(input: String) -> Result(BitArray, Nil)
 /// inspect(<<100, 5:3>>)
 /// // -> "<<100, 5:size(3)>>"
 /// ```
-/// 
+///
+@external(javascript, "../gleam_stdlib.mjs", "bit_array_inspect")
+pub fn inspect(input: BitArray) -> String
+
+@target(erlang)
 pub fn inspect(input: BitArray) -> String {
   do_inspect(input, "<<") <> ">>"
 }
 
-fn do_inspect(input: BitArray, accumulator: String) -> String {
+@target(erlang)
+pub fn do_inspect(input: BitArray, accumulator: String) -> String {
   case input {
     <<>> -> accumulator
 

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -2,7 +2,6 @@
 
 import gleam/int
 import gleam/string
-import gleam/string_builder.{type StringBuilder}
 
 /// Converts a UTF-8 `String` type into a `BitArray`.
 ///
@@ -171,24 +170,20 @@ pub fn base16_decode(input: String) -> Result(BitArray, Nil)
 /// ```
 /// 
 pub fn inspect(input: BitArray) -> String {
-  string_builder.new()
-  |> string_builder.append("<<")
-  |> do_inspect(input)
-  |> string_builder.append(">>")
-  |> string_builder.to_string
+  do_inspect(input, "<<") <> ">>"
 }
 
-fn do_inspect(builder: StringBuilder, input: BitArray) -> StringBuilder {
+fn do_inspect(input: BitArray, accumulator: String) -> String {
   case input {
-    <<>> -> builder
+    <<>> -> accumulator
 
-    <<x:size(1)>> -> do_inspect_int(builder, x, ":size(1)")
-    <<x:size(2)>> -> do_inspect_int(builder, x, ":size(2)")
-    <<x:size(3)>> -> do_inspect_int(builder, x, ":size(3)")
-    <<x:size(4)>> -> do_inspect_int(builder, x, ":size(4)")
-    <<x:size(5)>> -> do_inspect_int(builder, x, ":size(5)")
-    <<x:size(6)>> -> do_inspect_int(builder, x, ":size(6)")
-    <<x:size(7)>> -> do_inspect_int(builder, x, ":size(7)")
+    <<x:size(1)>> -> accumulator <> int.to_string(x) <> ":size(1)"
+    <<x:size(2)>> -> accumulator <> int.to_string(x) <> ":size(2)"
+    <<x:size(3)>> -> accumulator <> int.to_string(x) <> ":size(3)"
+    <<x:size(4)>> -> accumulator <> int.to_string(x) <> ":size(4)"
+    <<x:size(5)>> -> accumulator <> int.to_string(x) <> ":size(5)"
+    <<x:size(6)>> -> accumulator <> int.to_string(x) <> ":size(6)"
+    <<x:size(7)>> -> accumulator <> int.to_string(x) <> ":size(7)"
 
     <<x, rest:bits>> -> {
       let suffix = case rest {
@@ -196,17 +191,11 @@ fn do_inspect(builder: StringBuilder, input: BitArray) -> StringBuilder {
         _ -> ", "
       }
 
-      builder
-      |> do_inspect_int(x, suffix)
-      |> do_inspect(rest)
+      let accumulator = accumulator <> int.to_string(x) <> suffix
+
+      do_inspect(rest, accumulator)
     }
 
-    _ -> builder
+    _ -> accumulator
   }
-}
-
-fn do_inspect_int(builder: StringBuilder, value: Int, suffix: String) {
-  builder
-  |> string_builder.append(int.to_string(value))
-  |> string_builder.append(suffix)
 }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -879,3 +879,7 @@ export function base16_decode(string) {
   }
   return new Ok(new BitArray(bytes));
 }
+
+export function bit_array_inspect(bits) {
+  return `<<${[...bits.buffer].join(", ")}>>`;
+}

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -289,15 +289,13 @@ pub fn inspect_test() {
 
   bit_array.inspect(<<0, 20, 0x20, 255>>)
   |> should.equal("<<0, 20, 32, 255>>")
-}
 
-pub fn inspect_base16_test() {
-  bit_array.inspect_base16(<<>>)
-  |> should.equal("<<>>")
+  bit_array.inspect(<<4:5>>)
+  |> should.equal("<<4:size(5)>>")
 
-  bit_array.inspect_base16(<<0x80>>)
-  |> should.equal("<<80>>")
+  bit_array.inspect(<<100, 5:3>>)
+  |> should.equal("<<100, 5:size(3)>>")
 
-  bit_array.inspect_base16(<<0, 20, 0x20, 255>>)
-  |> should.equal("<<00 14 20 FF>>")
+  bit_array.inspect(<<5:3, 11:4, 1:2>>)
+  |> should.equal("<<182, 1:size(1)>>")
 }

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -289,7 +289,10 @@ pub fn inspect_test() {
 
   bit_array.inspect(<<0, 20, 0x20, 255>>)
   |> should.equal("<<0, 20, 32, 255>>")
+}
 
+@target(erlang)
+pub fn inspect_partial_bytes_test() {
   bit_array.inspect(<<4:5>>)
   |> should.equal("<<4:size(5)>>")
 

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -279,3 +279,25 @@ pub fn base16_decode_test() {
   bit_array.base16_decode("a1b2c3d4e5f67891")
   |> should.equal(Ok(<<161, 178, 195, 212, 229, 246, 120, 145>>))
 }
+
+pub fn inspect_test() {
+  bit_array.inspect(<<>>)
+  |> should.equal("<<>>")
+
+  bit_array.inspect(<<80>>)
+  |> should.equal("<<80>>")
+
+  bit_array.inspect(<<0, 20, 0x20, 255>>)
+  |> should.equal("<<0, 20, 32, 255>>")
+}
+
+pub fn inspect_base16_test() {
+  bit_array.inspect_base16(<<>>)
+  |> should.equal("<<>>")
+
+  bit_array.inspect_base16(<<0x80>>)
+  |> should.equal("<<80>>")
+
+  bit_array.inspect_base16(<<0, 20, 0x20, 255>>)
+  |> should.equal("<<00 14 20 FF>>")
+}


### PR DESCRIPTION
Proposal for `bit_array.inspect` function.

Details:

- `bit_array.inspect` gives output identical to `string.inspect` (in the case when the bits aren't valid UTF-8).
- Handles partial bytes
- Added tests and updated changelog