### PR TITLE
Correct implementation of uri.origin and add tests for default ports

### DIFF
--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -374,20 +374,18 @@ pub fn to_string(uri: Uri) -> String {
 ///
 pub fn origin(uri: Uri) -> Result(String, Nil) {
   let Uri(scheme: scheme, host: host, port: port, ..) = uri
-  case scheme {
-    Some("https") if port == Some(443) -> {
-      let origin = Uri(scheme, None, host, None, "", None, None)
-      Ok(to_string(origin))
+  case host, scheme {
+    Some(h), Some("https") if port == Some(443) ->
+      Ok(string.concat(["https://", h]))
+    Some(h), Some("http") if port == Some(80) ->
+      Ok(string.concat(["http://", h]))
+    Some(h), Some(s) if s == "http" || s == "https" -> {
+      case port {
+        Some(p) -> Ok(string.concat([s, "://", h, ":", int.to_string(p)]))
+        None -> Ok(string.concat([s, "://", h]))
+      }
     }
-    Some("http") if port == Some(80) -> {
-      let origin = Uri(scheme, None, host, None, "", None, None)
-      Ok(to_string(origin))
-    }
-    Some(s) if s == "http" || s == "https" -> {
-      let origin = Uri(scheme, None, host, port, "", None, None)
-      Ok(to_string(origin))
-    }
-    _ -> Error(Nil)
+    _, _ -> Error(Nil)
   }
 }
 

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -409,19 +409,19 @@ pub fn parse_segments_test() {
 pub fn origin1_test() {
   let assert Ok(parsed) = uri.parse("http://example.test/path?weebl#bob")
   uri.origin(parsed)
-  |> should.equal(Ok("http://example.test/"))
+  |> should.equal(Ok("http://example.test"))
 }
 
 pub fn origin2_test() {
   let assert Ok(parsed) = uri.parse("http://example.test:8080")
   uri.origin(parsed)
-  |> should.equal(Ok("http://example.test:8080/"))
+  |> should.equal(Ok("http://example.test:8080"))
 }
 
 pub fn origin3_test() {
   let assert Ok(parsed) = uri.parse("https://example.test")
   uri.origin(parsed)
-  |> should.equal(Ok("https://example.test/"))
+  |> should.equal(Ok("https://example.test"))
 }
 
 pub fn origin4_test() {
@@ -446,6 +446,18 @@ pub fn origin7_test() {
   let assert Ok(parsed) = uri.parse("file:///dev/null")
   uri.origin(parsed)
   |> should.equal(Error(Nil))
+}
+
+pub fn origin8_test() {
+  let assert Ok(parsed) = uri.parse("https://mozilla.org:443/")
+  uri.origin(parsed)
+  |> should.equal(Ok("https://mozilla.org"))
+}
+
+pub fn origin9_test() {
+  let assert Ok(parsed) = uri.parse("http://localhost:80/")
+  uri.origin(parsed)
+  |> should.equal(Ok("http://localhost"))
 }
 
 pub fn merge1_test() {


### PR DESCRIPTION
`uri.origin` should not include a trailing slash - I've corrected the relevant tests and updated the function to `concat` its own results, as this behaviour appears specific to the `origin` function only, not `to_string`.

Additionally, I've added two tests to cover the default port stripping when `http` or `https` are supplied along wtih port `80` or `443` respectively.

Fixes https://github.com/gleam-lang/stdlib/issues/623.