### PR TITLE
Pad to a whole number of bytes when encoding bit arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The performance of `string.trim`, `string.trim_start`, and `string.trim_end`
   has been improved on JavaScript.
+- The `base64_encode`, `base64_url_encode`, and `base16_encode` functions in the
+  `bit_array` module no longer throw an exception when called with a bit array
+  which is not a whole number of bytes. Instead, the bit array is now padded
+  with zero bits prior to being encoded.
 
 ## v0.44.0 - 2024-11-25
 

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -108,6 +108,9 @@ fn do_to_string(bits: BitArray) -> Result(String, Nil) {
 pub fn concat(bit_arrays: List(BitArray)) -> BitArray
 
 /// Encodes a BitArray into a base 64 encoded string.
+/// 
+/// If the bit array does not contain a whole number of bytes then it is padded
+/// with zero bits prior to being encoded.
 ///
 @external(erlang, "gleam_stdlib", "bit_array_base64_encode")
 @external(javascript, "../gleam_stdlib.mjs", "encode64")
@@ -127,7 +130,11 @@ pub fn base64_decode(encoded: String) -> Result(BitArray, Nil) {
 @external(javascript, "../gleam_stdlib.mjs", "decode64")
 fn decode64(a: String) -> Result(BitArray, Nil)
 
-/// Encodes a `BitArray` into a base 64 encoded string with URL and filename safe alphabet.
+/// Encodes a `BitArray` into a base 64 encoded string with URL and filename
+/// safe alphabet.
+///
+/// If the bit array does not contain a whole number of bytes then it is padded
+/// with zero bits prior to being encoded.
 ///
 pub fn base64_url_encode(input: BitArray, padding: Bool) -> String {
   base64_encode(input, padding)
@@ -135,7 +142,8 @@ pub fn base64_url_encode(input: BitArray, padding: Bool) -> String {
   |> string.replace("/", "_")
 }
 
-/// Decodes a base 64 encoded string with URL and filename safe alphabet into a `BitArray`.
+/// Decodes a base 64 encoded string with URL and filename safe alphabet into a
+/// `BitArray`.
 ///
 pub fn base64_url_decode(encoded: String) -> Result(BitArray, Nil) {
   encoded
@@ -144,10 +152,17 @@ pub fn base64_url_decode(encoded: String) -> Result(BitArray, Nil) {
   |> base64_decode()
 }
 
-@external(erlang, "binary", "encode_hex")
+/// Encodes a `BitArray` into a base 16 encoded string.
+///
+/// If the bit array does not contain a whole number of bytes then it is padded
+/// with zero bits prior to being encoded.
+///
+@external(erlang, "gleam_stdlib", "base16_encode")
 @external(javascript, "../gleam_stdlib.mjs", "base16_encode")
 pub fn base16_encode(input: BitArray) -> String
 
+/// Decodes a base 16 encoded string into a `BitArray`.
+///
 @external(erlang, "gleam_stdlib", "base16_decode")
 @external(javascript, "../gleam_stdlib.mjs", "base16_decode")
 pub fn base16_decode(input: String) -> Result(BitArray, Nil)

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -207,6 +207,23 @@ pub fn base64_encode_test() {
   ))
 }
 
+// This test is target specific since it's using non byte-aligned BitArrays
+// and those are not supported on the JavaScript target.
+@target(erlang)
+pub fn base64_erlang_only_encode_test() {
+  <<-1:7>>
+  |> bit_array.base64_encode(True)
+  |> should.equal("/g==")
+
+  <<0xFA, 5:3>>
+  |> bit_array.base64_encode(True)
+  |> should.equal("+qA=")
+
+  <<0xFA, 0xBC, 0x6D, 1:1>>
+  |> bit_array.base64_encode(True)
+  |> should.equal("+rxtgA==")
+}
+
 pub fn base64_decode_test() {
   "/3/+/A=="
   |> bit_array.base64_decode()
@@ -303,6 +320,27 @@ pub fn base16_test() {
 
   bit_array.base16_encode(<<161, 178, 195, 212, 229, 246, 120, 145>>)
   |> should.equal("A1B2C3D4E5F67891")
+}
+
+// This test is target specific since it's using non byte-aligned BitArrays
+// and those are not supported on the JavaScript target.
+@target(erlang)
+pub fn base16_encode_erlang_only_test() {
+  <<-1:7>>
+  |> bit_array.base16_encode()
+  |> should.equal("FE")
+
+  <<0xFA, 5:3>>
+  |> bit_array.base16_encode()
+  |> should.equal("FAA0")
+
+  <<0xFA, 5:4>>
+  |> bit_array.base16_encode()
+  |> should.equal("FA50")
+
+  <<0xFA, 0xBC, 0x6D, 1:1>>
+  |> bit_array.base16_encode()
+  |> should.equal("FABC6D80")
 }
 
 pub fn base16_decode_test() {


### PR DESCRIPTION
Fixes #750.

My main hesitation with this change is that a round trip isn't stable, i.e. `bit array -> encode to base 64 string -> decode to bit array` doesn't give you back what you started with.

But in practice that's probably not going to cause many problems for people.

---

This PR also removes `bit_array_int_to_u32` and `bit_array_int_from_u32` from `gleam_stdlib.erl` as I couldn't find any reference to them anywhere in the stdlib or compiler. They look to be leftover from some helper functions that were removed a long time ago.