### PR TITLE
Improve `string.pop_grapheme` performance

### DIFF
--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -194,8 +194,12 @@ string_pad(String, Length, Dir, PadString) ->
 
 string_pop_grapheme(String) ->
     case string:next_grapheme(String) of
-        [ Next | Rest ] ->
+        [ Next | Rest ] when is_binary(Rest) ->
+            {ok, {unicode:characters_to_binary([Next]), Rest}};
+
+        [ Next | Rest ]  ->
             {ok, {unicode:characters_to_binary([Next]), unicode:characters_to_binary(Rest)}};
+
         _ -> {error, nil}
     end.
 


### PR DESCRIPTION
While parsing Gleam code with glexer, I noticed that ~75% of the total runtime of my program was spent in `unicode:characters_to_binary/2`.

After investigating, I've found that glexer is basically a big `string.pop_grapheme` loop, which in turn calls `unicode:characters_to_binary` twice on the result of `string:next_grapheme`, once on the popped character, and once on the remaining string. `characters_to_binary` seems to at least loop once through the string to check if its valid UTF-8. 

According to the [docs](https://www.erlang.org/doc/apps/stdlib/string.html#next_grapheme/1), next_grapheme returns the character as a charlist, but the remaining string as a binary. Just to be sure, I've added a guard to make sure the old behaviour is triggered if `next_grapheme` happens to not return a binary, as promised.

This improves parsing of the stdlib source code using glexer from 3 seconds to 0.65 seconds wall clock time, including erl/escript boot time (~0.2-0.3s on my machine idk).