### PR TITLE
Add float.modulo

### DIFF
--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -441,38 +441,23 @@ pub fn random() -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// modulo(3.0, 2.0)
-/// // -> Ok(1.0)
+/// modulo(13.3, by: 3.3)
+/// // -> Ok(0.1)
 /// ```
 ///
 /// ```gleam
-/// modulo(1.0, 0.0)
-/// // -> Error(Nil)
+/// modulo(-13.3, by: 3.3)
+/// // -> Ok(3.2)
 /// ```
 ///
 /// ```gleam
-/// modulo(10.0, -1.0)
-/// // -> Ok(0.0)
+/// modulo(13.3, by: -3.3)
+/// // -> Ok(-3.2)
 /// ```
 ///
 /// ```gleam
-/// modulo(13.0, by: 3.0)
-/// // -> Ok(1.0)
-/// ```
-///
-/// ```gleam
-/// modulo(-13.0, by: 3.0)
-/// // -> Ok(2.0)
-/// ```
-///
-/// ```gleam
-/// modulo(13.0, by: -3.0)
-/// // -> Ok(-2.0)
-/// ```
-///
-/// ```gleam
-/// modulo(-13.0, by: -3.0)
-/// // -> Ok(-1.0)
+/// modulo(-13.3, by: -3.3)
+/// // -> Ok(-0.1)
 /// ```
 ///
 pub fn modulo(dividend: Float, by divisor: Float) -> Result(Float, Nil) {

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -433,6 +433,55 @@ fn do_product(numbers: List(Float), initial: Float) -> Float {
 @external(javascript, "../gleam_stdlib.mjs", "random_uniform")
 pub fn random() -> Float
 
+/// Computes the modulo of an float division of inputs as a `Result`.
+///
+/// Returns division of the inputs as a `Result`: If the given divisor equals
+/// `0`, this function returns an `Error`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// modulo(3.0, 2.0)
+/// // -> Ok(1.0)
+/// ```
+///
+/// ```gleam
+/// modulo(1.0, 0.0)
+/// // -> Error(Nil)
+/// ```
+///
+/// ```gleam
+/// modulo(10.0, -1.0)
+/// // -> Ok(0.0)
+/// ```
+///
+/// ```gleam
+/// modulo(13.0, by: 3.0)
+/// // -> Ok(1.0)
+/// ```
+///
+/// ```gleam
+/// modulo(-13.0, by: 3.0)
+/// // -> Ok(2.0)
+/// ```
+///
+/// ```gleam
+/// modulo(13.0, by: -3.0)
+/// // -> Ok(-2.0)
+/// ```
+///
+/// ```gleam
+/// modulo(-13.0, by: -3.0)
+/// // -> Ok(-1.0)
+/// ```
+///
+pub fn modulo(dividend: Float, by divisor: Float) -> Result(Float, Nil) {
+  case divisor {
+    0.0 -> Error(Nil)
+    _ -> Ok(dividend -. floor(dividend /. divisor) *. divisor)
+  }
+}
+
 /// Returns division of the inputs as a `Result`.
 ///
 /// ## Examples

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -372,13 +372,13 @@ pub fn random_test() {
 }
 
 pub fn modulo_test() {
-  float.modulo(3.0, 2.0)
+  float.modulo(3.0, by: 2.0)
   |> should.equal(Ok(1.0))
 
-  float.modulo(1.0, 0.0)
+  float.modulo(1.0, by: 0.0)
   |> should.equal(Error(Nil))
 
-  float.modulo(10.0, -1.0)
+  float.modulo(10.0, by: -1.0)
   |> should.equal(Ok(0.0))
 
   float.modulo(13.0, by: 3.0)
@@ -392,6 +392,33 @@ pub fn modulo_test() {
 
   float.modulo(-13.0, by: -3.0)
   |> should.equal(Ok(-1.0))
+
+  float.modulo(3.3, 2.3)
+  |> should.equal(Ok(1.0))
+
+  float.modulo(13.3, by: 3.0)
+  |> should.equal(Ok(1.3))
+
+  float.modulo(13.0, by: 3.3)
+  |> should.equal(Ok(3.1))
+
+  float.modulo(-13.3, by: 3.0)
+  |> should.equal(Ok(1.3))
+
+  float.modulo(-13.0, by: 3.3)
+  |> should.equal(Ok(3.1))
+
+  float.modulo(13.3, by: -3.0)
+  |> should.equal(Ok(-1.3))
+
+  float.modulo(13.0, by: -3.3)
+  |> should.equal(Ok(-3.1))
+
+  float.modulo(-13.3, by: -3.0)
+  |> should.equal(Ok(1.3))
+
+  float.modulo(-13.0, by: -3.3)
+  |> should.equal(Ok(3.1))
 }
 
 pub fn divide_test() {

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -3,6 +3,7 @@ import gleam/int
 import gleam/iterator
 import gleam/list
 import gleam/order
+import gleam/result
 import gleam/should
 
 pub fn parse_test() {
@@ -372,53 +373,28 @@ pub fn random_test() {
 }
 
 pub fn modulo_test() {
-  float.modulo(3.0, by: 2.0)
-  |> should.equal(Ok(1.0))
-
-  float.modulo(1.0, by: 0.0)
+  float.modulo(13.3, by: 0.0)
   |> should.equal(Error(Nil))
 
-  float.modulo(10.0, by: -1.0)
-  |> should.equal(Ok(0.0))
+  float.modulo(13.3, by: 3.3)
+  |> result.unwrap(or: 0.0)
+  |> float.loosely_equals(with: 0.1, tolerating: 0.001)
+  |> should.be_true
 
-  float.modulo(13.0, by: 3.0)
-  |> should.equal(Ok(1.0))
+  float.modulo(-13.3, by: 3.3)
+  |> result.unwrap(or: 0.0)
+  |> float.loosely_equals(with: 3.2, tolerating: 0.001)
+  |> should.be_true
 
-  float.modulo(-13.0, by: 3.0)
-  |> should.equal(Ok(2.0))
+  float.modulo(13.3, by: -3.3)
+  |> result.unwrap(or: 0.0)
+  |> float.loosely_equals(with: -3.2, tolerating: 0.001)
+  |> should.be_true
 
-  float.modulo(13.0, by: -3.0)
-  |> should.equal(Ok(-2.0))
-
-  float.modulo(-13.0, by: -3.0)
-  |> should.equal(Ok(-1.0))
-
-  float.modulo(3.3, 2.3)
-  |> should.equal(Ok(1.0))
-
-  float.modulo(13.3, by: 3.0)
-  |> should.equal(Ok(1.3))
-
-  float.modulo(13.0, by: 3.3)
-  |> should.equal(Ok(3.1))
-
-  float.modulo(-13.3, by: 3.0)
-  |> should.equal(Ok(1.3))
-
-  float.modulo(-13.0, by: 3.3)
-  |> should.equal(Ok(3.1))
-
-  float.modulo(13.3, by: -3.0)
-  |> should.equal(Ok(-1.3))
-
-  float.modulo(13.0, by: -3.3)
-  |> should.equal(Ok(-3.1))
-
-  float.modulo(-13.3, by: -3.0)
-  |> should.equal(Ok(1.3))
-
-  float.modulo(-13.0, by: -3.3)
-  |> should.equal(Ok(3.1))
+  float.modulo(-13.3, by: -3.3)
+  |> result.unwrap(or: 0.0)
+  |> float.loosely_equals(with: -0.1, tolerating: 0.001)
+  |> should.be_true
 }
 
 pub fn divide_test() {

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -371,6 +371,29 @@ pub fn random_test() {
   |> should.be_true
 }
 
+pub fn modulo_test() {
+  float.modulo(3.0, 2.0)
+  |> should.equal(Ok(1.0))
+
+  float.modulo(1.0, 0.0)
+  |> should.equal(Error(Nil))
+
+  float.modulo(10.0, -1.0)
+  |> should.equal(Ok(0.0))
+
+  float.modulo(13.0, by: 3.0)
+  |> should.equal(Ok(1.0))
+
+  float.modulo(-13.0, by: 3.0)
+  |> should.equal(Ok(2.0))
+
+  float.modulo(13.0, by: -3.0)
+  |> should.equal(Ok(-2.0))
+
+  float.modulo(-13.0, by: -3.0)
+  |> should.equal(Ok(-1.0))
+}
+
 pub fn divide_test() {
   float.divide(1.0, 1.0)
   |> should.equal(Ok(1.0))


### PR DESCRIPTION
Should close #525 by adding the `float.modulo` function.

I also tried implementing the `float.remainder` function as:

``` gleam
pub fn modulo(dividend: Float, by divisor: Float) -> Result(Float, Nil) {
  case divisor {
    0.0 -> Error(Nil)
    _ -> Ok(dividend -. round(dividend /. divisor) *. divisor)
  }
}
```

But `round` returns an `Int` and I could not find an easy way to convert it back to `Float`. A little bit off-topic, but why does it return an `Int` it should return a `Float` right?