### PR TITLE
Add `regex.escape`

### DIFF
--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -3,7 +3,9 @@
 //// all of the PCRE library is interfaced and some parts of the library go beyond
 //// what PCRE offers. Currently PCRE version 8.40 (release date 2017-01-11) is used.
 
+import gleam/list
 import gleam/option.{type Option}
+import gleam/string
 
 pub type Regex
 
@@ -214,3 +216,10 @@ pub fn replace(
   in string: String,
   with substitute: String,
 ) -> String
+
+pub fn escape(input: String) -> String {
+  ["\\", "$", "^", ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|"]
+  |> list.fold(input, fn(acc, char) {
+    string.replace(in: acc, each: char, with: "\\" <> char)
+  })
+}

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -217,6 +217,19 @@ pub fn replace(
   with substitute: String,
 ) -> String
 
+/// Exapes all Regex characters in a given `String`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// regex.escape("hello$world^test")
+/// // -> "hello\\$world\\^test"
+/// ```
+///
+/// ```gleam
+/// regex.escape("$^.*+?()[]{}|\\")
+/// // -> "\\$\\^\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\\\"
+/// ```
 pub fn escape(input: String) -> String {
   ["\\", "$", "^", ".", "*", "+", "?", "(", ")", "[", "]", "{", "}", "|"]
   |> list.fold(input, fn(acc, char) {

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -217,7 +217,7 @@ pub fn replace(
   with substitute: String,
 ) -> String
 
-/// Exapes all Regex characters in a given `String`.
+/// Escapes all `Regex` characters in a given `String`.
 ///
 /// ## Examples
 ///

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -185,3 +185,31 @@ pub fn replace_3_test() {
   regex.replace(re, "🐈🐈 are great!", "🐕")
   |> should.equal("🐕🐕 are great!")
 }
+
+// Test for escaping regex special characters
+pub fn escape_test() {
+  // Test escaping common regex symbols
+  let input = "$^.*+?()[]{}|\\"
+  let expected = "\\$\\^\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\\\"
+  input
+  |> regex.escape
+  |> should.equal(expected)
+}
+
+// Test with a string that contains no special characters
+pub fn escape_no_special_chars_test() {
+  let input = "hello"
+  let expected = "hello"
+  input
+  |> regex.escape
+  |> should.equal(expected)
+}
+
+// Test with a mix of normal characters and regex symbols
+pub fn escape_mixed_string_test() {
+  let input = "hello$world^test"
+  let expected = "hello\\$world\\^test"
+  input
+  |> regex.escape
+  |> should.equal(expected)
+}

--- a/test/gleam/regex_test.gleam
+++ b/test/gleam/regex_test.gleam
@@ -186,7 +186,6 @@ pub fn replace_3_test() {
   |> should.equal("🐕🐕 are great!")
 }
 
-// Test for escaping regex special characters
 pub fn escape_test() {
   // Test escaping common regex symbols
   let input = "$^.*+?()[]{}|\\"
@@ -196,7 +195,6 @@ pub fn escape_test() {
   |> should.equal(expected)
 }
 
-// Test with a string that contains no special characters
 pub fn escape_no_special_chars_test() {
   let input = "hello"
   let expected = "hello"
@@ -205,7 +203,6 @@ pub fn escape_no_special_chars_test() {
   |> should.equal(expected)
 }
 
-// Test with a mix of normal characters and regex symbols
 pub fn escape_mixed_string_test() {
   let input = "hello$world^test"
   let expected = "hello\\$world\\^test"


### PR DESCRIPTION
Added `regex.escape` to escape regex strings. I saw the issue for this and needed the same, so here it is! It takes a string, escapes all regex chars, and returns it.

Closes #677