### PR TITLE
Remove target annotations

### DIFF
--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -1,6 +1,5 @@
 //// BitArrays are a sequence of binary data of any length.
 
-@target(erlang)
 import gleam/int
 import gleam/string
 
@@ -145,7 +144,6 @@ pub fn base16_encode(input: BitArray) -> String
 @external(javascript, "../gleam_stdlib.mjs", "base16_decode")
 pub fn base16_decode(input: String) -> Result(BitArray, Nil)
 
-@target(javascript)
 /// Converts a bit array to a string containing the decimal value of each byte.
 ///
 /// ## Examples
@@ -158,15 +156,11 @@ pub fn base16_decode(input: String) -> Result(BitArray, Nil)
 /// // -> "<<100, 5:size(3)>>"
 /// ```
 ///
-@external(javascript, "../gleam_stdlib.mjs", "bit_array_inspect")
-pub fn inspect(input: BitArray) -> String
-
-@target(erlang)
 pub fn inspect(input: BitArray) -> String {
   do_inspect(input, "<<") <> ">>"
 }
 
-@target(erlang)
+@external(javascript, "../gleam_stdlib.mjs", "bit_array_inspect")
 fn do_inspect(input: BitArray, accumulator: String) -> String {
   case input {
     <<>> -> accumulator

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -71,20 +71,11 @@ pub fn reverse(string: String) -> String {
   do_reverse(string)
 }
 
-@target(erlang)
 fn do_reverse(string: String) -> String {
   string
   |> string_builder.from_string
   |> string_builder.reverse
   |> string_builder.to_string
-}
-
-@target(javascript)
-fn do_reverse(string: String) -> String {
-  string
-  |> to_graphemes
-  |> list.reverse
-  |> concat
 }
 
 /// Creates a new `String` by replacing all occurrences of a given substring.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -913,6 +913,6 @@ export function base16_decode(string) {
   return new Ok(new BitArray(bytes));
 }
 
-export function bit_array_inspect(bits) {
-  return `<<${[...bits.buffer].join(", ")}>>`;
+export function bit_array_inspect(bits, acc) {
+  return `${acc}${[...bits.buffer].join(", ")}`;
 }


### PR DESCRIPTION
In this PR I removed some other `@target` annotations from:
- `bit_array.inspect`, this required a really small change to the js implementation but nothing special
- `string.reverse`, this one I'm not super sure about: I removed the specialised javascript implementation and used the one leveraging `string_builder`, the difference is it's adding two new calls to the identity function. If this poses any performance concerns (I'm not sure it does) then I can revert this one!

So with this PR stdlib doesn't have any needless target annotation remaining. The only remaining one are totally reasonable and cannot really be removed:
- In tests to check the behaviour of different targets
- In `set` to choose an appropriate type for the token for each target
- Some remaining ones in the `bit_array` module, needed to work around the lack of support for some segment options in the js target