### PR TITLE
Add `replace_one` for string, string_builder, and regex

### DIFF
--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -214,3 +214,27 @@ pub fn replace(
   in string: String,
   with substitute: String,
 ) -> String
+
+/// Creates a new `String` by replacing the first substring that matches the regular
+/// expression.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let assert Ok(re) = regex.from_string("^https://")
+/// replace(one_of: re, in: "https://example.com", with: "www.")
+/// // -> "www.example.com"
+/// ```
+///
+/// ```gleam
+/// let assert Ok(re) = regex.from_string("[, +-]")
+/// replace(one_of: re, in: "a,b-c d+e", with: "/")
+/// // -> "a/b-c d+e"
+/// ```
+@external(erlang, "gleam_stdlib", "regex_replace_one")
+@external(javascript, "../gleam_stdlib.mjs", "regex_replace_one")
+pub fn replace_one(
+  one_of pattern: Regex,
+  in string: String,
+  with substitute: String,
+) -> String

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -103,6 +103,31 @@ pub fn replace(
   |> string_builder.to_string
 }
 
+/// Creates a new `String` by replacing the first occurrence of a given substring.
+///
+/// ## Examples
+///
+/// ```gleam
+/// replace("www.example.com", each: ".", with: "-")
+/// // -> "www-example.com"
+/// ```
+///
+/// ```gleam
+/// replace("a,b,c,d,e", each: ",", with: "/")
+/// // -> "a/b,c,d,e"
+/// ```
+///
+pub fn replace_one(
+  in string: String,
+  one_of pattern: String,
+  with substitute: String,
+) -> String {
+  string
+  |> string_builder.from_string
+  |> string_builder.replace_one(one_of: pattern, with: substitute)
+  |> string_builder.to_string
+}
+
 /// Creates a new `String` with all the graphemes in the input `String` converted to
 /// lowercase.
 ///

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -205,6 +205,16 @@ pub fn replace(
   with substitute: String,
 ) -> StringBuilder
 
+/// Replaces the first instance of a pattern with a given string substitute.
+///
+@external(erlang, "gleam_stdlib", "string_replace_one")
+@external(javascript, "../gleam_stdlib.mjs", "string_replace_one")
+pub fn replace_one(
+  in builder: StringBuilder,
+  one_of pattern: String,
+  with substitute: String,
+) -> StringBuilder
+
 /// Compares two builders to determine if they have the same textual content.
 ///
 /// Comparing two iodata using the `==` operator may return `False` even if they

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -14,7 +14,8 @@
     decode_tuple5/1, decode_tuple6/1, tuple_get/2, classify_dynamic/1, print/1,
     println/1, print_error/1, println_error/1, inspect/1, float_to_string/1,
     int_from_base_string/2, utf_codepoint_list_to_string/1, contains_string/2,
-    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3, bit_array_to_int_and_size/1
+    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3,
+    bit_array_to_int_and_size/1, string_replace_one/3
 ]).
 
 %% Taken from OTP's uri_string module
@@ -552,6 +553,9 @@ base16_decode(String) ->
 
 string_replace(String, Pattern, Replacement) ->
     string:replace(String, Pattern, Replacement, all).
+
+string_replace_one(String, Pattern, Replacement) ->
+    string:replace(String, Pattern, Replacement).
 
 slice(String, Index, Length) ->
     case string:slice(String, Index, Length) of

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -15,7 +15,7 @@
     println/1, print_error/1, println_error/1, inspect/1, float_to_string/1,
     int_from_base_string/2, utf_codepoint_list_to_string/1, contains_string/2,
     crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3,
-    bit_array_to_int_and_size/1, string_replace_one/3
+    bit_array_to_int_and_size/1, string_replace_one/3, regex_replace_one/3
 ]).
 
 %% Taken from OTP's uri_string module
@@ -266,6 +266,9 @@ regex_scan(Regex, String) ->
 
 regex_replace(Regex, Subject, Replacement) ->
     re:replace(Subject, Regex, Replacement, [global, {return, binary}]).
+
+regex_replace_one(Regex, Subject, Replacement) ->
+    re:replace(Subject, Regex, Replacement, [{return, binary}]).
 
 base_decode64(S) ->
     try {ok, base64:decode(S)}

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -127,6 +127,10 @@ export function string_replace(string, target, substitute) {
   );
 }
 
+export function string_replace_one(string, target, substitute) {
+  return string.replace(target, substitute);
+}
+
 export function string_reverse(string) {
   return [...string].reverse().join("");
 }

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -455,6 +455,13 @@ export function regex_replace(regex, original_string, replacement) {
   return original_string.replaceAll(regex, replacement);
 }
 
+export function regex_replace_one(regex, original_string, replacement) {
+  // Forcibly strip the g flag from the regex, if it's present
+  let flags = regex.toString().split("/").pop().replace("g", "");
+  let match = new RegExp(regex, flags);
+  return original_string.replace(match, replacement);
+}
+
 export function new_map() {
   return Dict.new();
 }

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -185,3 +185,15 @@ pub fn replace_3_test() {
   regex.replace(re, "🐈🐈 are great!", "🐕")
   |> should.equal("🐕🐕 are great!")
 }
+
+pub fn replace_one_test() {
+  let assert Ok(re) = regex.from_string("🐈")
+  regex.replace_one(in: "🐈🐈 are great!", one_of: re, with: "🐕")
+  |> should.equal("🐕🐈 are great!")
+}
+
+pub fn replace_one_of_many_test() {
+  let assert Ok(re) = regex.from_string("[, +-]")
+  regex.replace_one(one_of: re, in: "a,b-c d+e", with: "/")
+  |> should.equal("a/b-c d+e")
+}


### PR DESCRIPTION
Read the tin! The replace functions were all replace all style by default and there was no option at all to just replace the first occurrence. This rectifies that for both Erlang and JS targets. I thought about naming it `replace_first` but `one` was shorter. Let me know if it needs a name change or if this change isn't a good fit for the standard lib.