### PR TITLE
Make `list.fold_right` tail recursive

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -762,18 +762,12 @@ pub fn fold(
 ///
 /// This function runs in linear time.
 ///
-/// Unlike `fold` this function is not tail recursive. Where possible use
-/// `fold` instead as it will use less memory.
-///
 pub fn fold_right(
   over list: List(a),
   from initial: acc,
   with fun: fn(acc, a) -> acc,
 ) -> acc {
-  case list {
-    [] -> initial
-    [x, ..rest] -> fun(fold_right(rest, initial, fun), x)
-  }
+  list |> reverse |> fold(initial, fun)
 }
 
 fn do_index_fold(


### PR DESCRIPTION
Thanks so much for creating and maintaining Gleam! I'm a fan already :)

I've been reading the `stdlib` and wondering why `list.fold_right` is implemented without tail-call optimization. In my mind the "fix" is simple: simply reverse the list and then call `list.fold`---they are both tail-recursive.

Feel free to close this PR if this "fix" is undesirable. Although, in this case, I'd be very curious why tail-recursive is undesirable.