### PR TITLE
Adjust dynamic.optional_field to better match documented behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   an exception on JavaScript.
 - Fixed `float.parse` failing to parse exponential notation on JavaScript.
 - The `regex` module gains the `replace` function.
+- The `dynamic.optional_field` decoder no longer treats the value as implicitly
+  optional. It only deals with the presence or absence of the key itself which
+  brings it inline with its documentation.
 
 ## v0.38.0 - 2024-05-24
 

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -3,7 +3,7 @@ import gleam/bit_array
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
-import gleam/option.{type Option}
+import gleam/option.{type Option, Some}
 import gleam/result
 import gleam/string_builder
 
@@ -452,8 +452,8 @@ pub fn optional_field(
     case maybe_inner {
       option.None -> Ok(option.None)
       option.Some(dynamic_inner) ->
-        dynamic_inner
-        |> decode_optional(inner_type)
+        inner_type(dynamic_inner)
+        |> result.map(Some)
         |> map_errors(push_path(_, name))
     }
   }

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -408,13 +408,30 @@ pub fn optional_field_test() {
   |> dict.insert("ok", None)
   |> dynamic.from
   |> dynamic.optional_field("ok", dynamic.int)
-  |> should.equal(Ok(None))
+  |> should.equal(
+    Error([DecodeError(expected: "Int", found: "Atom", path: ["ok"])]),
+  )
 
   dict.new()
   |> dict.insert("ok", Nil)
   |> dynamic.from
   |> dynamic.optional_field("ok", dynamic.int)
-  |> should.equal(Ok(None))
+  |> should.equal(
+    Error([DecodeError(expected: "Int", found: "Nil", path: ["ok"])]),
+  )
+
+  // optional_field and optional should combine together to give nested Options
+  dict.new()
+  |> dict.insert("ok", Nil)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.optional(dynamic.int))
+  |> should.equal(Ok(Some(None)))
+
+  dict.new()
+  |> dict.insert("ok", 4)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.optional(dynamic.int))
+  |> should.equal(Ok(Some(Some(4))))
 
   dict.new()
   |> dynamic.from

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -405,14 +405,6 @@ pub fn optional_field_test() {
   )
 
   dict.new()
-  |> dict.insert("ok", None)
-  |> dynamic.from
-  |> dynamic.optional_field("ok", dynamic.int)
-  |> should.equal(
-    Error([DecodeError(expected: "Int", found: "Atom", path: ["ok"])]),
-  )
-
-  dict.new()
   |> dict.insert("ok", Nil)
   |> dynamic.from
   |> dynamic.optional_field("ok", dynamic.int)
@@ -450,6 +442,30 @@ pub fn optional_field_test() {
   |> dynamic.optional_field("ok", dynamic.int)
   |> should.equal(
     Error([DecodeError(expected: "Dict", found: "List", path: [])]),
+  )
+}
+
+// Error is different for erlang & javascript
+@target(javascript)
+pub fn optional_field_error_test() {
+  dict.new()
+  |> dict.insert("ok", None)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(
+    Error([DecodeError(expected: "Int", found: "Object", path: ["ok"])]),
+  )
+}
+
+// Error is different for erlang & javascript
+@target(erlang)
+pub fn optional_field_error_test() {
+  dict.new()
+  |> dict.insert("ok", None)
+  |> dynamic.from
+  |> dynamic.optional_field("ok", dynamic.int)
+  |> should.equal(
+    Error([DecodeError(expected: "Int", found: "Atom", path: ["ok"])]),
   )
 }
 


### PR DESCRIPTION
As discussed on Discord, I believe the `dynamic.optional_field` behaviour is a bit off and this PR tries to adjust it to match the documented behaviour.

The use of `decode_optional` in the implementation meant that the value was optional as well as the key which means that each use of `optional_field` was implicitly wrapping its value decoder in `dynamic.optional`.

Awkwardly this is a breaking change in behaviour but not in types. We can now get `Some(None)` back which I don't think was previously possible and we get an error in situations where we didn't before.

I'm not sure if the per-target tests is how you like to manage that situation.