### PR TITLE
Hint at user when to use `result.lazy_or` vs `result.try_recover`

### DIFF
--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -313,6 +313,8 @@ pub fn or(first: Result(a, e), second: Result(a, e)) -> Result(a, e) {
 
 /// Returns the first value if it is `Ok`, otherwise evaluates the given function for a fallback value.
 ///
+/// If you need access to the initial error value, use `result.try_recover`.
+///
 /// ## Examples
 ///
 /// ```gleam
@@ -453,6 +455,8 @@ pub fn values(results: List(Result(a, e))) -> List(a) {
 ///
 /// This function is useful for chaining together computations that may fail
 /// and trying to recover from possible errors.
+///
+/// If you do not need access to the initial error value, use `result.lazy_or`.
 ///
 /// ## Examples
 ///


### PR DESCRIPTION
I found myself using `result.try_recover` like this, where I was ignoring the error value returned:

```gleam
import gleam/result

pub fn main() {
  use _ <- result.try_recover(Error(1))
  use _ <- result.try_recover(Error(2))
  Error(3)
}
```

Later, I found I could use `result.lazy_or`:

```gleam
import gleam/result

pub fn main() {
  use <- result.lazy_or(Error(1))
  use <- result.lazy_or(Error(2))
  Error(3)
}
```

... and I didn't need to use `_` to omit anything, as it does not provide the error value, which fit my use case better.

Maybe the wording can be improved, but I think this might be something worth calling out in the docs.
