### PR TITLE
Show more informative error when dynamic.dict fails

### DIFF
--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -974,15 +974,19 @@ pub fn dict(
     use pairs <- result.try(
       dict
       |> dict.to_list
-      |> list.try_map(fn(pair) {
+      |> list.index_map(fn(pair, index) {
         let #(k, v) = pair
+        #(index, k, v)
+      })
+      |> list.try_map(fn(triplet) {
+        let #(i, k, v) = triplet
         use k <- result.try(
           key_type(k)
-          |> map_errors(push_path(_, "keys")),
+          |> map_errors(push_path(_, "keys[" <> int.to_string(i) <> "]")),
         )
         use v <- result.try(
           value_type(v)
-          |> map_errors(push_path(_, "values")),
+          |> map_errors(push_path(_, "values[" <> int.to_string(i) <> "]")),
         )
         Ok(#(k, v))
       }),

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -1128,18 +1128,18 @@ pub fn dict_test() {
   |> dynamic.dict(dynamic.string, dynamic.int)
   |> should.equal(Ok(dict.from_list([#("a", 1), #("b", 2)])))
 
-  dict.from_list([#("a", 1), #("b", 2)])
+  dict.from_list([#(dynamic.from(3), 1), #(dynamic.from("b"), 2)])
   |> dynamic.from
   |> dynamic.dict(dynamic.int, dynamic.int)
   |> should.equal(
-    Error([DecodeError(expected: "Int", found: "String", path: ["keys[0]"])]),
+    Error([DecodeError(expected: "Int", found: "String", path: ["keys[1]"])]),
   )
 
-  dict.from_list([#("a", 1), #("b", 2)])
+  dict.from_list([#("a", dynamic.from("b")), #("b", dynamic.from(1))])
   |> dynamic.from
   |> dynamic.dict(dynamic.string, dynamic.string)
   |> should.equal(
-    Error([DecodeError(expected: "String", found: "Int", path: ["values[0]"])]),
+    Error([DecodeError(expected: "String", found: "Int", path: ["values[1]"])]),
   )
 
   1

--- a/test/gleam/dynamic_test.gleam
+++ b/test/gleam/dynamic_test.gleam
@@ -1132,14 +1132,14 @@ pub fn dict_test() {
   |> dynamic.from
   |> dynamic.dict(dynamic.int, dynamic.int)
   |> should.equal(
-    Error([DecodeError(expected: "Int", found: "String", path: ["keys"])]),
+    Error([DecodeError(expected: "Int", found: "String", path: ["keys[0]"])]),
   )
 
   dict.from_list([#("a", 1), #("b", 2)])
   |> dynamic.from
   |> dynamic.dict(dynamic.string, dynamic.string)
   |> should.equal(
-    Error([DecodeError(expected: "String", found: "Int", path: ["values"])]),
+    Error([DecodeError(expected: "String", found: "Int", path: ["values[0]"])]),
   )
 
   1


### PR DESCRIPTION
https://github.com/gleam-lang/stdlib/issues/740

This makes the decoding error a bit more informative by showing the index of the failed value or key.
As the key can decode to anything (not necessarily a string). It is not possible to show the name of the key.