### PR TITLE
fix typo in dict examples

### DIFF
--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -419,7 +419,7 @@ fn do_delete(a: k, b: Dict(k, v)) -> Dict(k, v)
 ///
 /// ```gleam
 /// from_list([#("a", 0), #("b", 1)]) |> drop(["a"])
-/// // -> from_list([#("b", 2)])
+/// // -> from_list([#("b", 1)])
 /// ```
 ///
 /// ```gleam


### PR DESCRIPTION
I think there was a small typo in the dict examples.