### PR TITLE
Add `bit_array.compare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - The `dynamic.optional_field` decoder no longer treats the value as implicitly
   optional. It only deals with the presence or absence of the key itself which
   brings it inline with its documentation.
+- The `bit_array` module gains the `compare` function.
 - Fixed a bug where `string.trim` could remove commas on JavaScript.
 - The `string.pop_grapheme` function has been optimised on Erlang, greatly
   improving its performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.41.0 - Unreleased
+
+- The `bit_array` module gains the `compare` function.
+
 ## v0.40.0 - 2024-08-19
 
 - The `function.curry*` and `function.apply*` functions have been deprecated.
@@ -11,7 +15,6 @@
 - The `dynamic.optional_field` decoder no longer treats the value as implicitly
   optional. It only deals with the presence or absence of the key itself which
   brings it inline with its documentation.
-- The `bit_array` module gains the `compare` function.
 - Fixed a bug where `string.trim` could remove commas on JavaScript.
 - The `string.pop_grapheme` function has been optimised on Erlang, greatly
   improving its performance.

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -212,9 +212,7 @@ fn do_compare(first: BitArray, second: BitArray, index: Int) -> order.Order {
   case slice(first, index, 1), slice(second, index, 1) {
     Ok(<<first_byte>>), Ok(<<second_byte>>) ->
       int.compare(first_byte, second_byte)
-      |> order.lazy_break_tie(fn() {
-        do_compare(first, second, index + 1)
-      })
+      |> order.lazy_break_tie(fn() { do_compare(first, second, index + 1) })
 
     // First has more items, example: "AB" > "A":
     Ok(_), Error(_) -> order.Gt

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -200,26 +200,24 @@ fn do_inspect(input: BitArray, accumulator: String) -> String {
 /// compare(<<"AB":utf8>>, <<"AA":utf8>>)
 /// // -> Gt
 ///
-/// compare(<<1, 2:size(2)>>, <<1, 2:size(2)>>)
+/// compare(<<1, 2:size(2)>>, with: <<1, 2:size(2)>>)
 /// // -> Eq
 /// ```
 ///
 /// Only supported on Erlang target for now.
 ///
