### PR TITLE
Add `bit_array.bit_size()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `bit_array` module gains the `bit_size` function.
+
 ## v0.41.0 - 2024-10-31
 
 Happy Samhain! 🎃

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -10,6 +10,12 @@ import gleam/string
 @external(javascript, "../gleam_stdlib.mjs", "bit_array_from_string")
 pub fn from_string(x: String) -> BitArray
 
+/// Returns an integer which is the number of bits in the bit array.
+///
+@external(erlang, "erlang", "bit_size")
+@external(javascript, "../gleam_stdlib.mjs", "bit_array_bit_size")
+pub fn bit_size(x: BitArray) -> Int
+
 /// Returns an integer which is the number of bytes in the bit array.
 ///
 @external(erlang, "erlang", "byte_size")
@@ -202,8 +208,6 @@ fn inspect_loop(input: BitArray, accumulator: String) -> String {
 /// compare(<<1, 2:size(2)>>, with: <<1, 2:size(2)>>)
 /// // -> Eq
 /// ```
-///
-/// Only supported on Erlang target for now.
 ///
 @external(javascript, "../gleam_stdlib.mjs", "bit_array_compare")
 pub fn compare(a: BitArray, with b: BitArray) -> order.Order {

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -310,6 +310,10 @@ export function trim_right(string) {
   return string.replace(right_trim_regex, "");
 }
 
+export function bit_array_bit_size(bit_array) {
+  return bit_array.length * 8;
+}
+
 export function bit_array_from_string(string) {
   return toBitArray([stringBits(string)]);
 }

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -4,6 +4,35 @@ import gleam/result
 import gleam/should
 import gleam/string
 
+pub fn bit_size_test() {
+  bit_array.bit_size(<<>>)
+  |> should.equal(0)
+
+  bit_array.bit_size(<<0>>)
+  |> should.equal(8)
+
+  bit_array.bit_size(<<-1:32>>)
+  |> should.equal(32)
+
+  bit_array.bit_size(<<0:-8>>)
+  |> should.equal(0)
+}
+
+@target(erlang)
+pub fn bit_size_unaligned_test() {
+  bit_array.bit_size(<<0:1>>)
+  |> should.equal(1)
+
+  bit_array.bit_size(<<7:3>>)
+  |> should.equal(3)
+
+  bit_array.bit_size(<<-1:190>>)
+  |> should.equal(190)
+
+  bit_array.bit_size(<<0:-1>>)
+  |> should.equal(0)
+}
+
 pub fn byte_size_test() {
   bit_array.byte_size(bit_array.from_string("hello"))
   |> should.equal(5)


### PR DESCRIPTION
Implements #727.

Also removed the sentence "Only supported on Erlang target for now." from `bit_array.compare()` which seems to be incorrect.

I used the argument name `x` because that's what `byte_size` uses, but there is some inconstancy in the bit array functions: sometimes the bit array argument is called `x`, sometimes `bits`, and sometimes `input`. Should this be unified to e.g. always be called `bits`?