### PR TITLE
Escape form feed control character in string.inspect on Erlang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - The `list` module gains the `wrap` function.
 - The `iterator` module gains the `find_map` function.
+- Fixed `string.inspect` not formatting the `\f` form feed control character
+  correctly on Erlang.
 
 ## v0.37.0 - 2024-04-19
 

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -497,6 +497,7 @@ inspect_maybe_utf8_string(Binary, Acc) ->
                 $\r -> <<$\\, $r>>;
                 $\n -> <<$\\, $n>>;
                 $\t -> <<$\\, $t>>;
+                $\f -> <<$\\, $f>>;
                 Other -> <<Other/utf8>>
             end,
             inspect_maybe_utf8_string(Rest, <<Acc/binary, Escaped/binary>>);

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -685,6 +685,9 @@ pub fn inspect_test() {
   string.inspect("\t")
   |> should.equal("\"\\t\"")
 
+  string.inspect("\f")
+  |> should.equal("\"\\f\"")
+
   string.inspect("\r\r")
   |> should.equal("\"\\r\\r\"")
 


### PR DESCRIPTION
Addresses https://github.com/gleam-lang/stdlib/issues/585.