### PR TITLE
Fix: do not crash w/ TypeError when field decodes a null object

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -673,6 +673,8 @@ export function decode_field(value, name) {
   ) {
     const entry = map_get(value, name);
     return new Ok(entry.isOk() ? new Some(entry[0]) : new None());
+  } else if (value === null) {
+    return not_a_map_error()
   } else if (Object.getPrototypeOf(value) == Object.prototype) {
     return try_get_field(value, name, () => new Ok(new None()));
   } else {

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -79,6 +79,16 @@ pub fn dict_from_null_test() {
   )
 }
 
+@target(javascript)
+pub fn null_for_field_test() {
+  get_null()
+  |> dynamic.from
+  |> dynamic.field("x", dynamic.string)
+  |> should.equal(
+    Error([DecodeError(expected: "Dict", found: "Null", path: [])]),
+  )
+}
+
 pub fn string_test() {
   ""
   |> dynamic.from


### PR DESCRIPTION
null object possibly obtained when decoding JSON.

Solves #528 