### PR TITLE
Remove target annotations

### DIFF
--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -76,21 +76,16 @@ pub fn to_string(bits: BitArray) -> Result(String, Nil) {
   do_to_string(bits)
 }
 
-@target(erlang)
 @external(erlang, "gleam_stdlib", "identity")
 fn unsafe_to_string(a: BitArray) -> String
 
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "bit_array_to_string")
 fn do_to_string(bits: BitArray) -> Result(String, Nil) {
   case is_utf8(bits) {
     True -> Ok(unsafe_to_string(bits))
     False -> Error(Nil)
   }
 }
-
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "bit_array_to_string")
-fn do_to_string(a: BitArray) -> Result(String, Nil)
 
 /// Creates a new bit array by joining multiple binaries.
 ///

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -1,4 +1,3 @@
-@target(erlang)
 import gleam/bit_array
 import gleam/dict.{type Dict}
 import gleam/int
@@ -105,7 +104,7 @@ fn map_errors(
   result.map_error(result, list.map(_, f))
 }
 
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "decode_string")
 fn decode_string(data: Dynamic) -> Result(String, DecodeErrors) {
   bit_array(data)
   |> map_errors(put_expected(_, "String"))
@@ -118,14 +117,9 @@ fn decode_string(data: Dynamic) -> Result(String, DecodeErrors) {
   })
 }
 
-@target(erlang)
 fn put_expected(error: DecodeError, expected: String) -> DecodeError {
   DecodeError(..error, expected: expected)
 }
-
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "decode_string")
-fn decode_string(a: Dynamic) -> Result(String, DecodeErrors)
 
 /// Return a string indicating the type of the dynamic value.
 ///

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -239,11 +239,7 @@ pub fn round(x: Float) -> Int {
   do_round(x)
 }
 
-@target(erlang)
 @external(erlang, "erlang", "round")
-fn do_round(a: Float) -> Int
-
-@target(javascript)
 fn do_round(x: Float) -> Int {
   case x >=. 0.0 {
     True -> js_round(x)
@@ -251,7 +247,6 @@ fn do_round(x: Float) -> Int {
   }
 }
 
-@target(javascript)
 @external(javascript, "../gleam_stdlib.mjs", "round")
 fn js_round(a: Float) -> Int
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -385,11 +385,7 @@ pub fn split_once(
   do_split_once(x, substring)
 }
 
-@target(erlang)
-@external(erlang, "string", "split")
-fn erl_split(a: String, b: String) -> List(String)
-
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "split_once")
 fn do_split_once(x: String, substring: String) -> Result(#(String, String), Nil) {
   case erl_split(x, substring) {
     [first, rest] -> Ok(#(first, rest))
@@ -397,12 +393,8 @@ fn do_split_once(x: String, substring: String) -> Result(#(String, String), Nil)
   }
 }
 
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "split_once")
-fn do_split_once(
-  x x: String,
-  substring substring: String,
-) -> Result(#(String, String), Nil)
+@external(erlang, "string", "split")
+fn erl_split(a: String, b: String) -> List(String)
 
 /// Creates a new `String` by joining two `String`s together.
 ///
@@ -565,25 +557,19 @@ pub fn trim(string: String) -> String {
   do_trim(string)
 }
 
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "trim")
 fn do_trim(string: String) -> String {
   erl_trim(string, Both)
 }
 
-@target(erlang)
+@external(erlang, "string", "trim")
+fn erl_trim(a: String, b: Direction) -> String
+
 type Direction {
   Leading
   Trailing
   Both
 }
-
-@target(erlang)
-@external(erlang, "string", "trim")
-fn erl_trim(a: String, b: Direction) -> String
-
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "trim")
-fn do_trim(string string: String) -> String
 
 /// Removes whitespace on the left of a `String`.
 ///
@@ -598,14 +584,10 @@ pub fn trim_left(string: String) -> String {
   do_trim_left(string)
 }
 
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "trim_left")
 fn do_trim_left(string: String) -> String {
   erl_trim(string, Leading)
 }
-
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "trim_left")
-fn do_trim_left(string string: String) -> String
 
 /// Removes whitespace on the right of a `String`.
 ///
@@ -620,14 +602,10 @@ pub fn trim_right(string: String) -> String {
   do_trim_right(string)
 }
 
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "trim_right")
 fn do_trim_right(string: String) -> String {
   erl_trim(string, Trailing)
 }
-
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "trim_right")
-fn do_trim_right(string string: String) -> String
 
 /// Splits a non-empty `String` into its first element (head) and rest (tail).
 /// This lets you pattern match on `String`s exactly as you would with lists.

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -165,11 +165,7 @@ pub fn reverse(builder: StringBuilder) -> StringBuilder {
   do_reverse(builder)
 }
 
-@target(erlang)
 @external(erlang, "string", "reverse")
