### PR TITLE
list.count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   escape codes such as `\n` or `\r`.
 - Fixed a bug where `string.inspect` would use the incorrect syntax for unicode
   escape codes on JavaScript.
+- The `list` module gains the `count` function.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -65,6 +65,37 @@ fn count_length(list: List(a), count: Int) -> Int {
   }
 }
 
+/// Counts the number of elements in a given list satisfying a given predicate.
+///
+/// This function has to traverse the list to determine the number of elements,
+/// so it runs in linear time.
+///
+/// ## Examples
+///
+/// ```gleam
+/// count([], fn(a) { a > 0 })
+/// // -> 0
+/// ```
+///
+/// ```gleam
+/// count([1], fn(a) { a > 0 })
+/// // -> 1
+/// ```
+///
+/// ```gleam
+/// count([1, 2, 3], int.is_odd)
+/// // -> 2
+/// ```
+///
+pub fn count(list: List(a), where predicate: fn(a) -> Bool) -> Int {
+  fold(list, 0, fn(acc, value) {
+    case predicate(value) {
+      True -> acc + 1
+      False -> acc
+    }
+  })
+}
+
 /// Creates a new list from a given list containing the same elements but in the
 /// opposite order.
 ///

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -4,6 +4,7 @@ import gleam/int
 import gleam/list
 import gleam/pair
 import gleam/should
+import gleam/string
 
 @target(erlang)
 const recursion_test_cycles = 1_000_000
@@ -32,6 +33,22 @@ pub fn length_test() {
   // TCO test
   list.range(0, recursion_test_cycles)
   |> list.length()
+}
+
+pub fn count_test() {
+  list.count([], int.is_odd)
+  |> should.equal(0)
+
+  list.count([2, 4, 6], int.is_odd)
+  |> should.equal(0)
+
+  list.count([1, 2, 3, 4, 5], int.is_odd)
+  |> should.equal(3)
+
+  list.count(["a", "list", "with", "some", "string", "values"], fn(a) {
+    string.length(a) > 4
+  })
+  |> should.equal(2)
 }
 
 pub fn reverse_test() {


### PR DESCRIPTION
An attempt at implementing `list.count` and `iterator.count` as suggested in #592.
The functions will return the number of elements in a given list/iterator that satisfy the given predicate.