### PR TITLE
Improve Base64 decoding performance on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 - The behaviour of the string trim functions is now consistent across targets.
 - `iterator.yield` now yields values without waiting for the next one to become
   available.
-- Base64 encoding speed improvements. Encoding of bit arrays over ~100KiB to
-  Base64 on JavaScript no longer throws an exception.
+- Improved bit array Base64 encoding and decoding speed on JavaScript.
+- Fixed a bug where Base64 encoding a bit array larger than ~100KiB would throw
+  an exception on JavaScript.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -551,7 +551,11 @@ export function encode64(bit_array, padding) {
 export function decode64(sBase64) {
   try {
     const binString = atob(sBase64);
-    const array = Uint8Array.from(binString, (c) => c.charCodeAt(0));
+    const length = binString.length;
+    const array = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+        array[i] = binString.charCodeAt(i);
+    }
     return new Ok(new BitArray(array));
   } catch {
     return new Error(Nil);

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -162,11 +162,13 @@ pub fn base64_encode_test() {
   |> bit_array.base64_encode(True)
   |> should.equal("")
 
-  string.repeat("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 1024 * 32)
+  string.repeat("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 1024 * 32)
   |> bit_array.from_string
   |> bit_array.base64_encode(True)
-  |> string.length
-  |> should.equal(1_398_104)
+  |> should.equal(string.repeat(
+    "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
+    1024 * 32,
+  ))
 }
 
 pub fn base64_decode_test() {


### PR DESCRIPTION
This improves Base64 decoding speed on JavaScript by 5-30x in my benchmarks, with the greatest improvement seen on larger input sizes.

This PR also adjusts a recently added test that was causing the test suite to take 25 (!) minutes on Node.js versions prior to 22.0. This was caused by `string.length` being extremely slow on long strings on older Node.js versions, which I haven't investigated further at this stage.

---

Speedup with 8 byte input: 5x
Speedup with 64 byte input: 16x
Speedup with 1KiB input: 23x
Speedup with 1MiB input: 29x
Speedup with 16MiB input: 30x

Tested on Node.js 22 on a MacBook Pro M2.