### PR TITLE
Deprecate `bool.min` and `bool.max`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `list.LengthMismatch` has been removed.
 - The mistakenly public `bit_array.do_inspect` function has been removed.
 - Fixed the `dynamic.classification` function for bools.
+- The `min` function in the `bool` module has been deprecated in favour of
+  `bool.and`.
+- The `max` function in the `bool` module has been deprecated in favour of
+  `bool.or`.
 
 ## v0.36.0 - 2024-02-26
 

--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -253,6 +253,7 @@ pub fn compare(a: Bool, with b: Bool) -> Order {
 /// // -> False
 /// ```
 ///
+@deprecated("Use the `bool.or` function instead")
 pub fn max(a: Bool, b: Bool) -> Bool {
   case a {
     True -> True
@@ -279,6 +280,7 @@ pub fn max(a: Bool, b: Bool) -> Bool {
 /// // -> False
 /// ```
 ///
+@deprecated("Use the `bool.and` function instead")
 pub fn min(a: Bool, b: Bool) -> Bool {
   case a {
     False -> False


### PR DESCRIPTION
This PR closes #556