-pub fn compare(first: BitArray, second: BitArray) -> order.Order {
-  do_compare(first, second)
+pub fn compare(a: BitArray, with b: BitArray) -> order.Order {
+  do_compare(a, b)
 }
 
-@target(javascript)
 @external(javascript, "../gleam_stdlib.mjs", "bit_array_compare")
-fn do_compare(first: BitArray, second: BitArray) -> order.Order
-
-@target(erlang)
-fn do_compare(first: BitArray, second: BitArray) -> order.Order {
-  case first, second {
+fn do_compare(a: BitArray, with b: BitArray) -> order.Order {
+  case a, b {
     <<first_byte, first_rest:bits>>, <<second_byte, second_rest:bits>> ->
-      int.compare(first_byte, second_byte)
-      |> order.lazy_break_tie(fn() { compare(first_rest, second_rest) })
+      case int.compare(first_byte, second_byte) {
+        order.Eq -> compare(first_rest, second_rest)
+        result -> result
+      }
 
     <<>>, <<>> -> order.Eq
     // First has more items, example: "AB" > "A":
@@ -233,6 +231,5 @@ fn do_compare(first: BitArray, second: BitArray) -> order.Order {
   }
 }
 
-@target(erlang)
 @external(erlang, "gleam_stdlib", "bit_array_to_int")
-fn bit_array_to_int(first: BitArray) -> Int
+fn bit_array_to_int(a: BitArray) -> Int

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -1,6 +1,5 @@
 //// BitArrays are a sequence of binary data of any length.
 
-@target(erlang)
 import gleam/int
 import gleam/order
 import gleam/string

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -204,7 +204,18 @@ fn do_inspect(input: BitArray, accumulator: String) -> String {
 /// // -> Eq
 /// ```
 ///
+/// Only supported on Erlang target for now.
+///
 pub fn compare(first: BitArray, second: BitArray) -> order.Order {
+  do_compare(first, second)
+}
+
+@target(javascript)
+@external(javascript, "../gleam_stdlib.mjs", "bit_array_compare")
+fn do_compare(first: BitArray, second: BitArray) -> order.Order
+
+@target(erlang)
+fn do_compare(first: BitArray, second: BitArray) -> order.Order {
   case first, second {
     <<first_byte, first_rest:bits>>, <<second_byte, second_rest:bits>> ->
       int.compare(first_byte, second_byte)
@@ -217,11 +228,11 @@ pub fn compare(first: BitArray, second: BitArray) -> order.Order {
     <<>>, _ -> order.Lt
     // This happens when there's unusually sized elements.
     // Handle these special cases via custom erlang function.
-    // This cannot be reached in JS right now.
     first, second ->
       int.compare(bit_array_to_int(first), bit_array_to_int(second))
   }
 }
 
+@target(erlang)
 @external(erlang, "gleam_stdlib", "bit_array_to_int")
 fn bit_array_to_int(first: BitArray) -> Int

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -14,7 +14,7 @@
     decode_tuple5/1, decode_tuple6/1, tuple_get/2, classify_dynamic/1, print/1,
     println/1, print_error/1, println_error/1, inspect/1, float_to_string/1,
     int_from_base_string/2, utf_codepoint_list_to_string/1, contains_string/2,
-    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3, bit_array_to_int/1
+    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3, bit_array_to_int_and_size/1
 ]).
 
 %% Taken from OTP's uri_string module
@@ -492,10 +492,10 @@ inspect_bit_array(Rest, Acc) ->
     Segment = <<X1/binary, ":size(", Size1/binary, ")">>,
     inspect_bit_array(<<>>, append_segment(Acc, Segment)).
 
-bit_array_to_int(A) ->
+bit_array_to_int_and_size(A) ->
     Size = bit_size(A),
     <<A1:Size>> = A,
-    A1.
+    {A1, Size}.
 
 append_segment(<<"<<">>, Segment) ->
     <<"<<", Segment/binary>>;

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -14,7 +14,7 @@
     decode_tuple5/1, decode_tuple6/1, tuple_get/2, classify_dynamic/1, print/1,
     println/1, print_error/1, println_error/1, inspect/1, float_to_string/1,
     int_from_base_string/2, utf_codepoint_list_to_string/1, contains_string/2,
-    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3
+    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3, bit_array_to_int/1
 ]).
 
 %% Taken from OTP's uri_string module
@@ -491,6 +491,11 @@ inspect_bit_array(Rest, Acc) ->
     Size1 = erlang:integer_to_binary(Size),
     Segment = <<X1/binary, ":size(", Size1/binary, ")">>,
     inspect_bit_array(<<>>, append_segment(Acc, Segment)).
+
+bit_array_to_int(A) ->
+    Size = bit_size(A),
+    <<A1:Size>> = A,
+    A1.
 
 append_segment(<<"<<">>, Segment) ->
     <<"<<", Segment/binary>>;

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -16,6 +16,7 @@ import {
 } from "./gleam/regex.mjs";
 import { DecodeError } from "./gleam/dynamic.mjs";
 import { Some, None } from "./gleam/option.mjs";
+import { Eq, Gt, Lt } from "./gleam/order.mjs";
 import Dict from "./dict.mjs";
 
 const Nil = undefined;
@@ -915,4 +916,26 @@ export function base16_decode(string) {
 
 export function bit_array_inspect(bits, acc) {
   return `${acc}${[...bits.buffer].join(", ")}`;
+}
+
+export function bit_array_compare(first, second) {
+  for (let i = 0; i < first.length; i++) {
+    if (i >= second.length) {
+      return new Gt();  // first has more items
+    }
+    const f = first.buffer[i];
+    const s = second.buffer[i];
+    if (f > s) {
+      return new Gt();
+    }
+    if (f < s) {
+      return new Lt()
+    }
+  }
+  // This means that either first did not have any items
+  // or all items in first were equal to second.
+  if (first.length === second.length) {
+    return new Eq();
+  }
+  return new Lt();  // second has more items
 }

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -377,6 +377,7 @@ pub fn compare_utf8_test() {
   |> should.equal(order.Eq)
 }
 
+@target(erlang)
 pub fn compare_utf16_test() {
   bit_array.compare(<<"ABC":utf16>>, <<"ABC":utf16>>)
   |> should.equal(order.Eq)
@@ -388,6 +389,7 @@ pub fn compare_utf16_test() {
   |> should.equal(order.Lt)
 }
 
+@target(erlang)
 pub fn compare_mixed_utfs_test() {
   bit_array.compare(<<"A":utf16>>, <<"A":utf8>>)
   |> should.equal(order.Lt)

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -352,7 +352,6 @@ pub fn compare_test() {
 }
 
 pub fn compare_utf8_test() {
-  // utf8
   bit_array.compare(<<"ABC":utf8>>, <<"ABC":utf8>>)
   |> should.equal(order.Eq)
 
@@ -376,6 +375,26 @@ pub fn compare_utf8_test() {
 
   bit_array.compare(<<"":utf8>>, <<"":utf8>>)
   |> should.equal(order.Eq)
+}
+
+pub fn compare_utf8_and_numbers_test() {
+  bit_array.compare(<<"A":utf8>>, <<65>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"A":utf8>>, <<64>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"A":utf8>>, <<66>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"AA":utf8>>, <<65, 65>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"AAA":utf8>>, <<65, 65>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"AA":utf8>>, <<65, 65, 1>>)
+  |> should.equal(order.Lt)
 }
 
 @target(erlang)
@@ -438,6 +457,15 @@ pub fn compare_mixed_utfs_test() {
 @target(erlang)
 pub fn compare_different_sizes_test() {
   bit_array.compare(<<4:5>>, <<4:5>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<4:5, 3:3>>, <<4:5, 2:3>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<4:5, 3:3>>, <<4:5, 4:3>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<4:5, 3:3, 0:0>>, <<4:5, 3:3, 0:0>>)
   |> should.equal(order.Eq)
 
   bit_array.compare(<<3:5>>, <<4:5>>)

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -338,7 +338,7 @@ pub fn compare_test() {
   bit_array.compare(<<1, 2, 3>>, <<1, 2, 3>>)
   |> should.equal(order.Eq)
 
-  bit_array.compare(<<1, 2>>, <<1, 3>>)
+  bit_array.compare(<<1, 2>>, with: <<1, 3>>)
   |> should.equal(order.Lt)
 
   bit_array.compare(<<1, 3>>, <<1, 2>>)

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -334,127 +334,6 @@ pub fn inspect_partial_bytes_test() {
 }
 
 @target(erlang)
-pub fn compare_test() {
-  bit_array.compare(<<1, 2, 3>>, <<1, 2, 3>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<1, 2>>, with: <<1, 3>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<1, 3>>, <<1, 2>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<1, 2>>, <<1, 2, 3>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<1, 2, 3>>, <<1, 2>>)
-  |> should.equal(order.Gt)
-}
-
-pub fn compare_utf8_test() {
-  bit_array.compare(<<"ABC":utf8>>, <<"ABC":utf8>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"AB":utf8>>, <<"ABC":utf8>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"ABC":utf8>>, <<"AB":utf8>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"AB":utf8>>, <<"AC":utf8>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"AC":utf8>>, <<"AB":utf8>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"":utf8>>, <<"ABC":utf8>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"A":utf8>>, <<"":utf8>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"":utf8>>, <<"":utf8>>)
-  |> should.equal(order.Eq)
-}
-
-pub fn compare_utf8_and_numbers_test() {
-  bit_array.compare(<<"A":utf8>>, <<65>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"A":utf8>>, <<64>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"A":utf8>>, <<66>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"AA":utf8>>, <<65, 65>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"AAA":utf8>>, <<65, 65>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"AA":utf8>>, <<65, 65, 1>>)
-  |> should.equal(order.Lt)
-}
-
-@target(erlang)
-pub fn compare_utf16_test() {
-  bit_array.compare(<<"ABC":utf16>>, <<"ABC":utf16>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"ABC":utf16>>, <<"AB":utf16>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"A":utf16>>, <<"Z":utf16>>)
-  |> should.equal(order.Lt)
-}
-
-@target(erlang)
-pub fn compare_utf32_test() {
-  bit_array.compare(<<"ABC":utf32>>, <<"ABC":utf32>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"ABC":utf32>>, <<"AB":utf32>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"A":utf32>>, <<"Z":utf32>>)
-  |> should.equal(order.Lt)
-}
-
-@target(erlang)
-pub fn compare_mixed_utfs_test() {
-  bit_array.compare(<<"A":utf16>>, <<"A":utf8>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"A":utf32>>, <<"A":utf16>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"A":utf8>>, <<"A":utf16>>)
-  |> should.equal(order.Gt)
-
-  bit_array.compare(<<"":utf8>>, <<"A":utf16>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"":utf16>>, <<"A":utf8>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"":utf32>>, <<"A":utf8>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"":utf32>>, <<"A":utf16>>)
-  |> should.equal(order.Lt)
-
-  bit_array.compare(<<"":utf16>>, <<"":utf8>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"":utf8>>, <<"":utf16>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<"":utf8>>, <<"":utf32>>)
-  |> should.equal(order.Eq)
-}
-
-@target(erlang)
 pub fn compare_different_sizes_test() {
   bit_array.compare(<<4:5>>, <<4:5>>)
   |> should.equal(order.Eq)
@@ -468,6 +347,14 @@ pub fn compare_different_sizes_test() {
   bit_array.compare(<<4:5, 3:3, 0:0>>, <<4:5, 3:3, 0:0>>)
   |> should.equal(order.Eq)
 
+  bit_array.compare(<<4:2, 3:4, 0:0>>, <<4:2, 3:3, 0:0>>)
+  |> should.equal(order.Gt)
+
+  // first is: <<33, 1:size(1)>>
+  // second is: <<35>>
+  bit_array.compare(<<4:5, 3:4, 0:0>>, <<4:5, 3:3, 0:0>>)
+  |> should.equal(order.Lt)
+
   bit_array.compare(<<3:5>>, <<4:5>>)
   |> should.equal(order.Lt)
 
@@ -478,14 +365,17 @@ pub fn compare_different_sizes_test() {
   |> should.equal(order.Gt)
 
   bit_array.compare(<<4:8>>, <<4:5>>)
-  |> should.equal(order.Eq)
+  |> should.equal(order.Gt)
 
   bit_array.compare(<<4:5>>, <<4:8>>)
-  |> should.equal(order.Eq)
+  |> should.equal(order.Lt)
 
   bit_array.compare(<<0:5>>, <<0:8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<0:5>>, <<0:5>>)
   |> should.equal(order.Eq)
 
   bit_array.compare(<<0:2>>, <<0:1>>)
-  |> should.equal(order.Eq)
+  |> should.equal(order.Gt)
 }

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -410,6 +410,7 @@ pub fn compare_mixed_utfs_test() {
   |> should.equal(order.Eq)
 }
 
+@target(erlang)
 pub fn compare_different_sizes_test() {
   bit_array.compare(<<4:5>>, <<4:5>>)
   |> should.equal(order.Eq)

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -1,4 +1,5 @@
 import gleam/bit_array
+import gleam/order
 import gleam/result
 import gleam/should
 import gleam/string
@@ -330,4 +331,102 @@ pub fn inspect_partial_bytes_test() {
 
   bit_array.inspect(<<5:3, 11:4, 1:2>>)
   |> should.equal("<<182, 1:size(1)>>")
+}
+
+pub fn bit_array_compare_test() {
+  bit_array.compare(<<1, 2, 3>>, <<1, 2, 3>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<1, 2>>, <<1, 3>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<1, 3>>, <<1, 2>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<1, 2>>, <<1, 2, 3>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<1, 2, 3>>, <<1, 2>>)
+  |> should.equal(order.Gt)
+}
+
+pub fn bit_array_compare_utf8_test() {
+  // utf8
+  bit_array.compare(<<"ABC":utf8>>, <<"ABC":utf8>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"AB":utf8>>, <<"ABC":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"ABC":utf8>>, <<"AB":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"AB":utf8>>, <<"AC":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"AC":utf8>>, <<"AB":utf8>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"":utf8>>, <<"ABC":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"A":utf8>>, <<"":utf8>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"":utf8>>, <<"":utf8>>)
+  |> should.equal(order.Eq)
+}
+
+pub fn bit_array_compare_utf16_test() {
+  bit_array.compare(<<"ABC":utf16>>, <<"ABC":utf16>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"ABC":utf16>>, <<"AB":utf16>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"A":utf16>>, <<"Z":utf16>>)
+  |> should.equal(order.Lt)
+}
+
+pub fn bit_array_compare_mixed_utfs_test() {
+  bit_array.compare(<<"A":utf16>>, <<"A":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"A":utf8>>, <<"A":utf16>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"":utf8>>, <<"A":utf16>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"":utf16>>, <<"A":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"":utf16>>, <<"":utf8>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"":utf8>>, <<"":utf16>>)
+  |> should.equal(order.Eq)
+}
+
+pub fn bit_array_compare_different_sizes_test() {
+  bit_array.compare(<<4:5>>, <<4:5>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<3:5>>, <<4:5>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<5:5>>, <<4:5>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<4:8>>, <<4:5>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<4:5>>, <<4:8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<0:5>>, <<0:8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<0:2>>, <<0:1>>)
+  |> should.equal(order.Gt)
 }

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -333,7 +333,7 @@ pub fn inspect_partial_bytes_test() {
   |> should.equal("<<182, 1:size(1)>>")
 }
 
-pub fn bit_array_compare_test() {
+pub fn compare_test() {
   bit_array.compare(<<1, 2, 3>>, <<1, 2, 3>>)
   |> should.equal(order.Eq)
 
@@ -350,7 +350,7 @@ pub fn bit_array_compare_test() {
   |> should.equal(order.Gt)
 }
 
-pub fn bit_array_compare_utf8_test() {
+pub fn compare_utf8_test() {
   // utf8
   bit_array.compare(<<"ABC":utf8>>, <<"ABC":utf8>>)
   |> should.equal(order.Eq)
@@ -359,7 +359,7 @@ pub fn bit_array_compare_utf8_test() {
   |> should.equal(order.Lt)
 
   bit_array.compare(<<"ABC":utf8>>, <<"AB":utf8>>)
-  |> should.equal(order.Lt)
+  |> should.equal(order.Gt)
 
   bit_array.compare(<<"AB":utf8>>, <<"AC":utf8>>)
   |> should.equal(order.Lt)
@@ -377,7 +377,7 @@ pub fn bit_array_compare_utf8_test() {
   |> should.equal(order.Eq)
 }
 
-pub fn bit_array_compare_utf16_test() {
+pub fn compare_utf16_test() {
   bit_array.compare(<<"ABC":utf16>>, <<"ABC":utf16>>)
   |> should.equal(order.Eq)
 
@@ -388,7 +388,7 @@ pub fn bit_array_compare_utf16_test() {
   |> should.equal(order.Lt)
 }
 
-pub fn bit_array_compare_mixed_utfs_test() {
+pub fn compare_mixed_utfs_test() {
   bit_array.compare(<<"A":utf16>>, <<"A":utf8>>)
   |> should.equal(order.Lt)
 
@@ -408,15 +408,15 @@ pub fn bit_array_compare_mixed_utfs_test() {
   |> should.equal(order.Eq)
 }
 
-pub fn bit_array_compare_different_sizes_test() {
+pub fn compare_different_sizes_test() {
   bit_array.compare(<<4:5>>, <<4:5>>)
   |> should.equal(order.Eq)
 
   bit_array.compare(<<3:5>>, <<4:5>>)
-  |> should.equal(order.Lt)
+  |> should.equal(order.Eq)
 
   bit_array.compare(<<5:5>>, <<4:5>>)
-  |> should.equal(order.Gt)
+  |> should.equal(order.Eq)
 
   bit_array.compare(<<4:8>>, <<4:5>>)
   |> should.equal(order.Gt)
@@ -428,5 +428,5 @@ pub fn bit_array_compare_different_sizes_test() {
   |> should.equal(order.Lt)
 
   bit_array.compare(<<0:2>>, <<0:1>>)
-  |> should.equal(order.Gt)
+  |> should.equal(order.Eq)
 }

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -390,8 +390,23 @@ pub fn compare_utf16_test() {
 }
 
 @target(erlang)
+pub fn compare_utf32_test() {
+  bit_array.compare(<<"ABC":utf32>>, <<"ABC":utf32>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"ABC":utf32>>, <<"AB":utf32>>)
+  |> should.equal(order.Gt)
+
+  bit_array.compare(<<"A":utf32>>, <<"Z":utf32>>)
+  |> should.equal(order.Lt)
+}
+
+@target(erlang)
 pub fn compare_mixed_utfs_test() {
   bit_array.compare(<<"A":utf16>>, <<"A":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"A":utf32>>, <<"A":utf16>>)
   |> should.equal(order.Lt)
 
   bit_array.compare(<<"A":utf8>>, <<"A":utf16>>)
@@ -403,10 +418,19 @@ pub fn compare_mixed_utfs_test() {
   bit_array.compare(<<"":utf16>>, <<"A":utf8>>)
   |> should.equal(order.Lt)
 
+  bit_array.compare(<<"":utf32>>, <<"A":utf8>>)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<"":utf32>>, <<"A":utf16>>)
+  |> should.equal(order.Lt)
+
   bit_array.compare(<<"":utf16>>, <<"":utf8>>)
   |> should.equal(order.Eq)
 
   bit_array.compare(<<"":utf8>>, <<"":utf16>>)
+  |> should.equal(order.Eq)
+
+  bit_array.compare(<<"":utf8>>, <<"":utf32>>)
   |> should.equal(order.Eq)
 }
 
@@ -416,19 +440,22 @@ pub fn compare_different_sizes_test() {
   |> should.equal(order.Eq)
 
   bit_array.compare(<<3:5>>, <<4:5>>)
-  |> should.equal(order.Eq)
+  |> should.equal(order.Lt)
+
+  bit_array.compare(<<3:7>>, <<4:7>>)
+  |> should.equal(order.Lt)
 
   bit_array.compare(<<5:5>>, <<4:5>>)
-  |> should.equal(order.Eq)
-
-  bit_array.compare(<<4:8>>, <<4:5>>)
   |> should.equal(order.Gt)
 
+  bit_array.compare(<<4:8>>, <<4:5>>)
+  |> should.equal(order.Eq)
+
   bit_array.compare(<<4:5>>, <<4:8>>)
-  |> should.equal(order.Lt)
+  |> should.equal(order.Eq)
 
   bit_array.compare(<<0:5>>, <<0:8>>)
-  |> should.equal(order.Lt)
+  |> should.equal(order.Eq)
 
   bit_array.compare(<<0:2>>, <<0:1>>)
   |> should.equal(order.Eq)

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -333,6 +333,7 @@ pub fn inspect_partial_bytes_test() {
   |> should.equal("<<182, 1:size(1)>>")
 }
 
+@target(erlang)
 pub fn compare_test() {
   bit_array.compare(<<1, 2, 3>>, <<1, 2, 3>>)
   |> should.equal(order.Eq)


### PR DESCRIPTION
All credit for the implementation goes to @RGBboy

I changed some details, main ones are:
- I use pattern matching instead of a `bit_array_to_int` function call 
- No more panics
- Tie is lazy evaluated in my version
- Improved naming in some places

I think that the main use-case for this is sorting text entries from APIs that return bit arrays. 

Please, suggest more ideas for test cases and docs!

Closes #679