### PR TITLE
Base64 encoding optimisations. Fix encoding of large bit arrays on JS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - The behaviour of the string trim functions is now consistent across targets.
 - `iterator.yield` now yields values without waiting for the next one to become
   available.
+- Base64 encoding speed improvements. Encoding of bit arrays over ~100KiB to
+  Base64 on JavaScript no longer throws an exception.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -107,17 +107,9 @@ pub fn concat(bit_arrays: List(BitArray)) -> BitArray
 
 /// Encodes a BitArray into a base 64 encoded string.
 ///
-pub fn base64_encode(input: BitArray, padding: Bool) -> String {
-  let encoded = encode64(input)
-  case padding {
-    True -> encoded
-    False -> string.replace(encoded, "=", "")
-  }
-}
-
-@external(erlang, "base64", "encode")
+@external(erlang, "gleam_stdlib", "bit_array_base64_encode")
 @external(javascript, "../gleam_stdlib.mjs", "encode64")
-fn encode64(a: BitArray) -> String
+pub fn base64_encode(input: BitArray, padding: Bool) -> String
 
 /// Decodes a base 64 encoded string into a `BitArray`.
 ///

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -8,7 +8,8 @@
     bit_array_int_to_u32/1, bit_array_int_from_u32/1, decode_result/1,
     bit_array_slice/3, decode_bit_array/1, compile_regex/2, regex_scan/2,
     percent_encode/1, percent_decode/1, regex_check/2, regex_split/2,
-    base_decode64/1, parse_query/1, bit_array_concat/1, size_of_tuple/1,
+    base_decode64/1, parse_query/1, bit_array_concat/1,
+    bit_array_base64_encode/2, size_of_tuple/1,
     decode_tuple/1, decode_tuple2/1, decode_tuple3/1, decode_tuple4/1,
     decode_tuple5/1, decode_tuple6/1, tuple_get/2, classify_dynamic/1, print/1,
     println/1, print_error/1, println_error/1, inspect/1, float_to_string/1,
@@ -200,6 +201,9 @@ string_pop_grapheme(String) ->
 
 bit_array_concat(BitArrays) ->
     list_to_bitstring(BitArrays).
+
+bit_array_base64_encode(Bin, Padding) ->
+    base64:encode(Bin, #{padding => Padding}).
 
 bit_array_slice(Bin, Pos, Len) ->
     try {ok, binary:part(Bin, Pos, Len)}

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -1,6 +1,7 @@
 import gleam/bit_array
 import gleam/result
 import gleam/should
+import gleam/string
 
 pub fn byte_size_test() {
   bit_array.byte_size(bit_array.from_string("hello"))
@@ -145,6 +146,10 @@ pub fn base64_encode_test() {
   |> bit_array.base64_encode(True)
   |> should.equal("/3/+/A==")
 
+  <<255, 127, 254, 252, 100>>
+  |> bit_array.base64_encode(True)
+  |> should.equal("/3/+/GQ=")
+
   <<255, 127, 254, 252>>
   |> bit_array.base64_encode(False)
   |> should.equal("/3/+/A")
@@ -156,6 +161,12 @@ pub fn base64_encode_test() {
   <<>>
   |> bit_array.base64_encode(True)
   |> should.equal("")
+
+  string.repeat("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 1024 * 32)
+  |> bit_array.from_string
+  |> bit_array.base64_encode(True)
+  |> string.length
+  |> should.equal(1_398_104)
 }
 
 pub fn base64_decode_test() {


### PR DESCRIPTION
Fixes #642.

This replaces the implementation of Base64 encoding with a native JS implementation that is significantly faster, 13-14x in my benchmarks. It's based on https://github.com/mitschabaude/fast-base64/blob/main/js.js.

The new implementation works on large inputs, this was tested up to 128MiB on Node.js 22 with no issues.

The Erlang implementation also now gets `base64:encode` to add the padding to the returned string if it's requested, which optimises away a `string.replace` when padding isn't desired.