### PR TITLE
deprecate `io.debug` in favour of `echo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The `debug` function in the `io` module has been deprecated in favour of
+  the `echo` keyword.
+
 ## v0.58.0 - 2025-03-23
 
 - The deprecated `pop` and `pop_map` functions have been removed from the

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -93,6 +93,7 @@ pub fn println_error(string: String) -> Nil
 /// with some types having the same runtime representation results in it not
 /// always being possible to correctly choose which Gleam syntax to show.
 ///
+@deprecated("To debug print a value use the `echo` keyword instead")
 pub fn debug(term: anything) -> anything {
   term
   |> string.inspect


### PR DESCRIPTION
This can be merged only after <https://github.com/gleam-lang/gleam/pull/3676> has been merged.