-fn do_reverse(a: StringBuilder) -> StringBuilder
-
-@target(javascript)
 fn do_reverse(builder: StringBuilder) -> StringBuilder {
   builder
   |> to_string
@@ -178,7 +174,6 @@ fn do_reverse(builder: StringBuilder) -> StringBuilder {
   |> from_strings
 }
 
-@target(javascript)
 @external(javascript, "../gleam_stdlib.mjs", "graphemes")
 fn do_to_graphemes(string string: String) -> List(String)
 
@@ -188,26 +183,17 @@ pub fn split(iodata: StringBuilder, on pattern: String) -> List(StringBuilder) {
   do_split(iodata, pattern)
 }
 
-@target(erlang)
 type Direction {
   All
 }
 
-@target(erlang)
-@external(erlang, "string", "split")
-fn erl_split(a: StringBuilder, b: String, c: Direction) -> List(StringBuilder)
-
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "split")
 fn do_split(iodata: StringBuilder, pattern: String) -> List(StringBuilder) {
   erl_split(iodata, pattern, All)
 }
 
-@target(javascript)
-@external(javascript, "../gleam_stdlib.mjs", "split")
-fn do_split(
-  builder builder: StringBuilder,
-  pattern pattern: String,
-) -> List(StringBuilder)
+@external(erlang, "string", "split")
+fn erl_split(a: StringBuilder, b: String, c: Direction) -> List(StringBuilder)
 
 /// Replaces all instances of a pattern with a given string substitute.
 ///

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -10,11 +10,8 @@
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
-@target(javascript)
 import gleam/pair
-@target(javascript)
 import gleam/regex
-@target(javascript)
 import gleam/result
 import gleam/string
 import gleam/string_builder.{type StringBuilder}
@@ -60,11 +57,7 @@ pub fn parse(uri_string: String) -> Result(Uri, Nil) {
   do_parse(uri_string)
 }
 
-@target(erlang)
 @external(erlang, "gleam_stdlib", "uri_parse")
-fn do_parse(a: String) -> Result(Uri, Nil)
-
-@target(javascript)
 fn do_parse(uri_string: String) -> Result(Uri, Nil) {
   // From https://tools.ietf.org/html/rfc3986#appendix-B
   let pattern =
@@ -120,7 +113,6 @@ fn do_parse(uri_string: String) -> Result(Uri, Nil) {
   ))
 }
 
-@target(javascript)
 fn regex_submatches(pattern: String, string: String) -> List(Option(String)) {
   pattern
   |> regex.compile(regex.Options(case_insensitive: True, multi_line: False))
@@ -131,7 +123,6 @@ fn regex_submatches(pattern: String, string: String) -> List(Option(String)) {
   |> result.unwrap([])
 }
 
-@target(javascript)
 fn noneify_query(x: Option(String)) -> Option(String) {
   case x {
     None -> None
@@ -143,7 +134,6 @@ fn noneify_query(x: Option(String)) -> Option(String) {
   }
 }
 
-@target(javascript)
 fn noneify_empty_string(x: Option(String)) -> Option(String) {
   case x {
     Some("") | None -> None
@@ -152,7 +142,6 @@ fn noneify_empty_string(x: Option(String)) -> Option(String) {
 }
 
 // Split an authority into its userinfo, host and port parts.
-@target(javascript)
 fn split_authority(
   authority: Option(String),
 ) -> #(Option(String), Option(String), Option(Int)) {
@@ -181,13 +170,11 @@ fn split_authority(
   }
 }
 
-@target(javascript)
 fn pad_list(list: List(Option(a)), size: Int) -> List(Option(a)) {
   list
   |> list.append(list.repeat(None, extra_required(list, size)))
 }
 
-@target(javascript)
 fn extra_required(list: List(a), remaining: Int) -> Int {
   case list {
     _ if remaining == 0 -> 0

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -30,6 +30,8 @@ pub fn append_test() {
   |> should.equal(<<1, 2, 3, 4>>)
 }
 
+// This test is target specific since it's using non byte-aligned BitArrays
+// and those are not supported on the JavaScript target.
 @target(erlang)
 pub fn append_erlang_only_test() {
   <<1, 2:4>>
@@ -47,6 +49,8 @@ pub fn concat_test() {
   |> should.equal(<<1, 2, 3, 4>>)
 }
 
+// This test is target specific since it's using non byte-aligned BitArrays
+// and those are not supported on the JavaScript target.
 @target(erlang)
 pub fn concat_erlang_only_test() {
   [<<1, 2:4>>, <<3>>]
@@ -314,6 +318,8 @@ pub fn inspect_test() {
   |> should.equal("<<0, 20, 32, 255>>")
 }
 
+// This test is target specific since it's using non byte-aligned BitArrays
+// and those are not supported on the JavaScript target.
 @target(erlang)
 pub fn inspect_partial_bytes_test() {
   bit_array.inspect(<<4:5>>)


### PR DESCRIPTION
I've removed as many `target` annotations as I could. Some are still left in tests (but that makes sense since we want to check different behaviours on different targets) and in some modules but those are way less frequent now :)