### PR TITLE
Fail-safe checking of `Intl` availability

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -156,7 +156,7 @@ export function graphemes(string) {
 }
 
 function graphemes_iterator(string) {
-  if (Intl && Intl.Segmenter) {
+  if (typeof Intl !== 'undefined' && Intl.Segmenter) {
     return new Intl.Segmenter().segment(string)[Symbol.iterator]();
   }
 }


### PR DESCRIPTION
Hey there, I'm running the Gleam JS output on an environment where the Intl API is not available unfortunately, and I'm getting this error:
```js
ReferenceError("Intl is not defined")
```

I see that there is a check in place to avoid this failure, but unfortunately that doesn't work, using the `typeof` keyword would avoid throwing a `ReferenceError` here ([mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#interaction_with_undeclared_and_uninitialized_variables)).