### PR TITLE
Optimise dict equality check on JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Comparing two `Dict`s of equal size has been optimised on the JavaScript
+  target.
+
 ## v0.45.0 - 2024-11-28
 
 - The performance of `string.trim`, `string.trim_start`, and `string.trim_end`

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -968,10 +968,24 @@ export default class Dict {
     if (!(o instanceof Dict) || this.size !== o.size) {
       return false;
     }
-    let equal = true;
-    this.forEach((v, k) => {
-      equal = equal && isEqual(o.get(k, !v), v);
-    });
-    return equal;
+
+    try {
+      this.forEach((v, k) => {
+        if (!isEqual(o.get(k, !v), v)) {
+          throw unequalDictSymbol;
+        }
+      });
+      return true;
+    } catch (e) {
+      if (e === unequalDictSymbol) {
+        return false;
+      }
+
+      throw e;
+    }
   }
 }
+
+// This is thrown internally in Dict.equals() so that it returns false as soon
+// as a non-matching key is found
+const unequalDictSymbol = Symbol();

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -14,6 +14,14 @@ pub fn from_list_test() {
   [#(1, 0), #(1, 1)]
   |> dict.from_list
   |> should.equal(dict.from_list([#(1, 1)]))
+
+  [#(1, 0), #(2, 1)]
+  |> dict.from_list
+  |> should.not_equal(dict.from_list([#(1, 0), #(2, 2)]))
+
+  [#(1, 0), #(2, 1)]
+  |> dict.from_list
+  |> should.not_equal(dict.from_list([#(1, 0), #(3, 1)]))
 }
 
 pub fn has_key_test() {


### PR DESCRIPTION
The dict equality check now returns false as soon as any item doesn't match, rather than continuing to unnecessarily check remaining items.