### PR TITLE
fixed test to float.negate after changes to OTP

### DIFF
--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -325,6 +325,7 @@ pub fn negate_test() {
   |> should.equal(-2.0)
 
   float.negate(0.0)
+  |> float.negate
   |> should.equal(0.0)
 }
 


### PR DESCRIPTION
OTP v27.0 changed floating point behavior, such that 0.0 and -0.0 have distinct internal representations and are no longer considered equal.

Details:
https://erlang.org/documentation/doc-15.0-rc1/doc/upcoming_incompatibilities.html#0-0-and-0-0-will-no-longer-be-exactly-equal