### PR TITLE
Fix incorrect example in the `iterator.last` docs

### DIFF
--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1319,7 +1319,7 @@ pub fn reduce(
 ///
 /// ```gleam
 /// range(1, 10) |> last
-/// // -> Ok(9)
+/// // -> Ok(10)
 /// ```
 ///
 pub fn last(iterator: Iterator(element)) -> Result(element, Nil) {


### PR DESCRIPTION
Fix an incorrect example in the `iterator.last` docs