### PR TITLE
Small refactorings

### DIFF
--- a/src/gleam/bool.gleam
+++ b/src/gleam/bool.gleam
@@ -331,9 +331,9 @@ pub fn to_string(bool: Bool) -> String {
 ///
 pub fn guard(
   when requirement: Bool,
-  return consequence: t,
-  otherwise alternative: fn() -> t,
-) -> t {
+  return consequence: a,
+  otherwise alternative: fn() -> a,
+) -> a {
   case requirement {
     True -> consequence
     False -> alternative()

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -85,9 +85,9 @@ pub fn string(from data: Dynamic) -> Result(String, DecodeErrors) {
 }
 
 fn map_errors(
-  result: Result(t, DecodeErrors),
+  result: Result(a, DecodeErrors),
   f: fn(DecodeError) -> DecodeError,
-) -> Result(t, DecodeErrors) {
+) -> Result(a, DecodeErrors) {
   result.map_error(result, list.map(_, f))
 }
 
@@ -467,7 +467,7 @@ fn decode_field(a: Dynamic, b: name) -> Result(Option(Dynamic), DecodeErrors)
 /// // ])
 /// ```
 ///
-pub fn element(at index: Int, of inner_type: Decoder(t)) -> Decoder(t) {
+pub fn element(at index: Int, of inner_type: Decoder(inner)) -> Decoder(inner) {
   fn(data: Dynamic) {
     use tuple <- result.try(decode_tuple(data))
     let size = tuple_size(tuple)
@@ -1018,7 +1018,7 @@ fn decode_map(a: Dynamic) -> Result(Dict(Dynamic, Dynamic), DecodeErrors)
 /// // -> Error(DecodeError(expected: "another type", found: "Int", path: []))
 /// ```
 ///
-pub fn any(of decoders: List(Decoder(t))) -> Decoder(t) {
+pub fn any(of decoders: List(Decoder(a))) -> Decoder(a) {
   fn(data) {
     case decoders {
       [] ->

--- a/src/gleam/iterator.gleam
+++ b/src/gleam/iterator.gleam
@@ -3,7 +3,6 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/order
-import gleam/result
 
 // Internal private representation of an Iterator
 type Action(element) {

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -331,14 +331,14 @@ pub fn lazy_or(first: Option(a), second: fn() -> Option(a)) -> Option(a) {
 fn do_values(list: List(Option(a)), acc: List(a)) -> List(a) {
   case list {
     [] -> acc
-    [x, ..xs] -> {
+    [first, ..rest] -> {
       let accumulate = fn(acc, item) {
         case item {
           Some(value) -> [value, ..acc]
           None -> acc
         }
       }
-      accumulate(do_values(xs, acc), x)
+      accumulate(do_values(rest, acc), first)
     }
   }
 }

--- a/src/gleam/queue.gleam
+++ b/src/gleam/queue.gleam
@@ -13,8 +13,8 @@ import gleam/list
 /// may return surprising results, and the `is_equal` and `is_logically_equal`
 /// functions are the recommended way to test queues for equality.
 ///
-pub opaque type Queue(element) {
-  Queue(in: List(element), out: List(element))
+pub opaque type Queue(a) {
+  Queue(in: List(a), out: List(a))
 }
 
 /// Creates a fresh queue that contains no values.
@@ -238,11 +238,11 @@ pub fn reverse(queue: Queue(a)) -> Queue(a) {
 }
 
 fn check_equal(
-  xs: List(t),
-  x_tail: List(t),
-  ys: List(t),
-  y_tail: List(t),
-  eq: fn(t, t) -> Bool,
+  xs: List(a),
+  x_tail: List(a),
+  ys: List(a),
+  y_tail: List(a),
+  eq: fn(a, a) -> Bool,
 ) -> Bool {
   case xs, x_tail, ys, y_tail {
     [], [], [], [] -> True
@@ -269,9 +269,9 @@ fn check_equal(
 /// element equality checking function.
 ///
 pub fn is_logically_equal(
-  a: Queue(t),
-  to b: Queue(t),
-  checking element_is_equal: fn(t, t) -> Bool,
+  a: Queue(a),
+  to b: Queue(a),
+  checking element_is_equal: fn(a, a) -> Bool,
 ) -> Bool {
   check_equal(a.out, a.in, b.out, b.in, element_is_equal)
 }
@@ -285,6 +285,6 @@ pub fn is_logically_equal(
 ///
 /// This function runs in linear time.
 ///
-pub fn is_equal(a: Queue(t), to b: Queue(t)) -> Bool {
+pub fn is_equal(a: Queue(a), to b: Queue(a)) -> Bool {
   check_equal(a.out, a.in, b.out, b.in, fn(a, b) { a == b })
 }

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -61,7 +61,10 @@ pub fn compile(
 
 @external(erlang, "gleam_stdlib", "compile_regex")
 @external(javascript, "../gleam_stdlib.mjs", "compile_regex")
-fn do_compile(a: String, with with: Options) -> Result(Regex, CompileError)
+fn do_compile(
+  pattern: String,
+  with with: Options,
+) -> Result(Regex, CompileError)
 
 /// Creates a new `Regex`.
 ///
@@ -105,13 +108,13 @@ pub fn from_string(pattern: String) -> Result(Regex, CompileError) {
 /// // -> False
 /// ```
 ///
-pub fn check(with regex: Regex, content content: String) -> Bool {
-  do_check(regex, content)
+pub fn check(with regex: Regex, content string: String) -> Bool {
+  do_check(regex, string)
 }
 
 @external(erlang, "gleam_stdlib", "regex_check")
 @external(javascript, "../gleam_stdlib.mjs", "regex_check")
-fn do_check(a: Regex, b: String) -> Bool
+fn do_check(regex: Regex, string: String) -> Bool
 
 /// Splits a string.
 ///
@@ -129,7 +132,7 @@ pub fn split(with regex: Regex, content string: String) -> List(String) {
 
 @external(erlang, "gleam_stdlib", "regex_split")
 @external(javascript, "../gleam_stdlib.mjs", "regex_split")
-fn do_split(a: Regex, b: String) -> List(String)
+fn do_split(regex: Regex, string: String) -> List(String)
 
 /// Collects all matches of the regular expression.
 ///
@@ -189,7 +192,7 @@ pub fn scan(with regex: Regex, content string: String) -> List(Match) {
 
 @external(erlang, "gleam_stdlib", "regex_scan")
 @external(javascript, "../gleam_stdlib.mjs", "regex_scan")
-fn do_scan(a: Regex, b: String) -> List(Match)
+fn do_scan(regex: Regex, string: String) -> List(Match)
 
 /// Creates a new `String` by replacing all substrings that match the regular
 /// expression.

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -424,7 +424,7 @@ pub fn replace(result: Result(a, e), value: b) -> Result(b, e) {
 /// // -> Ok(1)
 /// ```
 ///
-pub fn replace_error(result: Result(a, e1), error: e2) -> Result(a, e2) {
+pub fn replace_error(result: Result(a, e), error: f) -> Result(a, f) {
   case result {
     Ok(x) -> Ok(x)
     Error(_) -> Error(error)

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -1,7 +1,6 @@
 //// Strings in Gleam are UTF-8 binaries. They can be written in your code as
 //// text surrounded by `"double quotes"`.
 
-import gleam/iterator
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/order
@@ -365,15 +364,18 @@ pub fn split(x: String, on substring: String) -> List(String) {
 /// ```
 ///
 pub fn split_once(
-  x: String,
+  string: String,
   on substring: String,
 ) -> Result(#(String, String), Nil) {
-  do_split_once(x, substring)
+  do_split_once(string, substring)
 }
 
 @external(javascript, "../gleam_stdlib.mjs", "split_once")
-fn do_split_once(x: String, substring: String) -> Result(#(String, String), Nil) {
-  case erl_split(x, substring) {
+fn do_split_once(
+  string: String,
+  substring: String,
+) -> Result(#(String, String), Nil) {
+  case erl_split(string, substring) {
     [first, rest] -> Ok(#(first, rest))
     _ -> Error(Nil)
   }
@@ -711,7 +713,7 @@ fn do_to_utf_codepoints(string: String) -> List(UtfCodepoint) {
 
 @target(javascript)
 @external(javascript, "../gleam_stdlib.mjs", "string_to_codepoint_integer_list")
-fn string_to_codepoint_integer_list(a: String) -> List(Int)
+fn string_to_codepoint_integer_list(string: String) -> List(Int)
 
 /// Converts a `List` of `UtfCodepoint`s to a `String`.
 ///
@@ -779,10 +781,10 @@ fn do_utf_codepoint_to_int(cp cp: UtfCodepoint) -> Int
 /// // -> Some("hats")
 /// ```
 ///
-pub fn to_option(s: String) -> Option(String) {
-  case s {
+pub fn to_option(string: String) -> Option(String) {
+  case string {
     "" -> None
-    _ -> Some(s)
+    _ -> Some(string)
   }
 }
 
@@ -802,8 +804,8 @@ pub fn to_option(s: String) -> Option(String) {
 /// // -> Ok("i")
 /// ```
 ///
-pub fn first(s: String) -> Result(String, Nil) {
-  case pop_grapheme(s) {
+pub fn first(string: String) -> Result(String, Nil) {
+  case pop_grapheme(string) {
     Ok(#(first, _)) -> Ok(first)
     Error(e) -> Error(e)
   }
@@ -825,8 +827,8 @@ pub fn first(s: String) -> Result(String, Nil) {
 /// // -> Ok("m")
 /// ```
 ///
-pub fn last(s: String) -> Result(String, Nil) {
-  case pop_grapheme(s) {
+pub fn last(string: String) -> Result(String, Nil) {
+  case pop_grapheme(string) {
     Ok(#(first, "")) -> Ok(first)
     Ok(#(_, rest)) -> Ok(slice(rest, -1, 1))
     Error(e) -> Error(e)
@@ -843,8 +845,8 @@ pub fn last(s: String) -> Result(String, Nil) {
 /// // -> "Mamouna"
 /// ```
 ///
-pub fn capitalise(s: String) -> String {
-  case pop_grapheme(s) {
+pub fn capitalise(string: String) -> String {
+  case pop_grapheme(string) {
     Ok(#(first, rest)) -> append(to: uppercase(first), suffix: lowercase(rest))
     _ -> ""
   }
@@ -859,7 +861,7 @@ pub fn inspect(term: anything) -> String {
 
 @external(erlang, "gleam_stdlib", "inspect")
 @external(javascript, "../gleam_stdlib.mjs", "inspect")
-fn do_inspect(term term: anything) -> StringBuilder
+fn do_inspect(term: anything) -> StringBuilder
 
 /// Returns the number of bytes in a `String`.
 ///

--- a/src/gleam/string_builder.gleam
+++ b/src/gleam/string_builder.gleam
@@ -92,7 +92,7 @@ pub fn concat(builders: List(StringBuilder)) -> StringBuilder {
 
 @external(erlang, "gleam_stdlib", "identity")
 @external(javascript, "../gleam_stdlib.mjs", "concat")
-fn do_concat(a: List(StringBuilder)) -> StringBuilder
+fn do_concat(builders: List(StringBuilder)) -> StringBuilder
 
 /// Converts a string into a builder.
 ///
@@ -104,7 +104,7 @@ pub fn from_string(string: String) -> StringBuilder {
 
 @external(erlang, "gleam_stdlib", "identity")
 @external(javascript, "../gleam_stdlib.mjs", "identity")
-fn do_from_string(a: String) -> StringBuilder
+fn do_from_string(string: String) -> StringBuilder
 
 /// Turns an `StringBuilder` into a `String`
 ///
@@ -117,7 +117,7 @@ pub fn to_string(builder: StringBuilder) -> String {
 
 @external(erlang, "unicode", "characters_to_binary")
 @external(javascript, "../gleam_stdlib.mjs", "identity")
-fn do_to_string(a: StringBuilder) -> String
+fn do_to_string(builder: StringBuilder) -> String
 
 /// Returns the size of the `StringBuilder` in bytes.
 ///
@@ -127,7 +127,7 @@ pub fn byte_size(builder: StringBuilder) -> Int {
 
 @external(erlang, "erlang", "iolist_size")
 @external(javascript, "../gleam_stdlib.mjs", "length")
-fn do_byte_size(a: StringBuilder) -> Int
+fn do_byte_size(builder: StringBuilder) -> Int
 
 /// Joins the given builders into a new builder separated with the given string
 ///
@@ -146,7 +146,7 @@ pub fn lowercase(builder: StringBuilder) -> StringBuilder {
 
 @external(erlang, "string", "lowercase")
 @external(javascript, "../gleam_stdlib.mjs", "lowercase")
-fn do_lowercase(a: StringBuilder) -> StringBuilder
+fn do_lowercase(builder: StringBuilder) -> StringBuilder
 
 /// Converts a builder to a new builder where the contents have been
 /// uppercased.
@@ -157,7 +157,7 @@ pub fn uppercase(builder: StringBuilder) -> StringBuilder {
 
 @external(erlang, "string", "uppercase")
 @external(javascript, "../gleam_stdlib.mjs", "uppercase")
-fn do_uppercase(a: StringBuilder) -> StringBuilder
+fn do_uppercase(builder: StringBuilder) -> StringBuilder
 
 /// Converts a builder to a new builder with the contents reversed.
 ///
@@ -175,7 +175,7 @@ fn do_reverse(builder: StringBuilder) -> StringBuilder {
 }
 
 @external(javascript, "../gleam_stdlib.mjs", "graphemes")
-fn do_to_graphemes(string string: String) -> List(String)
+fn do_to_graphemes(string: String) -> List(String)
 
 /// Splits a builder on a given pattern into a list of builders.
 ///

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -179,7 +179,7 @@ fn extra_required(list: List(a), remaining: Int) -> Int {
   case list {
     _ if remaining == 0 -> 0
     [] -> remaining
-    [_, ..xs] -> extra_required(xs, remaining - 1)
+    [_, ..rest] -> extra_required(rest, remaining - 1)
   }
 }
 


### PR DESCRIPTION
This PR contains many small refactorings to make sure the stdlib follows a consistent style:
- type variables for collection items are `a`, `b`, ...
- type variables for errors are `e`, `f`, ...
- type variables for dicts or key-value things are `k` and `v`
- when pattern matching on a list it's always `[first, ..rest]` instead of `[x, ..XS]`
- in public apis argument names are full words instead of single letters (e.g. `first(s: String)` becomes `first(string: String)`)
- I've added type signatures in a couple top level functions that didn't have it
- I've removed an unused import from the `iterator` module

The only exceptions are the `set` and `iterator` modules where the type variable seems to almost always be called `member` and `element` respectively instead of a plain `a`. So I haven't changed it, but if you want I can take care of that as well and make it consistent with the rest!