### PR TITLE
Fix `float.parse` failing to parse exponential notation on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improved bit array Base64 encoding and decoding speed on JavaScript.
 - Fixed a bug where Base64 encoding a bit array larger than ~100KiB would throw
   an exception on JavaScript.
+- Fixed `float.parse` failing to parse exponential notation on JavaScript.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -34,7 +34,7 @@ export function parse_int(value) {
 }
 
 export function parse_float(value) {
-  if (/^[-+]?(\d+)\.(\d+)$/.test(value)) {
+  if (/^[-+]?(\d+)\.(\d+)([eE][-+]?\d+)?$/.test(value)) {
     return new Ok(parseFloat(value));
   } else {
     return new Error(Nil);

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -26,6 +26,18 @@ pub fn parse_test() {
   |> float.parse
   |> should.equal(Ok(0.123456789))
 
+  "1.234e10"
+  |> float.parse
+  |> should.equal(Ok(1.234e10))
+
+  "-1.234e+10"
+  |> float.parse
+  |> should.equal(Ok(-1.234e10))
+
+  "1.234e-10"
+  |> float.parse
+  |> should.equal(Ok(1.234e-10))
+
   ""
   |> float.parse
   |> should.equal(Error(Nil))


### PR DESCRIPTION
Fixes #640.