### PR TITLE
Add charset based variants for trimming, rename from left/right to start/end

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -553,8 +553,34 @@ fn do_trim(string: String) -> String {
   erl_trim(string, Both)
 }
 
+/// Like `trim`, but removes the specified chars on both sides of a `String`
+///
+/// ## Examples
+///
+/// ```gleam
+/// trim_chars_left("..,hats,..", ".,")
+/// // -> "hats"
+/// ```
+pub fn trim_chars(string: String, charset: String) -> String {
+  do_trim_chars(string, charset)
+}
+
+@external(javascript, "../gleam_stdlib.mjs", "trim_chars")
+fn do_trim_chars(string: String, charset: String) -> String {
+  erl_trim_chars(string, Both, erl_to_graphemes(charset))
+}
+
 @external(erlang, "string", "trim")
 fn erl_trim(a: String, b: Direction) -> String
+
+@external(erlang, "string", "trim")
+fn erl_trim_chars(a: String, b: Direction, c: ErlGraphemes) -> String
+
+@external(erlang, "string", "to_graphemes")
+fn erl_to_graphemes(a: String) -> ErlGraphemes
+
+// erlang's string:to_graphemes returns char() | [char()], which cannot be directly represented
+type ErlGraphemes
 
 type Direction {
   Leading
@@ -596,6 +622,40 @@ pub fn trim_right(string: String) -> String {
 @external(javascript, "../gleam_stdlib.mjs", "trim_right")
 fn do_trim_right(string: String) -> String {
   erl_trim(string, Trailing)
+}
+
+/// Like `trim_left`, but removes the specified chars on the left of a `String`
+///
+/// ## Examples
+///
+/// ```gleam
+/// trim_chars_left("..,hats,..", ".,")
+/// // -> "hats,.."
+/// ```
+pub fn trim_chars_left(string: String, charset: String) -> String {
+  do_trim_chars_left(string, charset)
+}
+
+@external(javascript, "../gleam_stdlib.mjs", "trim_chars_left")
+fn do_trim_chars_left(string: String, charset: String) -> String {
+  erl_trim_chars(string, Leading, erl_to_graphemes(charset))
+}
+
+/// Like `trim_right`, but removes the specified chars on the right of a `String`
+///
+/// ## Examples
+///
+/// ```gleam
+/// trim_chars_right("..,hats,..", ".,")
+/// // -> "..,hats"
+/// ```
+pub fn trim_chars_right(string: String, charset: String) -> String {
+  do_trim_chars_right(string, charset)
+}
+
+@external(javascript, "../gleam_stdlib.mjs", "trim_chars_right")
+fn do_trim_chars_right(string: String, charset: String) -> String {
+  erl_trim_chars(string, Trailing, erl_to_graphemes(charset))
 }
 
 /// Splits a non-empty `String` into its first element (head) and rest (tail).

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -558,23 +558,23 @@ fn do_trim(string: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// trim_chars("..,hats,..", ".,")
+/// trim_with("..,hats,..", ".,")
 /// // -> "hats"
 /// ```
-pub fn trim_chars(string: String, charset: String) -> String {
-  do_trim_chars(string, charset)
+pub fn trim_with(string: String, charset: String) -> String {
+  do_trim_with(string, charset)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_chars")
-fn do_trim_chars(string: String, charset: String) -> String {
-  erl_trim_chars(string, Both, erl_to_graphemes(charset))
+@external(javascript, "../gleam_stdlib.mjs", "trim_with")
+fn do_trim_with(string: String, charset: String) -> String {
+  erl_trim_with(string, Both, erl_to_graphemes(charset))
 }
 
 @external(erlang, "string", "trim")
 fn erl_trim(a: String, b: Direction) -> String
 
 @external(erlang, "string", "trim")
-fn erl_trim_chars(a: String, b: Direction, c: ErlGraphemes) -> String
+fn erl_trim_with(a: String, b: Direction, c: ErlGraphemes) -> String
 
 @external(erlang, "string", "to_graphemes")
 fn erl_to_graphemes(a: String) -> ErlGraphemes
@@ -641,16 +641,16 @@ fn do_trim_end(string: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// trim_chars_start("..,hats,..", ".,")
+/// trim_start_with("..,hats,..", ".,")
 /// // -> "hats,.."
 /// ```
-pub fn trim_chars_start(string: String, charset: String) -> String {
-  do_trim_chars_start(string, charset)
+pub fn trim_start_with(string: String, charset: String) -> String {
+  do_trim_start_with(string, charset)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_chars_start")
-fn do_trim_chars_start(string: String, charset: String) -> String {
-  erl_trim_chars(string, Leading, erl_to_graphemes(charset))
+@external(javascript, "../gleam_stdlib.mjs", "trim_start_with")
+fn do_trim_start_with(string: String, charset: String) -> String {
+  erl_trim_with(string, Leading, erl_to_graphemes(charset))
 }
 
 /// Like `trim_end`, but removes the specified chars at the end of a `String`
@@ -658,16 +658,16 @@ fn do_trim_chars_start(string: String, charset: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// trim_chars_end("..,hats,..", ".,")
+/// trim_end_with("..,hats,..", ".,")
 /// // -> "..,hats"
 /// ```
-pub fn trim_chars_end(string: String, charset: String) -> String {
-  do_trim_chars_end(string, charset)
+pub fn trim_end_with(string: String, charset: String) -> String {
+  do_trim_end_with(string, charset)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_chars_end")
-fn do_trim_chars_end(string: String, charset: String) -> String {
-  erl_trim_chars(string, Trailing, erl_to_graphemes(charset))
+@external(javascript, "../gleam_stdlib.mjs", "trim_end_with")
+fn do_trim_end_with(string: String, charset: String) -> String {
+  erl_trim_with(string, Trailing, erl_to_graphemes(charset))
 }
 
 /// Splits a non-empty `String` into its first element (head) and rest (tail).

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -558,7 +558,7 @@ fn do_trim(string: String) -> String {
 /// ## Examples
 ///
 /// ```gleam
-/// trim_chars_left("..,hats,..", ".,")
+/// trim_chars("..,hats,..", ".,")
 /// // -> "hats"
 /// ```
 pub fn trim_chars(string: String, charset: String) -> String {
@@ -588,73 +588,85 @@ type Direction {
   Both
 }
 
-/// Removes whitespace on the left of a `String`.
+/// Removes whitespace at the start of a `String`.
 ///
 /// ## Examples
 ///
 /// ```gleam
-/// trim_left("  hats  \n")
+/// trim_start("  hats  \n")
 /// // -> "hats  \n"
 /// ```
 ///
-pub fn trim_left(string: String) -> String {
-  do_trim_left(string)
+pub fn trim_start(string: String) -> String {
+  do_trim_start(string)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_left")
-fn do_trim_left(string: String) -> String {
+/// An alias for trim_start
+@deprecated("Use trim_start. There is no behavior change")
+pub fn trim_left(string: String) -> String {
+  trim_start(string)
+}
+
+@external(javascript, "../gleam_stdlib.mjs", "trim_start")
+fn do_trim_start(string: String) -> String {
   erl_trim(string, Leading)
 }
 
-/// Removes whitespace on the right of a `String`.
+/// Removes whitespace at the end of a `String`.
 ///
 /// ## Examples
 ///
 /// ```gleam
-/// trim_right("  hats  \n")
+/// trim_end("  hats  \n")
 /// // -> "  hats"
 /// ```
 ///
-pub fn trim_right(string: String) -> String {
-  do_trim_right(string)
+pub fn trim_end(string: String) -> String {
+  do_trim_end(string)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_right")
-fn do_trim_right(string: String) -> String {
+/// An alias for trim_end
+@deprecated("Use trim_end. There is no behavior change")
+pub fn trim_right(string: String) -> String {
+  trim_end(string)
+}
+
+@external(javascript, "../gleam_stdlib.mjs", "trim_end")
+fn do_trim_end(string: String) -> String {
   erl_trim(string, Trailing)
 }
 
-/// Like `trim_left`, but removes the specified chars on the left of a `String`
+/// Like `trim_start`, but removes the specified chars at the start of a `String`
 ///
 /// ## Examples
 ///
 /// ```gleam
-/// trim_chars_left("..,hats,..", ".,")
+/// trim_chars_start("..,hats,..", ".,")
 /// // -> "hats,.."
 /// ```
-pub fn trim_chars_left(string: String, charset: String) -> String {
-  do_trim_chars_left(string, charset)
+pub fn trim_chars_start(string: String, charset: String) -> String {
+  do_trim_chars_start(string, charset)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_chars_left")
-fn do_trim_chars_left(string: String, charset: String) -> String {
+@external(javascript, "../gleam_stdlib.mjs", "trim_chars_start")
+fn do_trim_chars_start(string: String, charset: String) -> String {
   erl_trim_chars(string, Leading, erl_to_graphemes(charset))
 }
 
-/// Like `trim_right`, but removes the specified chars on the right of a `String`
+/// Like `trim_end`, but removes the specified chars at the end of a `String`
 ///
 /// ## Examples
 ///
 /// ```gleam
-/// trim_chars_right("..,hats,..", ".,")
+/// trim_chars_end("..,hats,..", ".,")
 /// // -> "..,hats"
 /// ```
-pub fn trim_chars_right(string: String, charset: String) -> String {
-  do_trim_chars_right(string, charset)
+pub fn trim_chars_end(string: String, charset: String) -> String {
+  do_trim_chars_end(string, charset)
 }
 
-@external(javascript, "../gleam_stdlib.mjs", "trim_chars_right")
-fn do_trim_chars_right(string: String, charset: String) -> String {
+@external(javascript, "../gleam_stdlib.mjs", "trim_chars_end")
+fn do_trim_chars_end(string: String, charset: String) -> String {
   erl_trim_chars(string, Trailing, erl_to_graphemes(charset))
 }
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -262,33 +262,33 @@ const unicode_whitespaces = [
   "\u2029", // Paragraph separator
 ].join("");
 
-const left_trim_regex = new_left_trim_regexp(unicode_whitespaces);
+const start_trim_regex = new_start_trim_regexp(unicode_whitespaces);
 const right_trim_regex = new_right_trim_regexp(unicode_whitespaces);
 
 export function trim(string) {
-  return trim_left(trim_right(string));
+  return trim_start(trim_end(string));
 }
 
-export function trim_left(string) {
-  return string.replace(left_trim_regex, "");
+export function trim_start(string) {
+  return string.replace(start_trim_regex, "");
 }
 
-export function trim_right(string) {
+export function trim_end(string) {
   return string.replace(right_trim_regex, "");
 }
 
 export function trim_chars(string, charset) {
-    const trimmed_right = trim_chars_right(string, charset);
-    return trim_chars_left(trimmed_right, charset);
+    const trimmed_right = trim_chars_end(string, charset);
+    return trim_chars_start(trimmed_right, charset);
 }
 
-export function trim_chars_left(string, charset) {
-  const trim_regexp = new_left_trim_regexp(charset);
+export function trim_chars_start(string, charset) {
+  const trim_regexp = new_start_trim_regexp(charset);
 
   return string.replace(trim_regexp, "")
 }
 
-export function trim_chars_right(string, charset) {
+export function trim_chars_end(string, charset) {
   const trim_regexp = new_right_trim_regexp(charset);
 
   return string.replace(trim_regexp, "")
@@ -974,7 +974,7 @@ export function bit_array_compare(first, second) {
   return new Lt();  // second has more items
 }
 
-function new_left_trim_regexp(charset) {
+function new_start_trim_regexp(charset) {
   return new RegExp(`^([${charset}]*)`, "g");
 }
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -316,7 +316,7 @@ export function crash(message) {
 
 export function bit_array_to_string(bit_array) {
   try {
-    const decoder = new TextDecoder("utf-8", { fatarl: true });
+    const decoder = new TextDecoder("utf-8", { fatal: true });
     return new Ok(decoder.decode(bit_array.buffer));
   } catch {
     return new Error(Nil);

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -277,18 +277,18 @@ export function trim_end(string) {
   return string.replace(right_trim_regex, "");
 }
 
-export function trim_chars(string, charset) {
-    const trimmed_right = trim_chars_end(string, charset);
-    return trim_chars_start(trimmed_right, charset);
+export function trim_with(string, charset) {
+    const trimmed_right = trim_end_with(string, charset);
+    return trim_start_with(trimmed_right, charset);
 }
 
-export function trim_chars_start(string, charset) {
+export function trim_start_with(string, charset) {
   const trim_regexp = new_start_trim_regexp(charset);
 
   return string.replace(trim_regexp, "")
 }
 
-export function trim_chars_end(string, charset) {
+export function trim_end_with(string, charset) {
   const trim_regexp = new_right_trim_regexp(charset);
 
   return string.replace(trim_regexp, "")

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -170,6 +170,18 @@ pub fn trim_left_test() {
   |> should.equal("hats  \n")
 }
 
+pub fn trim_left_rtl_test() {
+  "  עברית  "
+  |> string.trim_left
+  |> should.equal("עברית  ")
+}
+
+pub fn trim_right_rtl_test() {
+  "  עברית  "
+  |> string.trim_right
+  |> should.equal("  עברית")
+}
+
 pub fn trim_right_test() {
   "  hats  \n"
   |> string.trim_right
@@ -182,10 +194,22 @@ pub fn trim_chars_left_test() {
   |> should.equal("hats..,")
 }
 
+pub fn trim_chars_left_rtl_test() {
+  "שמש"
+  |> string.trim_chars_left("ש")
+  |> should.equal("מש")
+}
+
 pub fn trim_chars_right_test() {
   ",..hats..,"
   |> string.trim_chars_right(",.")
   |> should.equal(",..hats")
+}
+
+pub fn trim_chars_right_rtl_test() {
+  "שמש"
+  |> string.trim_chars_right("ש")
+  |> should.equal("שמ")
 }
 
 // unicode whitespaces

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -176,6 +176,18 @@ pub fn trim_right_test() {
   |> should.equal("  hats")
 }
 
+pub fn trim_chars_left_test() {
+  ",..hats..,"
+  |> string.trim_chars_left(",.")
+  |> should.equal("hats..,")
+}
+
+pub fn trim_chars_right_test() {
+  ",..hats..,"
+  |> string.trim_chars_right(",.")
+  |> should.equal(",..hats")
+}
+
 // unicode whitespaces
 pub fn trim_horizontal_tab_test() {
   "hats\u{0009}"
@@ -362,6 +374,36 @@ pub fn trim_comma_test() {
   "hats,"
   |> string.trim
   |> should.equal("hats,")
+}
+
+pub fn trim_chars_test() {
+  ",,hats,"
+  |> string.trim_chars(",")
+  |> should.equal("hats")
+}
+
+pub fn trim_chars_commas_and_periods_test() {
+  ",,hats,..."
+  |> string.trim_chars(",.")
+  |> should.equal("hats")
+}
+
+pub fn trim_chars_keeps_whitespace_not_in_charset_test() {
+  ",,hats ,..."
+  |> string.trim_chars(",.")
+  |> should.equal("hats ")
+}
+
+pub fn trim_chars_does_not_trim_from_middle_of_string_test() {
+  ",,hats,hats,hats,..."
+  |> string.trim_chars(",.")
+  |> should.equal("hats,hats,hats")
+}
+
+pub fn trim_chars_trims_complex_graphemes_test() {
+  "hats👍👍👍👍"
+  |> string.trim_chars("👍")
+  |> should.equal("hats")
 }
 
 pub fn starts_with_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -188,27 +188,27 @@ pub fn trim_end_test() {
   |> should.equal("  hats")
 }
 
-pub fn trim_chars_start_test() {
+pub fn trim_start_with_test() {
   ",..hats..,"
-  |> string.trim_chars_start(",.")
+  |> string.trim_start_with(",.")
   |> should.equal("hats..,")
 }
 
-pub fn trim_chars_start_rtl_test() {
+pub fn trim_start_with_rtl_test() {
   "שמש"
-  |> string.trim_chars_start("ש")
+  |> string.trim_start_with("ש")
   |> should.equal("מש")
 }
 
-pub fn trim_chars_end_test() {
+pub fn trim_end_with_test() {
   ",..hats..,"
-  |> string.trim_chars_end(",.")
+  |> string.trim_end_with(",.")
   |> should.equal(",..hats")
 }
 
-pub fn trim_chars_end_rtl_test() {
+pub fn trim_end_with_rtl_test() {
   "שמש"
-  |> string.trim_chars_end("ש")
+  |> string.trim_end_with("ש")
   |> should.equal("שמ")
 }
 
@@ -400,33 +400,33 @@ pub fn trim_comma_test() {
   |> should.equal("hats,")
 }
 
-pub fn trim_chars_test() {
+pub fn trim_with_test() {
   ",,hats,"
-  |> string.trim_chars(",")
+  |> string.trim_with(",")
   |> should.equal("hats")
 }
 
-pub fn trim_chars_commas_and_periods_test() {
+pub fn trim_with_commas_and_periods_test() {
   ",,hats,..."
-  |> string.trim_chars(",.")
+  |> string.trim_with(",.")
   |> should.equal("hats")
 }
 
-pub fn trim_chars_keeps_whitespace_not_in_charset_test() {
+pub fn trim_with_keeps_whitespace_not_in_charset_test() {
   ",,hats ,..."
-  |> string.trim_chars(",.")
+  |> string.trim_with(",.")
   |> should.equal("hats ")
 }
 
-pub fn trim_chars_does_not_trim_from_middle_of_string_test() {
+pub fn trim_with_does_not_trim_from_middle_of_string_test() {
   ",,hats,hats,hats,..."
-  |> string.trim_chars(",.")
+  |> string.trim_with(",.")
   |> should.equal("hats,hats,hats")
 }
 
-pub fn trim_chars_trims_complex_graphemes_test() {
+pub fn trim_with_trims_complex_graphemes_test() {
   "hats👍👍👍👍"
-  |> string.trim_chars("👍")
+  |> string.trim_with("👍")
   |> should.equal("hats")
 }
 

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -164,51 +164,51 @@ pub fn trim_test() {
   |> should.equal("hats")
 }
 
-pub fn trim_left_test() {
+pub fn trim_start_test() {
   "  hats  \n"
-  |> string.trim_left
+  |> string.trim_start
   |> should.equal("hats  \n")
 }
 
-pub fn trim_left_rtl_test() {
+pub fn trim_start_rtl_test() {
   "  עברית  "
-  |> string.trim_left
+  |> string.trim_start
   |> should.equal("עברית  ")
 }
 
-pub fn trim_right_rtl_test() {
+pub fn trim_end_rtl_test() {
   "  עברית  "
-  |> string.trim_right
+  |> string.trim_end
   |> should.equal("  עברית")
 }
 
-pub fn trim_right_test() {
+pub fn trim_end_test() {
   "  hats  \n"
-  |> string.trim_right
+  |> string.trim_end
   |> should.equal("  hats")
 }
 
-pub fn trim_chars_left_test() {
+pub fn trim_chars_start_test() {
   ",..hats..,"
-  |> string.trim_chars_left(",.")
+  |> string.trim_chars_start(",.")
   |> should.equal("hats..,")
 }
 
-pub fn trim_chars_left_rtl_test() {
+pub fn trim_chars_start_rtl_test() {
   "שמש"
-  |> string.trim_chars_left("ש")
+  |> string.trim_chars_start("ש")
   |> should.equal("מש")
 }
 
-pub fn trim_chars_right_test() {
+pub fn trim_chars_end_test() {
   ",..hats..,"
-  |> string.trim_chars_right(",.")
+  |> string.trim_chars_end(",.")
   |> should.equal(",..hats")
 }
 
-pub fn trim_chars_right_rtl_test() {
+pub fn trim_chars_end_rtl_test() {
   "שמש"
-  |> string.trim_chars_right("ש")
+  |> string.trim_chars_end("ש")
   |> should.equal("שמ")
 }
 


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/stdlib/issues/587

The primary intent of this PR is to add `trim_with`, `trim_start_with` and `trim_end_with` to the `string` module, which will trim the specified chars from both ends of a string, the start of a string, or the end of the string, respectively.

Given this change from `left/right` to `start/end` (to be more clear about RTL behavior), I renamed the existing `trim_left`/`trim_end` to `trim_start` and `trim_end`, and deprecated the old ones. Do let me know if this was an over-reach on my part!

The names here are certainly changeable here, I just picked ones that made sense to me :) 