### PR TITLE
List negative indexing

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -13,7 +13,7 @@
 //// ```
 ////
 //// And a matching syntax for getting the first elements of a list:
-////
+////1
 //// ```gleam
 //// case list {
 ////   [first_element, ..rest] -> first_element
@@ -1121,7 +1121,10 @@ pub fn at(in list: List(a), get index: Int) -> Result(a, Nil) {
       list
       |> drop(index)
       |> first
-    False -> Error(Nil)
+    False -> 
+      list
+      |> reverse
+      |> at(-index - 1) 
   }
 }
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -13,7 +13,7 @@
 //// ```
 ////
 //// And a matching syntax for getting the first elements of a list:
-////1
+////
 //// ```gleam
 //// case list {
 ////   [first_element, ..rest] -> first_element

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1101,7 +1101,7 @@ pub fn intersperse(list: List(a), with elem: a) -> List(a) {
 /// position.
 ///
 /// `Error(Nil)` is returned if the list is not long enough for the given index
-/// or if the index is less than 0.
+/// You can also use negative indexes with -1 being the last element
 ///
 /// ## Examples
 ///
@@ -1113,6 +1113,11 @@ pub fn intersperse(list: List(a), with elem: a) -> List(a) {
 /// ```gleam
 /// at([1, 2, 3], 5)
 /// // -> Error(Nil)
+/// ```
+///
+/// ```gleam
+/// at([1, 2, 3], -1)
+/// // -> Ok(3)
 /// ```
 ///
 pub fn at(in list: List(a), get index: Int) -> Result(a, Nil) {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -579,6 +579,9 @@ pub fn at_test() {
   |> should.equal(Error(Nil))
 
   list.at([1, 2, 3, 4, 5, 6], -1)
+  |> should.equal(Ok(6))
+
+  list.at([1, 2, 3, 4, 5, 6], -10)
   |> should.equal(Error(Nil))
 }
 


### PR DESCRIPTION
This allows you to access the nth element form the back, starting at 1 (as you can't do -0).

It can be used like this:
```gleam
at([1, 2, 3], -1)
// -> Ok(3)
```

Similar to in python:
```python
>>> [1, 2, 3][-1]
3
```
If there is anything else I should do, let me know! :)