### PR TITLE
Add `dict.each`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `sort` function of the `list` module has been optimised in case it's
   working on an already sorted list.
+- The `dict` module gains the `each` function.
 - The `list` module gains the `wrap` function.
 - The `iterator` module gains the `find_map` function.
 - Fixed `string.inspect` not formatting the `\f` form feed control character

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The `sort` function of the `list` module has been optimised in case it's
+  working on an already sorted list.
 - The `list` module gains the `wrap` function.
 - The `iterator` module gains the `find_map` function.
 - Fixed `string.inspect` not formatting the `\f` form feed control character

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -497,3 +497,32 @@ pub fn fold(
   |> to_list
   |> do_fold(initial, fun)
 }
+
+/// Calls a function for each key and value in a dict, discarding the return 
+/// value.
+/// 
+/// Useful for producing a side effect for every item of a dict.
+/// 
+/// ```gleam
+/// import gleam/io
+/// 
+/// let dict = from_list([#("a", "apple"), #("b", "banana"), #("c", "cherry")])
+/// 
+/// each(dict, fn(key, value) { 
+///   io.println(key <> " => " <> value)
+/// })
+/// // -> Nil
+/// // a => apple
+/// // b => banana
+/// // c => cherry
+/// ```
+/// 
+/// The order of elements in the iteration is an implementation detail that
+/// should not be relied upon.
+/// 
+pub fn each(dict: Dict(k, v), fun: fn(k, v) -> b) -> Nil {
+  fold(dict, Nil, fn(nil, k, v) {
+    fun(k, v)
+    nil
+  })
+}

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -220,6 +220,18 @@ pub fn fold_test() {
   |> should.equal(0)
 }
 
+pub fn each_test() {
+  let dict = dict.from_list([#("a", 1), #("b", 2), #("c", 3), #("d", 4)])
+
+  dict.each(dict, fn(k, v) {
+    let assert True = case k, v {
+      "a", 1 | "b", 2 | "c", 3 | "d", 4 -> True
+      _, _ -> False
+    }
+  })
+  |> should.equal(Nil)
+}
+
 fn range(start, end, a) {
   case end - start {
     n if n < 1 -> a


### PR DESCRIPTION
Addresses https://github.com/gleam-lang/stdlib/issues/580.

- Adds `dict.each` implemented using `dict.fold`.
- Parameter names are modeled after those in the `dict` module.
  - The `list.each` function uses `f` rather than `fun` for the name of the iterating function, however.
- Tests are modeled after those for `list.each`.
- Docs are modeled after those for `list.each`.