### PR TITLE
Fix `regex.split` including `Nil` in the returned `List(String)` on JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   `bool.and`.
 - The `max` function in the `bool` module has been deprecated in favour of
   `bool.or`.
+- Fixed a bug with `regex.split` where it could include `Nil` elements in the
+  returned list of strings on the JavaScript target when the expression to
+  split with included an optional match group which wasn't matched.
 
 ## v0.36.0 - 2024-02-26
 

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -127,18 +127,9 @@ pub fn split(with regex: Regex, content string: String) -> List(String) {
   do_split(regex, string)
 }
 
-@target(erlang)
 @external(erlang, "gleam_stdlib", "regex_split")
+@external(javascript, "../gleam_stdlib.mjs", "regex_split")
 fn do_split(a: Regex, b: String) -> List(String)
-
-@target(javascript)
-fn do_split(regex, string) -> List(String) {
-  js_split(string, regex)
-}
-
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "split")
-fn js_split(a: String, b: Regex) -> List(String)
 
 /// Collects all matches of the regular expression.
 ///

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -402,6 +402,10 @@ export function compile_regex(pattern, options) {
   }
 }
 
+export function regex_split(regex, string) {
+  return List.fromArray(string.split(regex).map(item => item === undefined ? "" : item));
+}
+
 export function regex_scan(regex, string) {
   const matches = Array.from(string.matchAll(regex)).map((match) => {
     const content = match[0];

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -73,6 +73,15 @@ pub fn split_test() {
   |> should.equal(["foo", "32", "4", "9", "0"])
 }
 
+pub fn matching_split_test() {
+  let assert Ok(re) = regex.from_string("([+-])( *)(d)*")
+
+  regex.split(re, "abc+ def+ghi+  abc")
+  |> should.equal([
+    "abc", "+", " ", "d", "ef", "+", "", "", "ghi", "+", "  ", "", "abc",
+  ])
+}
+
 pub fn scan_test() {
   let assert Ok(re) = regex.from_string("Gl\\w+")
 


### PR DESCRIPTION
Fixes #561

Only happens when the regex to split with has an optional match which isn't present.

For consistency with the Erlang target, we replace `Nil` (`undefined`) with `""`.