### PR TITLE
Add `list.group_last`

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -301,6 +301,39 @@ pub fn group(list: List(v), by key: fn(v) -> k) -> Dict(k, List(v)) {
   fold(list, dict.new(), update_group(key))
 }
 
+/// Takes a list and creates a lookup table by a key
+/// which is built from a key function.
+/// 
+/// If the same key maps to multiple elements,
+/// only the last element in each group will be kept.
+/// 
+/// ## Examples
+/// 
+/// ```gleam
+/// import gleam/dict
+/// impor gleam/string
+/// 
+/// ["Apple", "Cherry", "Orange", "Apricots"]
+/// |> group_last(by: fn(fruit) { string.slice(fruit, 0, 1) })
+/// // -> dict.from_list([#("A", "Apricots"), #("C", "Cherry"), #("O", Orange)])
+/// ```
+/// 
+/// ```gleam
+/// import gleam/dict
+/// 
+/// [#("Alice", 42), #("Bob", 24), #("Cosmo", 27)]
+/// |> group_last(by: fn(user) { user.1 })
+/// // -> dict.from_list([
+/// //    #(42, #("Alice", 42)),
+/// //    #(24, #("Bob", 24)),
+/// //    #(27, #("Cosmo", 27)),
+/// // ])
+/// ```
+pub fn group_last(list: List(v), by key: fn(v) -> k) -> Dict(k, v) {
+  use table, elem <- fold(list, dict.new())
+  dict.insert(table, key(elem), elem)
+}
+
 fn do_filter(list: List(a), fun: fn(a) -> Bool, acc: List(a)) -> List(a) {
   case list {
     [] -> reverse(acc)

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -315,7 +315,7 @@ pub fn group(list: List(v), by key: fn(v) -> k) -> Dict(k, List(v)) {
 /// 
 /// ["Apple", "Cherry", "Orange", "Apricots"]
 /// |> group_last(by: fn(fruit) { string.slice(fruit, 0, 1) })
-/// // -> dict.from_list([#("A", "Apricots"), #("C", "Cherry"), #("O", Orange)])
+/// // -> dict.from_list([#("A", "Apricots"), #("C", "Cherry"), #("O", "Orange")])
 /// ```
 /// 
 /// ```gleam

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -134,6 +134,20 @@ pub fn group_test() {
   )
 }
 
+pub fn group_last_test() {
+  ["Apple", "Cherry", "Orange", "Apricots"]
+  |> list.group_last(by: fn(fruit) { string.slice(fruit, 0, 1) })
+  |> should.equal(dict.from_list([#("A", "Apricots"), #("C", "Cherry"), #("O", "Orange")]))
+
+  [#("Alice", 42), #("Bob", 24), #("Cosmo", 27)]
+  |> list.group_last(by: fn(user) { user.1 })
+  |> should.equal(dict.from_list([
+    #(42, #("Alice", 42)),
+    #(24, #("Bob", 24)),
+    #(27, #("Cosmo", 27)),
+  ]))
+}
+
 pub fn filter_test() {
   []
   |> list.filter(fn(_) { True })


### PR DESCRIPTION
This is the utility function I reach for most often in other languages, after the basics like `map`.

It takes a list of elements and turns them into a lookup table using a key function. Similar functions in other libraries include [_.keyBy](https://lodash.com/docs/4.17.15#keyBy), [R.indexBy](https://ramdajs.com/docs/#indexBy), or [Dict.Extra.fromListBy](https://package.elm-lang.org/packages/elm-community/dict-extra/latest/Dict-Extra#fromListBy).
