### PR TITLE
Fixing wrong argument name in the doc example for set.filter

### DIFF
--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -206,7 +206,7 @@ pub fn fold(
 /// import gleam/int
 ///
 /// from_list([1, 4, 6, 3, 675, 44, 67])
-/// |> filter(for: int.is_even)
+/// |> filter(keeping: int.is_even)
 /// |> to_list
 /// // -> [4, 6, 44]
 /// ```


### PR DESCRIPTION
Unsure why the docs was using the wrong argument name here, but this PR fixes the small typo to prevent confusion :)