### PR TITLE
Improve performance of `list.sort` for (pre)sorted lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The `sort` function of the `list` module has been optimised in case it's
+  working on an already sorted list.
 - The `list` module gains the `wrap` function.
 - The `iterator` module gains the `find_map` function.
 - Fixed `string.inspect` not formatting the `\f` form feed control character


### PR DESCRIPTION
This PR changes the implementation of `list.sort` to improve its performance on (pre)sorted lists (~10x)!