### PR TITLE
Adds capitalize function to string module as alias of capitalise

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -857,6 +857,11 @@ pub fn capitalise(string: String) -> String {
   }
 }
 
+/// Alias for [capitalise](#capitalise)
+pub fn capitalize(string: String) -> String {
+  capitalise(string)
+}
+
 /// Returns a `String` representation of a term in Gleam syntax.
 ///
 pub fn inspect(term: anything) -> String {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -778,6 +778,40 @@ pub fn capitalise_test() {
   |> should.equal("る")
 }
 
+pub fn capitalize_test() {
+  ""
+  |> string.capitalize
+  |> should.equal("")
+
+  "gleam"
+  |> string.capitalize
+  |> should.equal("Gleam")
+
+  "GLEAM"
+  |> string.capitalize
+  |> should.equal("Gleam")
+
+  "g l e a m"
+  |> string.capitalize
+  |> should.equal("G l e a m")
+
+  "1GLEAM"
+  |> string.capitalize
+  |> should.equal("1gleam")
+
+  "_gLeAm1"
+  |> string.capitalize
+  |> should.equal("_gleam1")
+
+  " gLeAm1"
+  |> string.capitalize
+  |> should.equal(" gleam1")
+
+  "る"
+  |> string.capitalize
+  |> should.equal("る")
+}
+
 type InspectType(a, b) {
   InspectTypeZero
   InspectTypeOne(a)


### PR DESCRIPTION
Hi! This is my first time attempting to contribute to an open source project. (And also my first time attempting to use git.)

This pull request adds a "capitalize" function to the string module in the standard library as an alias of of "capitalise." I have mistyped "capitalise" as "capitalize" about seventeen times now. I expect other gleam beginners and programming novices from my part of the world will have similar frustrations as they become familiar with the standard library.

I know that the Gleam ecosystem has pretty consistent British spellings throughout, and that having one function instead of two that do the same thing is simpler and more concise. However, for standard library function names, in my view, it seems more in keeping with the Gleam community values to make them as inclusive and as easy to use as possible, regardless of where in the world one has learned (learnt?) to spell. These types of changes are particularly friendly to speakers of English as a second language, who might not even have knowledge of the regional differences.

But mostly, this change had the benefit of being a very simple change to get my feet wet as an open source contributor. Even if "capitalize" is not deemed a worthy addition, I will call it a great success if I have managed to even submit the pull request properly. Huzzah!