### PR TITLE
Fail to tell esbuild to drop stuff

### DIFF
--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -6,7 +6,9 @@
 import { isEqual } from "./gleam.mjs";
 
 const referenceMap = new WeakMap();
-const tempDataView = new DataView(new ArrayBuffer(8));
+const tempDataView = /* @__PURE__ */ new DataView(
+  /* @__PURE__ */ new ArrayBuffer(8),
+);
 let referenceUID = 0;
 /**
  * hash the object by reference using a weak map and incrementing uid
@@ -308,7 +310,7 @@ function createNode(shift, key1, val1, key2hash, key2, val2) {
     key2hash,
     key2,
     val2,
-    addedLeaf
+    addedLeaf,
   );
 }
 /**
@@ -377,7 +379,7 @@ function assocArray(root, shift, hash, key, val, addedLeaf) {
       array: cloneAndSet(
         root.array,
         idx,
-        createNode(shift + SHIFT, node.k, node.v, hash, key, val)
+        createNode(shift + SHIFT, node.k, node.v, hash, key, val),
       ),
     };
   }
@@ -441,7 +443,7 @@ function assocIndex(root, shift, hash, key, val, addedLeaf) {
       array: cloneAndSet(
         root.array,
         idx,
-        createNode(shift + SHIFT, nodeKey, node.v, hash, key, val)
+        createNode(shift + SHIFT, nodeKey, node.v, hash, key, val),
       ),
     };
   } else {
@@ -528,7 +530,7 @@ function assocCollision(root, shift, hash, key, val, addedLeaf) {
     hash,
     key,
     val,
-    addedLeaf
+    addedLeaf,
   );
 }
 /**

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -47,13 +47,13 @@ export function to_string(term) {
 }
 
 export function float_to_string(float) {
-  const string = float.toString().replace('+', '');
+  const string = float.toString().replace("+", "");
   if (string.indexOf(".") >= 0) {
     return string;
   } else {
     const index = string.indexOf("e");
     if (index >= 0) {
-      return string.slice(0, index) + '.0' + string.slice(index);
+      return string.slice(0, index) + ".0" + string.slice(index);
     } else {
       return string + ".0";
     }
@@ -186,7 +186,7 @@ export function pop_grapheme(string) {
 }
 
 export function pop_codeunit(str) {
-  return [str.charCodeAt(0)|0, str.slice(1)]
+  return [str.charCodeAt(0) | 0, str.slice(1)];
 }
 
 export function lowercase(string) {
@@ -256,12 +256,15 @@ export function string_slice(string, idx, len) {
 
     return result;
   } else {
-    return string.match(/./gsu).slice(idx, idx + len).join("");
+    return string
+      .match(/./gsu)
+      .slice(idx, idx + len)
+      .join("");
   }
 }
 
 export function string_codeunit_slice(str, from, length) {
-  return str.slice(from, from + length)
+  return str.slice(from, from + length);
 }
 export function crop_string(string, substring) {
   return string.substring(string.indexOf(substring));
@@ -290,7 +293,8 @@ export function split_once(haystack, needle) {
   }
 }
 
-const unicode_whitespaces = [
+/* @__PURE__ */
+const unicode_whitespaces = /* @__PURE__ */ [
   "\u0020", // Space
   "\u0009", // Horizontal tab
   "\u000A", // Line feed
@@ -302,10 +306,17 @@ const unicode_whitespaces = [
   "\u2029", // Paragraph separator
 ].join("");
 
-const trim_start_regex = new RegExp(`^[${unicode_whitespaces}]*`);
-const trim_end_regex = new RegExp(`[${unicode_whitespaces}]*$`);
-const trim_regex = new RegExp(
-  `^[${unicode_whitespaces}]*(.*?)[${unicode_whitespaces}]*$`
+/* @__PURE__ */
+const trim_start_regex = /* @__PURE__ */ new RegExp(
+  `^[${unicode_whitespaces}]*`,
+);
+/* @__PURE__ */
+const trim_end_regex = /* @__PURE__ */ new RegExp(
+  /* @__PURE__ */ `[${unicode_whitespaces}]*$`,
+);
+/* @__PURE__ */
+const trim_regex = /* @__PURE__ */ new RegExp(
+  /* @__PURE__ */ `^[${unicode_whitespaces}]*(.*?)[${unicode_whitespaces}]*$`,
 );
 
 export function trim(string) {
@@ -1014,4 +1025,3 @@ export function bit_array_starts_with(bits, prefix) {
 
   return true;
 }
-


### PR DESCRIPTION
Help me @hayleigh-dot-dev ! I can't work out how to tell esbuild to not include these when they are not referenced

```js
$ esbuild --bundle build/dev/javascript/thingy/gleam.main.mjs
(() => {
  // build/dev/javascript/prelude.mjs
  var List = class {
    static fromArray(array, tail) {
      let t = tail || new Empty();
      for (let i = array.length - 1; i >= 0; --i) {
        t = new NonEmpty(array[i], t);
      }
      return t;
    }
    [Symbol.iterator]() {
      return new ListIterator(this);
    }
    toArray() {
      return [...this];
    }
    // @internal
    atLeastLength(desired) {
      for (let _ of this) {
        if (desired <= 0)
          return true;
        desired--;
      }
      return desired <= 0;
    }
    // @internal
    hasLength(desired) {
      for (let _ of this) {
        if (desired <= 0)
          return false;
        desired--;
      }
      return desired === 0;
    }
    // @internal
    countLength() {
      let length2 = 0;
      for (let _ of this)
        length2++;
      return length2;
    }
  };
  var ListIterator = class {
    #current;
    constructor(current) {
      this.#current = current;
    }
    next() {
      if (this.#current instanceof Empty) {
        return { done: true };
      } else {
        let { head, tail } = this.#current;
        this.#current = tail;
        return { value: head, done: false };
      }
    }
  };
  var Empty = class extends List {
  };
  var NonEmpty = class extends List {
    constructor(head, tail) {
      super();
      this.head = head;
      this.tail = tail;
    }
  };

  // build/dev/javascript/gleam_stdlib/dict.mjs
  var SHIFT = 5;
  var BUCKET_SIZE = Math.pow(2, SHIFT);
  var MASK = BUCKET_SIZE - 1;
  var MAX_INDEX_NODE = BUCKET_SIZE / 2;
  var MIN_ARRAY_NODE = BUCKET_SIZE / 4;

  // build/dev/javascript/gleam_stdlib/gleam_stdlib.mjs
  var unicode_whitespaces = /* @__PURE__ */ [
    " ",
    // Space
    "   ",
    // Horizontal tab
    "\n",
    // Line feed
    "\v",
    // Vertical tab
    "\f",
    // Form feed
    "\r",
    // Carriage return
    "\x85",
    // Next line
    "\u2028",
    // Line separator
    "\u2029"
    // Paragraph separator
  ].join("");
  var trim_start_regex = /* @__PURE__ */ new RegExp(
    `^[${unicode_whitespaces}]*`
  );
  var trim_end_regex = /* @__PURE__ */ new RegExp(
    `[${unicode_whitespaces}]*$`
  );
  var trim_regex = /* @__PURE__ */ new RegExp(
    `^[${unicode_whitespaces}]*(.*?)[${unicode_whitespaces}]*$`
  );
  function console_log(term) {
    console.log(term);
  }

  // build/dev/javascript/gleam_stdlib/gleam/io.mjs
  function println(string) {
    return console_log(string);
  }

  // build/dev/javascript/thingy/thingy.mjs
  function main() {
    return println("Hello from thingy!");
  }

  // build/dev/javascript/thingy/gleam.main.mjs
  main();
})();
```