### PR TITLE
Add `set.each` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - The `list.concat` function has been deprecated in favour of `list.flatten`.
 - The handling of float exponentials and signs in the `float.to_string` and
   `string.inspect` functions have been improved on JavaScript.
+- The `set` module gains the `each` function.
 
 ## v0.40.0 - 2024-08-19
 

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -380,3 +380,30 @@ pub fn symmetric_difference(
     minus: intersection(of: first, and: second),
   )
 }
+
+/// Calls a function for each member in a set, discarding the return
+/// value.
+///
+/// Useful for producing a side effect for every item of a set.
+///
+/// ```gleam
+/// import gleam/io
+///
+/// let set = from_list(["apple", "banana", "cherry"])
+///
+/// each(set, io.println)
+/// // -> Nil
+/// // apple
+/// // banana
+/// // cherry
+/// ```
+///
+/// The order of elements in the iteration is an implementation detail that
+/// should not be relied upon.
+///
+pub fn each(set: Set(member), fun: fn(member) -> a) -> Nil {
+  fold(set, Nil, fn(nil, member) {
+    fun(member)
+    nil
+  })
+}

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -387,8 +387,6 @@ pub fn symmetric_difference(
 /// Useful for producing a side effect for every item of a set.
 ///
 /// ```gleam
-/// import gleam/io
-///
 /// let set = from_list(["apple", "banana", "cherry"])
 ///
 /// each(set, io.println)

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -158,3 +158,15 @@ pub fn symmetric_difference_test() {
   set.symmetric_difference(set.from_list([1, 2, 3]), set.from_list([3, 4]))
   |> should.equal(set.from_list([1, 2, 4]))
 }
+
+pub fn each_test() {
+  [1, 2, 3]
+  |> set.from_list
+  |> set.each(fn(member) {
+    let assert True = case member {
+      1 | 2 | 3 -> True
+      _ -> False
+    }
+  })
+  |> should.equal(Nil)
+}

--- a/test/gleam/set_test.gleam
+++ b/test/gleam/set_test.gleam
@@ -163,9 +163,9 @@ pub fn each_test() {
   [1, 2, 3]
   |> set.from_list
   |> set.each(fn(member) {
-    let assert True = case member {
-      1 | 2 | 3 -> True
-      _ -> False
+    case member {
+      1 | 2 | 3 -> Nil
+      _ -> panic as "unexpected value"
     }
   })
   |> should.equal(Nil)


### PR DESCRIPTION
Found myself needing this while working on a project, saw that `list` and `dict` had equivalent functions, so I thought it would be nice if `set` had one too.

Implementation, documentation and test adapted from the `list` and `dict` equivalents.