### PR TITLE
Make `list.unique` logarithmic instead of quadratic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where `list.unique` had quadratic complexity instead of loglinear.
 - The `bit_array` module gains the `bit_size` and `starts_with` functions.
 - Ths `string` module gains the `drop_start`, `drop_end`, `pad_start`,
   `pad_end`, `trim_start`, and `trim_end` functions. These replace the


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/stdlib/issues/667. ~New `list.unique` implementation uses `gleam/set` to detect whether item has already been seen.~ New `list.unique` implementation uses `gleam/dict` to detect whether item has already been seen (it can't use `gleam/set` because that would create import cycle).