### PR TITLE
Deduplicate gleam/order negate examples

### DIFF
--- a/src/gleam/order.gleam
+++ b/src/gleam/order.gleam
@@ -28,8 +28,8 @@ pub type Order {
 /// ```
 ///
 /// ```gleam
-/// negate(Lt)
-/// // -> Gt
+/// negate(Gt)
+/// // -> Lt
 /// ```
 ///
 pub fn negate(order: Order) -> Order {


### PR DESCRIPTION
Deletes duplicate `negate(Lt)` example in **gleam/order**. Replaces it with `negate(Gt)` to exhaustively complete the examples.