### PR TITLE
Adjust unwrap_both examples

### DIFF
--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -246,13 +246,18 @@ pub fn unwrap_error(result: Result(a, e), or default: e) -> e {
 /// ## Examples
 ///
 /// ```gleam
-/// unwrap_both(Error(1))
+/// let ok_result: Result(int, int) = Ok(1)
+/// unwrap_both(ok_result)
 /// // -> 1
-/// ```
 ///
-/// ```gleam
-/// unwrap_both(Ok(2))
+/// let err_result: Result(int, int) = Err(2)
+/// unwrap_both(err_result)
 /// // -> 2
+///
+/// // This fails!
+/// let err_result: Result(String, int) = Ok("Hello!")
+/// unwrap_both(err_result)
+/// // Type mismatch, expected Result(String, String) but got Result(String, Int)
 /// ```
 ///
 pub fn unwrap_both(result: Result(a, a)) -> a {


### PR DESCRIPTION
I tried to be a bit more verbose for the two examples to highlight the same type is needed for the Result-type.

Is it too verbose? Happy to get feedback.

I built it locally to get a feel for how it looks like with the LSP help.

![image](https://github.com/gleam-lang/stdlib/assets/6134511/7ce91a5b-a1db-4d60-a5e1-293d33761beb)
