### PR TITLE
Optimise string.pad_left, string.pad_right, string.slice

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -223,6 +223,34 @@ export function length(data) {
   return data.length;
 }
 
+export function string_slice(string, idx, len) {
+  if (len <= 0 || idx >= string.length) {
+    return "";
+  }
+
+  const iterator = graphemes_iterator(string);
+  if (iterator) {
+    while (idx-- > 0) {
+      iterator.next();
+    }
+
+    let result = "";
+
+    while (len-- > 0) {
+      const v = iterator.next().value;
+      if (v === undefined) {
+        break;
+      }
+
+      result += v.segment;
+    }
+
+    return result;
+  } else {
+    return string.match(/./gsu).slice(idx, idx + len).join("");
+  }
+}
+
 export function crop_string(string, substring) {
   return string.substring(string.indexOf(substring));
 }


### PR DESCRIPTION
Noticed in some benchmarks on the JS target that the current implementations of `string.pad_left()` and `string.pad_right()` are substantially slower than native `String.padLeft()` and `String.padRight()`.

This PR switches to using the native functions instead, and all the existing tests pass without any changes.

In my project this took total runtime from ~13s to ~3s.