### PR TITLE
Fix boolean classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   misused, resulting in poor code.
 - `list.LengthMismatch` has been removed.
 - The mistakenly public `bit_array.do_inspect` function has been removed.
+- Fixed the `dynamic.classification` function for boolean values.
 
 ## v0.36.0 - 2024-02-26
 

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -51,13 +51,13 @@ decode_error(Expected, Got) when is_binary(Expected) andalso is_binary(Got) ->
     {error, [{decode_error, Expected, Got, []}]}.
 
 classify_dynamic(nil) -> <<"Nil">>;
+classify_dynamic(X) when is_boolean(X) -> <<"Bool">>;
 classify_dynamic(X) when is_atom(X) -> <<"Atom">>;
 classify_dynamic(X) when is_binary(X) -> <<"String">>;
 classify_dynamic(X) when is_bitstring(X) -> <<"BitArray">>;
 classify_dynamic(X) when is_integer(X) -> <<"Int">>;
 classify_dynamic(X) when is_float(X) -> <<"Float">>;
 classify_dynamic(X) when is_list(X) -> <<"List">>;
-classify_dynamic(X) when is_boolean(X) -> <<"Bool">>;
 classify_dynamic(X) when is_map(X) -> <<"Dict">>;
 classify_dynamic(X) when is_tuple(X) ->
     iolist_to_binary(["Tuple of ", integer_to_list(tuple_size(X)), " elements"]);

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -1504,3 +1504,21 @@ pub fn decode9_test() {
     ]),
   )
 }
+
+type ClassifyAtom {
+  ClassifyAtom
+}
+
+pub fn classify_test() {
+  dynamic.from(True)
+  |> dynamic.classify
+  |> should.equal("Bool")
+
+  dynamic.from(False)
+  |> dynamic.classify
+  |> should.equal("Bool")
+
+  dynamic.from(ClassifyAtom)
+  |> dynamic.classify
+  |> should.equal("Atom")
+}

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -1517,8 +1517,4 @@ pub fn classify_test() {
   dynamic.from(False)
   |> dynamic.classify
   |> should.equal("Bool")
-
-  dynamic.from(ClassifyAtom)
-  |> dynamic.classify
-  |> should.equal("Atom")
 }


### PR DESCRIPTION
Hi. I noticed that the boolean type is incorrectly classified on the beam runtime. This should fix it.