### PR TITLE
Improve JS string performance by caching the Intl Segmenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - The `bit_array` module gains the `compare` function.
 - The `float` modeule gains the `to_precision` function.
 - The `try_fold` function in the `iterator` module is now tail recursive.
+- The performance of many functions in the `string` module on the JavaScript
+  target has been improved.
 
 ## v0.40.0 - 2024-08-19
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -156,9 +156,12 @@ export function graphemes(string) {
   }
 }
 
+let segmenter = undefined;
+
 function graphemes_iterator(string) {
   if (globalThis.Intl && Intl.Segmenter) {
-    return new Intl.Segmenter().segment(string)[Symbol.iterator]();
+    segmenter ??= new Intl.Segmenter();
+    return segmenter.segment(string)[Symbol.iterator]();
   }
 }
 


### PR DESCRIPTION
This speeds up many string functions including `string.length()`, `string.graphemes()`, `string.pop_grapheme()`, and any functions that call them, e.g. `string.slice()`.

In one app I work on this change reduced the runtime of a piece of string-heavy code from 5.6s to 2.0s.