### PR TITLE
Add io.debug_note

### DIFF
--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -116,3 +116,37 @@ pub fn debug(term: anything) -> anything {
 @external(erlang, "gleam_stdlib", "println_error")
 @external(javascript, "../gleam_stdlib.mjs", "print_debug")
 fn do_debug_println(string string: String) -> Nil
+
+/// Prints a string notating a value and the value itself to standard 
+/// error (stderr) yielding Gleam syntax.
+///
+/// Only the value is returned after being printed so it can be used in 
+/// pipelines.
+///
+/// ## Example
+///
+/// ```gleam
+/// debug_note("Hi mum", with: "This is my greeting")
+/// // -> "Hi mum"
+/// // This is my greeting: "Hi mum"
+/// ```
+///
+/// ```gleam
+/// import gleam/list
+///
+/// [1, 2]
+/// |> list.map(fn(x) { x + 1 })
+/// |> debug_note("After adding 1")
+/// |> list.map(fn(x) { x * 2 })
+/// |> debug_note("After multiplying by 2")
+/// // -> [4, 6]
+/// // After adding 1: [2, 3]
+/// // After multiplying by 2: [4, 6]
+/// ```
+///
+pub fn debug_note(term: anything, with note: String) -> anything {
+  { note <> ": " <> string.inspect(term) }
+  |> do_debug_println
+
+  term
+}


### PR DESCRIPTION
I had this idea and it was simple so I thought I'd implement it quickly instead of creating a discussion first. I often find myself wanting to add notes along with debug statements in pipelines, and would love a function like this in the stdlib. Feel free to do whatever you want with this PR, I know it is coming out of the blue. If the function or argument names need to be changed that is fine with me! Let me know if there's anything you'd like updated or if it can't be merged at all for some reason.