### PR TITLE
fix code example output of io.println_error()

### DIFF
--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -65,7 +65,7 @@ fn do_println(string string: String) -> Nil
 /// ```gleam
 /// io.println_error("Hi pop")
 /// // -> Nil
-/// // Hi mum
+/// // Hi pop
 /// ```
 ///
 pub fn println_error(string: String) -> Nil {


### PR DESCRIPTION
there's a small inconsistency on https://hexdocs.pm/gleam_stdlib/gleam/io.html#println_error where the output doesn't match the input.