### PR TITLE
Don't wait for next value in iterator.yield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - The `update` function of the `dict` module has been deprecated in favour
   of `upsert` and `update` will be used with a different signature in future.
 - The behaviour of the string trim functions is now consistent across targets.
+- `iterator.yield` now yields values without waiting for the next one to become
+  available.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -1617,5 +1617,5 @@ pub fn each(over iterator: Iterator(a), with f: fn(a) -> b) -> Nil {
 /// ```
 ///
 pub fn yield(element: a, next: fn() -> Iterator(a)) -> Iterator(a) {
-  Iterator(fn() { Continue(element, next().continuation) })
+  Iterator(fn() { Continue(element, fn() { next().continuation() }) })
 }

--- a/test/gleam/iterator_test.gleam
+++ b/test/gleam/iterator_test.gleam
@@ -699,3 +699,18 @@ pub fn yield_test() {
   |> iterator.to_list
   |> should.equal([1, 2, 3])
 }
+
+pub fn yield_computes_only_necessary_values_test() {
+  let items = {
+    use <- iterator.yield(1)
+    use <- iterator.yield(2)
+    use <- iterator.yield(3)
+    iterator.empty()
+    panic as "yield computed more values than necessary"
+  }
+
+  items
+  |> iterator.take(3)
+  |> iterator.to_list
+  |> should.equal([1, 2, 3])
+}


### PR DESCRIPTION
Closes #624

When using the `iterator.yield` function, yield the value without waiting for the next one to become available.