### PR TITLE
Add method map_reduce for list lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The `min` and `max` functions of the `order` module have been deprecated.
 - The `dict` and `set` modules gain the `is_empty` function.
 - The `set` module gains the `map` function.
+- The `list` module gains the `map_reduce` function.
 - Fixed `string.inspect` not formatting ASCII escape codes on Erlang that could
   lead to unexpected behavior. Now, all ASCII escape codes less than 32, as well
   as escape code 127, are converted into `\u{xxxx}` syntax, except for common

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2103,6 +2103,35 @@ pub fn reduce(over list: List(a), with fun: fn(a, a) -> a) -> Result(a, Nil) {
   }
 }
 
+/// This function acts similar to a map |> reduce, but with less overhead.
+///
+/// Returns an accumulated value based on the given `fun` and `initial` values.
+/// In case the list is empty, the `initial` value is returned.
+///
+/// ## Examples
+///
+/// ```gleam
+/// [] |> map_reduce(0, fn(acc, x) { acc + x })
+/// // -> 0
+/// ```
+///
+/// ```gleam
+/// [#("Red", 1), #("Orange", 2), #("Yellow", 3), #("Green", 4)]
+/// |> reduce(fn(acc, tuple) { acc + tuple.1 })
+/// // -> 10
+/// ```
+///
+pub fn map_reduce(
+  over list: List(a),
+  from initial: acc,
+  with fun: fn(acc, a) -> acc,
+) -> acc {
+  case list {
+    [] -> initial
+    [x, ..rest] -> map_reduce(rest, fun(initial, x), fun)
+  }
+}
+
 fn do_scan(
   list: List(a),
   accumulator: acc,

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1155,6 +1155,16 @@ pub fn reduce_test() {
   |> should.equal(Ok(15))
 }
 
+pub fn map_reduce_test() {
+  []
+  |> list.map_reduce(from: 0, with: fn(x, y) { x + y })
+  |> should.equal(0)
+
+  [#("EN", 1), #("BR", 3), #("JP", 2)]
+  |> list.map_reduce(from: 0, with: fn(acc, tuple) { acc + tuple.1 })
+  |> should.equal(6)
+}
+
 pub fn scan_test() {
   []
   |> list.scan(from: 0, with: fn(acc, i) { i + acc })


### PR DESCRIPTION
It can be beneficial to avoid having to map through a list to manipulate its data before reducing it, which would traverse the list twice.