### PR TITLE
Refactored list and dict to use Option type instead of Result for better ergonomics.

### DIFF
--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -2,6 +2,7 @@
 //// `Ok` means it was successful, `Error` means it was not successful.
 
 import gleam/list
+import gleam/option.{None, Some}
 
 /// Checks whether the result is an `Ok` value.
 ///
@@ -441,7 +442,12 @@ pub fn replace_error(result: Result(a, e1), error: e2) -> Result(a, e2) {
 /// ```
 ///
 pub fn values(results: List(Result(a, e))) -> List(a) {
-  list.filter_map(results, fn(r) { r })
+  list.filter_map(results, fn(result) {
+    case result {
+      Ok(value) -> Some(value)
+      Error(_) -> None
+    }
+  })
 }
 
 /// Updates a value held within the `Error` of a result by calling a given function

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -1,6 +1,6 @@
 import gleam/dict.{type Dict}
 import gleam/list
-import gleam/result
+import gleam/option
 
 // A list is used as the dict value as an empty list has the smallest
 // representation in Erlang's binary format
@@ -92,7 +92,7 @@ pub fn insert(into set: Set(member), this member: member) -> Set(member) {
 pub fn contains(in set: Set(member), this member: member) -> Bool {
   set.dict
   |> dict.get(member)
-  |> result.is_ok
+  |> option.is_some
 }
 
 /// Removes a member from a set. If the set does not contain the member then

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -60,45 +60,45 @@ pub fn get_test() {
 
   m
   |> dict.get(4)
-  |> should.equal(Ok(0))
+  |> should.equal(Some(0))
 
   m
   |> dict.get(1)
-  |> should.equal(Ok(1))
+  |> should.equal(Some(1))
 
   m
   |> dict.get(2)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   let proplist = [#(A, 0), #(B, 1)]
   let m = dict.from_list(proplist)
 
   m
   |> dict.get(A)
-  |> should.equal(Ok(0))
+  |> should.equal(Some(0))
 
   m
   |> dict.get(B)
-  |> should.equal(Ok(1))
+  |> should.equal(Some(1))
 
   m
   |> dict.get(C)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   let proplist = [#(<<1, 2, 3>>, 0), #(<<3, 2, 1>>, 1)]
   let m = dict.from_list(proplist)
 
   m
   |> dict.get(<<1, 2, 3>>)
-  |> should.equal(Ok(0))
+  |> should.equal(Some(0))
 
   m
   |> dict.get(<<3, 2, 1>>)
-  |> should.equal(Ok(1))
+  |> should.equal(Some(1))
 
   m
   |> dict.get(<<1, 3, 2>>)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn insert_test() {
@@ -260,7 +260,7 @@ pub fn persistence_test() {
   dict.insert(a, 1, 6)
   dict.delete(a, 0)
   dict.get(a, 0)
-  |> should.equal(Ok(0))
+  |> should.equal(Some(0))
 }
 
 // using maps as keys should work (tests hash function)
@@ -281,23 +281,23 @@ pub fn map_as_key_test() {
     |> dict.insert(d, "d")
 
   dict.get(map1, a)
-  |> should.equal(Ok("a"))
+  |> should.equal(Some("a"))
   dict.get(map1, a2)
-  |> should.equal(Ok("a"))
+  |> should.equal(Some("a"))
   dict.get(map1, a3)
-  |> should.equal(Ok("a"))
+  |> should.equal(Some("a"))
   dict.get(map1, b)
-  |> should.equal(Ok("b"))
+  |> should.equal(Some("b"))
   dict.get(map1, c)
-  |> should.equal(Ok("c"))
+  |> should.equal(Some("c"))
   dict.get(map1, d)
-  |> should.equal(Ok("d"))
+  |> should.equal(Some("d"))
   dict.insert(map1, a2, "a2")
   |> dict.get(a)
-  |> should.equal(Ok("a2"))
+  |> should.equal(Some("a2"))
   dict.insert(map1, a3, "a3")
   |> dict.get(a)
-  |> should.equal(Ok("a3"))
+  |> should.equal(Some("a3"))
 }
 
 pub fn large_n_test() {
@@ -305,10 +305,10 @@ pub fn large_n_test() {
   let l = range(0, n, [])
 
   let m = list_to_map(l)
-  list.map(l, fn(i) { should.equal(dict.get(m, i), Ok(i)) })
+  list.map(l, fn(i) { should.equal(dict.get(m, i), Some(i)) })
 
   let m = grow_and_shrink_map(n, 0)
-  list.map(l, fn(i) { should.equal(dict.get(m, i), Error(Nil)) })
+  list.map(l, fn(i) { should.equal(dict.get(m, i), None) })
 }
 
 pub fn size_test() {
@@ -359,7 +359,7 @@ pub fn peters_bug_test() {
   |> dict.insert(1, Nil)
   |> dict.insert(3, Nil)
   |> dict.get(0)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn zero_must_be_contained_test() {
@@ -369,7 +369,7 @@ pub fn zero_must_be_contained_test() {
 
   map
   |> dict.get(0)
-  |> should.equal(Ok(Nil))
+  |> should.equal(Some(Nil))
 
   map
   |> dict.has_key(0)

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -2,6 +2,7 @@ import gleam/dict
 import gleam/int
 import gleam/iterator.{Done, Next}
 import gleam/list
+import gleam/option.{None, Some}
 import gleam/should
 
 // a |> from_list |> to_list == a
@@ -282,13 +283,20 @@ pub fn filter_map_test() {
     |> should.equal(list.filter_map(subject, f))
   }
 
-  testcase([], int.parse)
-  testcase(["1"], int.parse)
-  testcase(["1", "2", "3"], int.parse)
-  testcase(["1", "a", "b"], int.parse)
-  testcase(["l", "2", "3", "a"], int.parse)
-  testcase(["1", "c", "3", "a", "b"], int.parse)
-  testcase(["1", "20", "ten", "4", "5", "69"], int.parse)
+  let string_to_int = fn(value) {
+    case int.parse(value) {
+      Ok(value) -> Some(value)
+      Error(_) -> None
+    }
+  }
+
+  testcase([], string_to_int)
+  testcase(["1"], string_to_int)
+  testcase(["1", "2", "3"], string_to_int)
+  testcase(["1", "a", "b"], string_to_int)
+  testcase(["l", "2", "3", "a"], string_to_int)
+  testcase(["1", "c", "3", "a", "b"], string_to_int)
+  testcase(["1", "20", "ten", "4", "5", "69"], string_to_int)
 }
 
 pub fn repeat_test() {
@@ -359,56 +367,56 @@ type Cat {
 pub fn find_test() {
   iterator.range(0, 10)
   |> iterator.find(fn(e) { e == 5 })
-  |> should.equal(Ok(5))
+  |> should.equal(Some(5))
 
   iterator.range(0, 10)
   |> iterator.find(fn(e) { e > 10 })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   iterator.empty()
   |> iterator.find(fn(_x) { True })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   iterator.unfold(Cat(id: 1), fn(cat: Cat) {
     iterator.Next(cat, Cat(id: cat.id + 1))
   })
   |> iterator.find(fn(cat: Cat) { cat.id == 10 })
-  |> should.equal(Ok(Cat(id: 10)))
+  |> should.equal(Some(Cat(id: 10)))
 }
 
 pub fn find_map_test() {
   iterator.range(0, 10)
   |> iterator.find_map(fn(e) {
     case e == 5 {
-      True -> Ok(e)
-      False -> Error(Nil)
+      True -> Some(e)
+      False -> None
     }
   })
-  |> should.equal(Ok(5))
+  |> should.equal(Some(5))
 
   iterator.range(0, 10)
   |> iterator.find_map(fn(e) {
     case e > 10 {
-      True -> Ok(e)
-      False -> Error(Nil)
+      True -> Some(e)
+      False -> None
     }
   })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   iterator.empty()
-  |> iterator.find_map(fn(_x) { Ok(True) })
-  |> should.equal(Error(Nil))
+  |> iterator.find_map(fn(_x) { Some(True) })
+  |> should.equal(None)
 
   iterator.unfold(Cat(id: 1), fn(cat: Cat) {
     iterator.Next(cat, Cat(id: cat.id + 1))
   })
   |> iterator.find_map(fn(cat: Cat) {
     case cat.id == 10 {
-      True -> Ok(cat)
-      False -> Error(Nil)
+      True -> Some(cat)
+      False -> None
     }
   })
-  |> should.equal(Ok(Cat(id: 10)))
+  |> should.equal(Some(Cat(id: 10)))
 }
 
 pub fn index_test() {
@@ -539,21 +547,21 @@ pub fn group_test() {
 pub fn reduce_test() {
   iterator.empty()
   |> iterator.reduce(with: fn(acc, x) { acc + x })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   iterator.from_list([1, 2, 3, 4, 5])
   |> iterator.reduce(with: fn(acc, x) { acc + x })
-  |> should.equal(Ok(15))
+  |> should.equal(Some(15))
 }
 
 pub fn last_test() {
   iterator.empty()
   |> iterator.last
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   iterator.range(1, 10)
   |> iterator.last
-  |> should.equal(Ok(10))
+  |> should.equal(Some(10))
 }
 
 pub fn empty_test() {
@@ -646,25 +654,25 @@ pub fn try_fold_test() {
 pub fn first_test() {
   iterator.from_list([1, 2, 3])
   |> iterator.first
-  |> should.equal(Ok(1))
+  |> should.equal(Some(1))
 
   iterator.empty()
   |> iterator.first
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn at_test() {
   iterator.from_list([1, 2, 3, 4])
   |> iterator.at(2)
-  |> should.equal(Ok(3))
+  |> should.equal(Some(3))
 
   iterator.from_list([1, 2, 3, 4])
   |> iterator.at(4)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   iterator.empty()
   |> iterator.at(0)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn length_test() {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -2,6 +2,7 @@ import gleam/dict
 import gleam/float
 import gleam/int
 import gleam/list
+import gleam/option.{None, Some}
 import gleam/pair
 import gleam/should
 
@@ -77,21 +78,21 @@ pub fn contains_test() {
 
 pub fn first_test() {
   list.first([0, 4, 5, 7])
-  |> should.equal(Ok(0))
+  |> should.equal(Some(0))
 
   list.first([])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn rest_test() {
   list.rest([0, 4, 5, 7])
-  |> should.equal(Ok([4, 5, 7]))
+  |> should.equal(Some([4, 5, 7]))
 
   list.rest([0])
-  |> should.equal(Ok([]))
+  |> should.equal(Some([]))
 
   list.rest([])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn group_test() {
@@ -141,16 +142,16 @@ pub fn filter_test() {
 
 pub fn filter_map_test() {
   [2, 4, 6, 1]
-  |> list.filter_map(fn(x) { Ok(x + 1) })
+  |> list.filter_map(fn(x) { Some(x + 1) })
   |> should.equal([3, 5, 7, 2])
 
   [2, 4, 6, 1]
-  |> list.filter_map(Error)
+  |> list.filter_map(fn(_) { None })
   |> should.equal([])
 
   // TCO test
   list.repeat(0, recursion_test_cycles)
-  |> list.filter_map(fn(x) { Ok(x + 1) })
+  |> list.filter_map(fn(x) { Some(x + 1) })
 }
 
 pub fn map_test() {
@@ -423,29 +424,29 @@ pub fn try_fold_test() {
 pub fn find_map_test() {
   let f = fn(x) {
     case x {
-      2 -> Ok(4)
-      _ -> Error(Nil)
+      2 -> Some(4)
+      _ -> None
     }
   }
 
   [1, 2, 3]
   |> list.find_map(with: f)
-  |> should.equal(Ok(4))
+  |> should.equal(Some(4))
 
   [1, 3, 2]
   |> list.find_map(with: f)
-  |> should.equal(Ok(4))
+  |> should.equal(Some(4))
 
   [1, 3]
   |> list.find_map(with: f)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   // TCO test
   list.range(0, recursion_test_cycles)
   |> list.find_map(with: fn(x) {
     case x == recursion_test_cycles {
-      True -> Ok(recursion_test_cycles)
-      _ -> Error(Nil)
+      True -> Some(recursion_test_cycles)
+      _ -> None
     }
   })
 }
@@ -455,15 +456,15 @@ pub fn find_test() {
 
   [1, 2, 3]
   |> list.find(one_that: is_two)
-  |> should.equal(Ok(2))
+  |> should.equal(Some(2))
 
   [1, 3, 2]
   |> list.find(one_that: is_two)
-  |> should.equal(Ok(2))
+  |> should.equal(Some(2))
 
   [1, 3]
   |> list.find(one_that: is_two)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   // TCO test
   list.range(0, recursion_test_cycles)
@@ -548,19 +549,19 @@ pub fn zip_test() {
 
 pub fn strict_zip_test() {
   list.strict_zip([], [1, 2, 3])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.strict_zip([1, 2], [])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.strict_zip([1, 2, 3], [4, 5, 6])
-  |> should.equal(Ok([#(1, 4), #(2, 5), #(3, 6)]))
+  |> should.equal(Some([#(1, 4), #(2, 5), #(3, 6)]))
 
   list.strict_zip([5, 6], [1, 2, 3])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.strict_zip([5, 6, 7], [1, 2])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn unzip_test() {
@@ -590,16 +591,16 @@ pub fn intersperse_test() {
 
 pub fn at_test() {
   list.at([1, 2, 3], 2)
-  |> should.equal(Ok(3))
+  |> should.equal(Some(3))
 
   list.at([1, 2, 3], 5)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.at([], 0)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.at([1, 2, 3, 4, 5, 6], -1)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn unique_test() {
@@ -815,15 +816,15 @@ pub fn key_find_test() {
 
   proplist
   |> list.key_find(0)
-  |> should.equal(Ok("1"))
+  |> should.equal(Some("1"))
 
   proplist
   |> list.key_find(1)
-  |> should.equal(Ok("2"))
+  |> should.equal(Some("2"))
 
   proplist
   |> list.key_find(2)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn key_filter_test() {
@@ -849,15 +850,15 @@ pub fn key_filter_test() {
 pub fn pop_test() {
   [1, 2, 3]
   |> list.pop(fn(x) { x > 2 })
-  |> should.equal(Ok(#(3, [1, 2])))
+  |> should.equal(Some(#(3, [1, 2])))
 
   [1, 2, 3]
   |> list.pop(fn(x) { x > 4 })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   []
   |> list.pop(fn(_x) { True })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   // TCO test
   list.repeat(0, recursion_test_cycles + 10)
@@ -867,29 +868,29 @@ pub fn pop_test() {
 pub fn pop_map_test() {
   let get = fn(x) {
     case x > 0 {
-      True -> Ok(x * 2)
-      False -> Error(Nil)
+      True -> Some(x * 2)
+      False -> None
     }
   }
   list.pop_map([0, 2, 3], get)
-  |> should.equal(Ok(#(4, [0, 3])))
+  |> should.equal(Some(#(4, [0, 3])))
 
   list.pop_map([0, -1], get)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.pop_map([], get)
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn key_pop_test() {
   list.key_pop([#("a", 0), #("b", 1)], "a")
-  |> should.equal(Ok(#(0, [#("b", 1)])))
+  |> should.equal(Some(#(0, [#("b", 1)])))
 
   list.key_pop([#("a", 0), #("b", 1)], "b")
-  |> should.equal(Ok(#(1, [#("a", 0)])))
+  |> should.equal(Some(#(1, [#("a", 0)])))
 
   list.key_pop([#("a", 0), #("b", 1)], "c")
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 }
 
 pub fn key_set_test() {
@@ -1137,11 +1138,11 @@ pub fn sized_chunk_test() {
 pub fn reduce_test() {
   []
   |> list.reduce(with: fn(x, y) { x + y })
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   [1, 2, 3, 4, 5]
   |> list.reduce(with: fn(x, y) { x + y })
-  |> should.equal(Ok(15))
+  |> should.equal(Some(15))
 }
 
 pub fn scan_test() {
@@ -1174,10 +1175,10 @@ pub fn scan_test() {
 
 pub fn last_test() {
   list.last([])
-  |> should.equal(Error(Nil))
+  |> should.equal(None)
 
   list.last([1, 2, 3, 4, 5])
-  |> should.equal(Ok(5))
+  |> should.equal(Some(5))
 }
 
 pub fn combinations_test() {


### PR DESCRIPTION
This PR will update the standard library from using `Result` to using `Optional`

### Why?
I found many of the list functions using `Result` were returning `Error(Nil)` or ignoring the user's passed error type.

`Error(a)` to me represents an unexpected outcome. Similar to a `raise` or `throw` in another language. Where we can then supply the developer inside with it's `a` value.

Filtering through a list, to not find the item, is not error worthy. The outcome is expected. Therefore, `None` is better, and at the same time we don't lose any data being returned to the developer. Since all of the previous implementations just returned `Error(Nil)` or ignored the `a` in `Error(a)` anyway.