### PR TITLE
Fix infinite recursion loop in `list.window` when `by` is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.39.0 - Unreleased
 
+- Fixed `list.window` entering an endless recursive loop for `n` = 0.
 - The `min` and `max` functions of the `order` module have been deprecated.
 
 ## v0.38.0 - 2024-05-24

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1886,8 +1886,10 @@ fn do_window(acc: List(List(a)), l: List(a), n: Int) -> List(List(a)) {
 /// ```
 ///
 pub fn window(l: List(a), by n: Int) -> List(List(a)) {
-  do_window([], l, n)
-  |> reverse
+  case n <= 0 {
+    True -> []
+    False -> do_window([], l, n) |> reverse
+  }
 }
 
 /// Returns a list of tuples containing two contiguous elements.

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1061,6 +1061,10 @@ pub fn window_test() {
   |> list.window(0)
   |> should.equal([])
 
+  [1, 2, 3]
+  |> list.window(-1)
+  |> should.equal([])
+
   // TCO test
   list.range(0, recursion_test_cycles)
   |> list.window(2)

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1057,6 +1057,10 @@ pub fn window_test() {
   |> list.window(3)
   |> should.equal([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
 
+  [1, 2, 3]
+  |> list.window(0)
+  |> should.equal([])
+
   // TCO test
   list.range(0, recursion_test_cycles)
   |> list.window(2)


### PR DESCRIPTION
- Fix for #612 , it makes the return value of this edge case default to an empty list