### PR TITLE
Improve `float.to_string` on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## v0.41.0 - Unreleased
 
 - The `bit_array` module gains the `compare` function.
-- The `float` modeule gains the `to_precision` function.
-- The `try_fold` function in the `iterator` module is now tail recursive.
+- The `float` module gains the `to_precision` function.
+- The `iterator.try_fold` function is now tail recursive.
 - The performance of many functions in the `string` module has been improved.
-- The `concat` function in the `list` module has been deprecated in favour of
-  `flatten`.
+- The `list.concat` function has been deprecated in favour of `list.flatten`.
+- The handling of exponentials and signs in the `float.to_string` function has
+  been improved on JavaScript.
+- The `string.inspect` function delegates the inspection of floats to
+  `float.to_string`.
 
 ## v0.40.0 - 2024-08-19
 

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -47,11 +47,16 @@ export function to_string(term) {
 }
 
 export function float_to_string(float) {
-  const string = float.toString();
+  const string = float.toString().replace('+', '');
   if (string.indexOf(".") >= 0) {
     return string;
   } else {
-    return string + ".0";
+    const index = string.indexOf("e");
+    if (index >= 0) {
+      return string.slice(0, index) + '.0' + string.slice(index);
+    } else {
+      return string + ".0";
+    }
   }
 }
 
@@ -837,7 +842,8 @@ export function inspect(v) {
   if (v === null) return "//js(null)";
   if (v === undefined) return "Nil";
   if (t === "string") return inspectString(v);
-  if (t === "bigint" || t === "number") return v.toString();
+  if (t === "bigint" || Number.isInteger(v)) return v.toString();
+  if (t === "number") return float_to_string(v);
   if (Array.isArray(v)) return `#(${v.map(inspect).join(", ")})`;
   if (v instanceof List) return inspectList(v);
   if (v instanceof UtfCodepoint) return inspectUtfCodepoint(v);

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -52,13 +52,65 @@ pub fn parse_test() {
 }
 
 pub fn to_string_test() {
+  0.0
+  |> float.to_string
+  |> should.equal("0.0")
+
+  0.0123
+  |> float.to_string
+  |> should.equal("0.0123")
+
+  -0.0123
+  |> float.to_string
+  |> should.equal("-0.0123")
+
+  12.67
+  |> float.to_string
+  |> should.equal("12.67")
+
+  -12.67
+  |> float.to_string
+  |> should.equal("-12.67")
+
   123.0
   |> float.to_string
   |> should.equal("123.0")
 
-  -8.1
+  -123.0
   |> float.to_string
-  |> should.equal("-8.1")
+  |> should.equal("-123.0")
+
+  3.0e26
+  |> float.to_string
+  |> should.equal("3.0e26")
+
+  -3.0e26
+  |> float.to_string
+  |> should.equal("-3.0e26")
+
+  3.0e-26
+  |> float.to_string
+  |> should.equal("3.0e-26")
+
+  -3.0e-26
+  |> float.to_string
+  |> should.equal("-3.0e-26")
+
+  456.12e78
+  |> float.to_string
+  |> should.equal("4.5612e80")
+
+  -456.12e78
+  |> float.to_string
+  |> should.equal("-4.5612e80")
+
+  456.12e-78
+  |> float.to_string
+  |> should.equal("4.5612e-76")
+
+  -456.12e-78
+  |> float.to_string
+  |> should.equal("-4.5612e-76")
 }
 
 pub fn clamp_test() {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -848,8 +848,14 @@ pub fn inspect_test() {
   string.inspect(-1.5)
   |> should.equal("-1.5")
 
+  string.inspect(5.0e-26)
+  |> should.equal("5.0e-26")
+
   string.inspect(1.5)
   |> should.equal("1.5")
+
+  string.inspect(-5.0e-26)
+  |> should.equal("-5.0e-26")
 
   string.inspect([1.5])
   |> should.equal("[1.5]")


### PR DESCRIPTION
Improve `float.to_string` handling of exponentials and sings. Address https://github.com/gleam-lang/stdlib/issues/694.

Before this PR `float.to_string(1.0e123)` would output `1e+123.0`.
