### PR TITLE
Clarify documentation for 'list.group'

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -254,8 +254,7 @@ pub fn rest(list: List(a)) -> Result(List(a), Nil) {
   }
 }
 
-/// Takes a list and groups the values by a key
-/// which is built from a key function.
+/// Groups the elements from the given list by the given key function.
 ///
 /// Does not preserve the initial value order.
 ///


### PR DESCRIPTION
Reworded the summary line to use similar structure as other function summaries in the list module and made the note about not preserving initial value order be more specific.

While in hindsight it makes sense what "does not preserve" means, and it can also be deducted from the supplied examples, at least for me it wasn't obvious at first glance and I ended up looking at the source code for answers.

