### PR TITLE
Fix documentation for int.undigits

### DIFF
--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -502,7 +502,7 @@ fn do_digits(x: Int, base: Int, acc: List(Int)) -> List(Int) {
 ///
 /// ```gleam
 /// undigits([2,3,4], 1)
-/// // -> Error(InvalidBase)
+/// // -> Error(Nil)
 /// ```
 ///
 /// ```gleam


### PR DESCRIPTION
InvalidBase can no longer be returned from the function since e174d4eea80dcf28f72c30d78cc17493998687aa (#673).