### PR TITLE
Remove regex dependency from uri module

### DIFF
--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -226,8 +226,6 @@ fn parse_host_within_brackets_loop(
     "" -> Ok(Uri(..pieces, host: Some(uri_string)))
 
     // A `]` marks the end of the host and the start of the port part.
-    // A port must always be preceded by a `:`, otherwise this is an invalid
-    // uri.
     "]" <> rest if size == 0 -> parse_port(rest, pieces)
     "]" <> rest -> {
       let host = codeunit_slice(original, at_index: 0, length: size + 1)
@@ -268,8 +266,9 @@ fn parse_host_within_brackets_loop(
       case is_valid_host_withing_brackets_char(char) {
         True ->
           parse_host_within_brackets_loop(original, rest, pieces, size + 1)
+
         False ->
-          parse_host_outside_of_brackets_loop(original, rest, pieces, size + 1)
+          parse_host_outside_of_brackets_loop(original, original, pieces, 0)
       }
     }
   }

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -65,6 +65,9 @@ pub fn do_parse(uri_string: String) -> Result(Uri, Nil) {
       query_with_question_mark: query,
       fragment: fragment,
     )) -> {
+      // TODO: instead of splitting the authority as a second step we can avoid
+      // going over this part of the string twice and incorporate the parsing in
+      // the main loop.
       let AuthorityPieces(userinfo: userinfo, host: host, port: port) =
         split_authority(authority_with_slashes)
       Ok(Uri(

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -3,18 +3,19 @@
 -export([
     map_get/2, iodata_append/2, identity/1, decode_int/1, decode_bool/1,
     decode_float/1, decode_list/1, decode_option/2, decode_field/2, parse_int/1,
-    parse_float/1, less_than/2, string_pop_grapheme/1, string_starts_with/2,
-    wrap_list/1, string_ends_with/2, string_pad/4, decode_map/1, uri_parse/1,
-    bit_array_int_to_u32/1, bit_array_int_from_u32/1, decode_result/1,
-    bit_array_slice/3, decode_bit_array/1, compile_regex/2, regex_scan/2,
-    percent_encode/1, percent_decode/1, regex_check/2, regex_split/2,
-    base_decode64/1, parse_query/1, bit_array_concat/1,
-    bit_array_base64_encode/2, size_of_tuple/1,
-    decode_tuple/1, decode_tuple2/1, decode_tuple3/1, decode_tuple4/1,
-    decode_tuple5/1, decode_tuple6/1, tuple_get/2, classify_dynamic/1, print/1,
-    println/1, print_error/1, println_error/1, inspect/1, float_to_string/1,
-    int_from_base_string/2, utf_codepoint_list_to_string/1, contains_string/2,
-    crop_string/2, base16_decode/1, string_replace/3, regex_replace/3, slice/3, bit_array_to_int_and_size/1
+    parse_float/1, less_than/2, string_pop_grapheme/1, string_pop_codeunit/1,
+    string_starts_with/2, wrap_list/1, string_ends_with/2, string_pad/4,
+    decode_map/1, uri_parse/1, bit_array_int_to_u32/1, bit_array_int_from_u32/1,
+    decode_result/1, bit_array_slice/3, decode_bit_array/1, compile_regex/2,
+    regex_scan/2, percent_encode/1, percent_decode/1, regex_check/2,
+    regex_split/2, base_decode64/1, parse_query/1, bit_array_concat/1,
+    bit_array_base64_encode/2, size_of_tuple/1, decode_tuple/1, decode_tuple2/1,
+    decode_tuple3/1, decode_tuple4/1, decode_tuple5/1, decode_tuple6/1,
+    tuple_get/2, classify_dynamic/1, print/1, println/1, print_error/1,
+    println_error/1, inspect/1, float_to_string/1, int_from_base_string/2,
+    utf_codepoint_list_to_string/1, contains_string/2, crop_string/2,
+    base16_decode/1, string_replace/3, regex_replace/3, slice/3,
+    bit_array_to_int_and_size/1
 ]).
 
 %% Taken from OTP's uri_string module
@@ -202,6 +203,9 @@ string_pop_grapheme(String) ->
 
         _ -> {error, nil}
     end.
+
+string_pop_codeunit(<<Cp/integer, Rest/binary>>) -> {Cp, Rest};
+string_pop_codeunit(Binary) -> {0, Binary}.
 
 bit_array_concat(BitArrays) ->
     list_to_bitstring(BitArrays).

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -185,6 +185,10 @@ export function pop_grapheme(string) {
   }
 }
 
+export function pop_codeunit(str) {
+  return [str.charCodeAt(0)|0, str.slice(1)]
+}
+
 export function lowercase(string) {
   return string.toLowerCase();
 }
@@ -256,6 +260,9 @@ export function string_slice(string, idx, len) {
   }
 }
 
+export function string_codeunit_slice(str, from, length) {
+  return str.slice(from, from + length)
+}
 export function crop_string(string, substring) {
   return string.substring(string.indexOf(substring));
 }
@@ -1004,3 +1011,4 @@ export function bit_array_starts_with(bits, prefix) {
 
   return true;
 }
+

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -177,6 +177,7 @@ fn assert_parse(s) {
 //   assert ":https" = uri.parse(":https").path
 //   assert "https" = uri.parse("https").path
 // }
+
 pub fn parse_downcases_scheme() {
   let assert Ok(uri) = uri.parse("HTTPS://EXAMPLE.COM")
   let assert Some("https") = uri.scheme


### PR DESCRIPTION
This PR closes #734

~~This version that's using `pop_grapheme` is about 10x slower than the implementation that uses a regex, which is unfortunate.~~
I've managed to make this (thanks to @joshi-monster!!) as fast as the implementation using regexes!!