### PR TITLE
Add set.map().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `list.window` entering an endless recursive loop for `n` = 0.
 - The `min` and `max` functions of the `order` module have been deprecated.
 - The `dict` and `set` modules gain the `is_empty` function.
+- The `set` module gains the `map` function.
 - Fixed `string.inspect` not formatting ASCII escape codes on Erlang that could
   lead to unexpected behavior. Now, all ASCII escape codes less than 32, as well
   as escape code 127, are converted into `\u{xxxx}` syntax, except for common

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -218,6 +218,21 @@ pub fn filter(
   Set(dict.filter(in: set.dict, keeping: fn(m, _) { predicate(m) }))
 }
 
+/// Creates a new set from a given set with the result of applying the given
+/// function to each member.
+///
+/// ## Examples
+///
+/// ```gleam
+/// map(from_list([1, 2, 3, 4], fn(x) { x * 2 }))
+/// // -> [2, 4, 6, 8]
+/// ```
+pub fn map(set: Set(member), with fun: fn(member) -> mapped) -> Set(mapped) {
+  fold(over: set, from: new(), with: fn(acc, member) {
+    insert(acc, fun(member))
+  })
+}
+
 /// Creates a new set from a given set with all the same entries except any
 /// entry found on the given list.
 ///

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -86,8 +86,8 @@ pub fn fold_test() {
 pub fn map_test() {
   [1, 2, 3, 4]
   |> set.from_list
-  |> set.map(with: fn(x) { x * 2 })
-  |> should.equal(set.from_list([2, 4, 6, 8]))
+  |> set.map(with: int.to_string)
+  |> should.equal(set.from_list(["1", "2", "3", "4"]))
 }
 
 pub fn filter_test() {

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -83,6 +83,13 @@ pub fn fold_test() {
   |> should.equal(13)
 }
 
+pub fn map_test() {
+  [1, 2, 3, 4]
+  |> set.from_list
+  |> set.map(with: fn(x) { x * 2 })
+  |> should.equal(set.from_list([2, 4, 6, 8]))
+}
+
 pub fn filter_test() {
   [1, 4, 6, 3, 675, 44, 67]
   |> set.from_list()


### PR DESCRIPTION
I had initially thought of proposing also adding `dict.map_keys()` and then implementing `set.map()` in terms of that function, but as I thought about it more, I couldn't think of a strong reason to add that other than just doing it for completeness' sake, so I did it in terms of `set.fold()` instead.

Resolves #636.