### PR TITLE
Add `dict.map_keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed `list.window` entering an endless recursive loop for `n` = 0.
 - The `min` and `max` functions of the `order` module have been deprecated.
 - The `dict` and `set` modules gain the `is_empty` function.
-- The `dict` module gain the `map_keys` function.
+- The `dict` module gains the `map_keys` function.
 - Fixed `string.inspect` not formatting ASCII escape codes on Erlang that could
   lead to unexpected behavior. Now, all ASCII escape codes less than 32, as well
   as escape code 127, are converted into `\u{xxxx}` syntax, except for common

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `list.window` entering an endless recursive loop for `n` = 0.
 - The `min` and `max` functions of the `order` module have been deprecated.
 - The `dict` and `set` modules gain the `is_empty` function.
+- The `dict` module gain the `map_keys` function.
 - Fixed `string.inspect` not formatting ASCII escape codes on Erlang that could
   lead to unexpected behavior. Now, all ASCII escape codes less than 32, as well
   as escape code 127, are converted into `\u{xxxx}` syntax, except for common

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -204,6 +204,28 @@ fn do_map_values(f: fn(key, value) -> b, dict: Dict(key, value)) -> Dict(key, b)
   |> fold(from: new(), with: f)
 }
 
+/// Updates all keys in a dict by applying a function to each entry.
+/// 
+/// If two entries are mapped to the same key, the value of the latter entry
+/// will overwrite the value of the former one.
+/// 
+/// Do not rely on the order in which entries are processed by this function,
+/// as it may change in future versions of Gleam or Erlang.
+///
+/// ## Examples
+///
+/// ```gleam
+/// from_list([#(3, 3), #(2, 4)])
+/// |> map_keys(fn(key, value) { key * value })
+/// // -> from_list([#(9, 3), #(8, 4)])
+/// ```
+///
+pub fn map_keys(in dict: Dict(k, v), with fun: fn(k, v) -> w) -> Dict(w, v) {
+  let key_update = fn(d, k, v) { insert(d, fun(k, v), v) }
+  dict
+  |> fold(from: new(), with: key_update)
+}
+
 /// Gets a list of all keys in a given dict.
 ///
 /// Dicts are not ordered so the keys are not returned in any specific order. Do

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -116,6 +116,19 @@ pub fn map_values_test() {
   |> should.equal(dict.from_list([#(1, 1), #(2, 3), #(3, 5)]))
 }
 
+pub fn map_keys_test() {
+  [#(0, 1), #(2, 1), #(3, 2)]
+  |> dict.from_list
+  |> dict.map_keys(fn(k, v) { k + v })
+  |> should.equal(dict.from_list([#(1, 1), #(3, 1), #(5, 2)]))
+
+  [#(1, 1), #(2, 0), #(0, 2), #(-1, 3)]
+  |> dict.from_list
+  |> dict.map_keys(fn(k, v) { k + v })
+  |> dict.size()
+  |> should.equal(1)
+}
+
 pub fn keys_test() {
   [#("a", 0), #("b", 1), #("c", 2)]
   |> dict.from_list


### PR DESCRIPTION
Added a similar to `dict.map_values` function for keys mapping.

Inspired by implementation in [Kotlin](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/map-keys.html).
