### PR TITLE
Update BytesBuilder docstring to reflect binary content, net text

### DIFF
--- a/src/gleam/bytes_builder.gleam
+++ b/src/gleam/bytes_builder.gleam
@@ -1,4 +1,4 @@
-//// `BytesBuilder` is a type used for efficiently building text content to be
+//// `BytesBuilder` is a type used for efficiently building binary content to be
 //// written to a file or a socket. Internally it is represented as tree so to
 //// append or prepend to a bytes builder is a constant time operation that
 //// allocates a new node in the tree without copying any of the content. When


### PR DESCRIPTION
This looks like a copy-paste error from string_builder. BytesBuilder is used to construct binary content rather than text content.

Other options:

"...efficiently building BitArrays"
"bytes content"