### PR TITLE
stdlib 0.40: reuse dict.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.39.0 - Unreleased
 
 - The `min` and `max` functions of the `order` module have been deprecated.
+- The `dict` module function `update` has been deprecated in favour of `upsert`
+  and `update` will be used with a different signature in future.
 
 ## v0.38.0 - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.40.0 - Unreleased
+
+- The previously deprecated `update` function of the `dict` has been replaced
+  with a new implementation having a new `Result` return signature, where
+  it returns `Ok(updated_dict)` if the given key existed, and otherwise
+  `Error(Nil)`.
+
 ## v0.39.0 - Unreleased
 
 - The `min` and `max` functions of the `order` module have been deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.39.0 - Unreleased
 
 - The `min` and `max` functions of the `order` module have been deprecated.
-- The `dict` module function `update` has been deprecated in favour of `upsert`
-  and `update` will be used with a different signature in future.
+- The `update` function of the `dict` module has been deprecated in favour
+  of `upsert` and `update` will be used with a different signature in future.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -457,8 +457,8 @@ pub fn upsert(
 }
 
 /// Returns a result with either
-/// - A new Dict with with one entry updated using a given function.
-/// - An error with `Nil` if the key was not found in the dict.
+/// - An `Ok` with a `Dict` with with one entry updated using a given function.
+/// - An `Error(Nil)` if the key was not found in the `Dict`.
 ///
 /// ## Example
 ///

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -421,7 +421,7 @@ pub fn drop(from dict: Dict(k, v), drop disallowed_keys: List(k)) -> Dict(k, v) 
   }
 }
 
-/// Creates a new dict with one entry updated using a given function.
+/// Creates a new dict with one entry inserted or updated using a given function.
 ///
 /// If there was not an entry in the dict for the given key then the function
 /// gets `None` as its argument, otherwise it gets `Some(value)`.
@@ -437,14 +437,14 @@ pub fn drop(from dict: Dict(k, v), drop disallowed_keys: List(k)) -> Dict(k, v) 
 ///   }
 /// }
 ///
-/// update(dict, "a", increment)
+/// upsert(dict, "a", increment)
 /// // -> from_list([#("a", 1)])
 ///
-/// update(dict, "b", increment)
+/// upsert(dict, "b", increment)
 /// // -> from_list([#("a", 0), #("b", 0)])
 /// ```
 ///
-pub fn update(
+pub fn upsert(
   in dict: Dict(k, v),
   update key: k,
   with fun: fn(Option(v)) -> v,
@@ -454,6 +454,20 @@ pub fn update(
   |> option.from_result
   |> fun
   |> insert(dict, key, _)
+}
+
+/// This function with this signature is deprecated.
+///
+/// In future this fuction will return an `Ok(Dict)` if the given key existed and
+/// thus could be updated in the `Dict` or an an `Error(Nil)` if the key was not found.
+///
+@deprecated("Use `upsert` instead")
+pub fn update(
+  in dict: Dict(k, v),
+  update key: k,
+  with fun: fn(Option(v)) -> v,
+) -> Dict(k, v) {
+  upsert(dict, key, fun)
 }
 
 fn do_fold(list: List(#(k, v)), initial: acc, fun: fn(acc, k, v) -> acc) -> acc {

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1245,7 +1245,7 @@ fn group_updater(
 ) -> fn(Dict(key, List(element)), element) -> Dict(key, List(element)) {
   fn(groups, elem) {
     groups
-    |> dict.update(f(elem), update_group_with(elem))
+    |> dict.upsert(f(elem), update_group_with(elem))
   }
 }
 

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -176,7 +176,7 @@ pub fn delete_test() {
   |> should.equal(dict.from_list([#("b", 1), #("c", 2)]))
 }
 
-pub fn update_test() {
+pub fn upsert_test() {
   let dict = dict.from_list([#("a", 0), #("b", 1), #("c", 2)])
 
   let inc_or_zero = fn(x) {
@@ -187,15 +187,15 @@ pub fn update_test() {
   }
 
   dict
-  |> dict.update("a", inc_or_zero)
+  |> dict.upsert("a", inc_or_zero)
   |> should.equal(dict.from_list([#("a", 1), #("b", 1), #("c", 2)]))
 
   dict
-  |> dict.update("b", inc_or_zero)
+  |> dict.upsert("b", inc_or_zero)
   |> should.equal(dict.from_list([#("a", 0), #("b", 2), #("c", 2)]))
 
   dict
-  |> dict.update("z", inc_or_zero)
+  |> dict.upsert("z", inc_or_zero)
   |> should.equal(dict.from_list([#("a", 0), #("b", 1), #("c", 2), #("z", 0)]))
 }
 

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -179,7 +179,7 @@ pub fn delete_test() {
 pub fn upsert_test() {
   let dict = dict.from_list([#("a", 0), #("b", 1), #("c", 2)])
 
-  let inc_or_zero = fn(x) {
+  let increment_or_zero = fn(x) {
     case x {
       Some(i) -> i + 1
       None -> 0
@@ -187,16 +187,34 @@ pub fn upsert_test() {
   }
 
   dict
-  |> dict.upsert("a", inc_or_zero)
+  |> dict.upsert("a", increment_or_zero)
   |> should.equal(dict.from_list([#("a", 1), #("b", 1), #("c", 2)]))
 
   dict
-  |> dict.upsert("b", inc_or_zero)
+  |> dict.upsert("b", increment_or_zero)
   |> should.equal(dict.from_list([#("a", 0), #("b", 2), #("c", 2)]))
 
   dict
-  |> dict.upsert("z", inc_or_zero)
+  |> dict.upsert("z", increment_or_zero)
   |> should.equal(dict.from_list([#("a", 0), #("b", 1), #("c", 2), #("z", 0)]))
+}
+
+pub fn update_test() {
+  let dict = dict.from_list([#("a", 0), #("b", 1), #("c", 2)])
+
+  let increment = fn(x) { x + 1 }
+
+  dict
+  |> dict.update("a", increment)
+  |> should.equal(Ok(dict.from_list([#("a", 1), #("b", 1), #("c", 2)])))
+
+  dict
+  |> dict.update("b", increment)
+  |> should.equal(Ok(dict.from_list([#("a", 0), #("b", 2), #("c", 2)])))
+
+  dict
+  |> dict.update("z", increment)
+  |> should.equal(Error(Nil))
 }
 
 pub fn fold_test() {


### PR DESCRIPTION
1. Target branch should be inoas:create-upsert - this branch is rebased to that.
2. Do not merge into next release, but the one after

Followup to https://github.com/gleam-lang/stdlib/issues/570
~~Potentially closes https://github.com/gleam-lang/stdlib/issues/599~~

