### PR TITLE
Compute is_odd and is_even with bitwise op.

### DIFF
--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -389,7 +389,7 @@ pub fn max(a: Int, b: Int) -> Int {
 /// ```
 ///
 pub fn is_even(x: Int) -> Bool {
-  x % 2 == 0
+  bitwise_and(x, 1) == 0
 }
 
 /// Returns whether the value provided is odd.
@@ -407,7 +407,7 @@ pub fn is_even(x: Int) -> Bool {
 /// ```
 ///
 pub fn is_odd(x: Int) -> Bool {
-  x % 2 != 0
+  bitwise_and(x, 1) != 0
 }
 
 /// Returns the negative of the value provided.


### PR DESCRIPTION
These predicates can be implemented with a `bitwise_and`.  
In binary all the digits are even (i.e. power of 2) except for the least significant bit, if such bit is set then number is odd otherwise it is even.  
Usually using the bitwise operation result in fewer instruction to execute.
If interested, more on bit manipulation can be found [here](https://graphics.stanford.edu/~seander/bithacks.html). 
Have a nice day.