### PR TITLE
Add a shared cache for regex compilation in the Erlang target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   an exception on JavaScript.
 - Fixed `float.parse` failing to parse exponential notation on JavaScript.
 - The `regex` module gains the `replace` function.
+- The `regex` module will now cache compiled regexes on Erlang.
 
 ## v0.38.0 - 2024-05-24
 


### PR DESCRIPTION
Fixes #655 

I haven't tested this extensively, but I have run this commit against the commonmark test suite and:

1. All the tests still pass, and those tests run a lot of different regexes many times.
2. The benchmarks on the commit before I introduced regex caching into the library went from an average of `2.53ms` to `1.42ms` on my hardware. This isn't quite as good as caching directly in memory (`1.31ms`), but it's still a tonne better for most people.

I haven't explicitly tested multi-process applications but they should function correctly, even if the caching doesn't work. However, from my reading the `public` option makes the ETS available across processes, and `named_table` means that other processes can look it up by name so this *should* be a globally available cache rather than per-process as I initially speculated.