### PR TITLE
fix: Fix js trim implementation removing commas

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -256,7 +256,7 @@ const unicode_whitespaces = [
   "\u0085", // Next line
   "\u2028", // Line separator
   "\u2029", // Paragraph separator
-].join();
+].join("");
 
 const left_trim_regex = new RegExp(`^([${unicode_whitespaces}]*)`, "g");
 const right_trim_regex = new RegExp(`([${unicode_whitespaces}]*)$`, "g");

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -358,6 +358,12 @@ pub fn trim_zero_width_non_breaking_space_test() {
   |> should.equal("hats\u{FEFF}")
 }
 
+pub fn trim_comma_test() {
+  "hats,"
+  |> string.trim
+  |> should.equal(",hats,")
+}
+
 pub fn starts_with_test() {
   "theory"
   |> string.starts_with("")

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -361,7 +361,7 @@ pub fn trim_zero_width_non_breaking_space_test() {
 pub fn trim_comma_test() {
   "hats,"
   |> string.trim
-  |> should.equal(",hats,")
+  |> should.equal("hats,")
 }
 
 pub fn starts_with_test() {


### PR DESCRIPTION
JS uses the comma by default when no separator is passed to `Array.prototype.join` so `unicode_whitespaces` is ` ,\t,\n,\x0B,\f,\r,\x85, , ` rather than just a string of whitespaces.

Fixed by passing an empty string to `join`.