### PR TITLE
Fixed typo in docs for absolute_value func in int module.

### DIFF
--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -19,7 +19,7 @@ import gleam/order.{type Order}
 ///
 /// ```gleam
 /// absolute_value(-12)
-/// // -> 2
+/// // -> 12
 /// ```
 ///
 /// ```gleam


### PR DESCRIPTION
Fixed typo in docs for absolute_value func in int module. It should be 12, but 2. 