### PR TITLE
Optimise string.repeat on JS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 - The `bit_array` module gains the `compare` function.
 - The `float` modeule gains the `to_precision` function.
 - The `try_fold` function in the `iterator` module is now tail recursive.
-- The performance of many functions in the `string` module on the JavaScript
-  target has been improved.
+- The performance of many functions in the `string` module has been improved.
 
 ## v0.40.0 - 2024-08-19
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -438,10 +438,14 @@ pub fn concat(strings: List(String)) -> String {
 /// ```
 ///
 pub fn repeat(string: String, times times: Int) -> String {
-  iterator.repeat(string)
-  |> iterator.take(times)
-  |> iterator.to_list
-  |> concat
+  do_repeat(string, times, "")
+}
+
+fn do_repeat(string: String, times: Int, acc: String) -> String {
+  case times <= 0 {
+    True -> acc
+    False -> do_repeat(string, times - 1, acc <> string)
+  }
 }
 
 /// Joins many `String`s together with a given separator.


### PR DESCRIPTION
Using the native repeat function is meaningfully faster.