### PR TITLE
Replace `do_*` with direct externals

### DIFF
--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -79,20 +79,16 @@ fn is_utf8_loop(bits: BitArray) -> Bool {
 ///
 /// Returns an error if the bit array is invalid UTF-8 data.
 ///
-pub fn to_string(bits: BitArray) -> Result(String, Nil) {
-  do_to_string(bits)
-}
-
-@external(erlang, "gleam_stdlib", "identity")
-fn unsafe_to_string(a: BitArray) -> String
-
 @external(javascript, "../gleam_stdlib.mjs", "bit_array_to_string")
-fn do_to_string(bits: BitArray) -> Result(String, Nil) {
+pub fn to_string(bits: BitArray) -> Result(String, Nil) {
   case is_utf8(bits) {
     True -> Ok(unsafe_to_string(bits))
     False -> Error(Nil)
   }
 }
+
+@external(erlang, "gleam_stdlib", "identity")
+fn unsafe_to_string(a: BitArray) -> String
 
 /// Creates a new bit array by joining multiple binaries.
 ///

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -124,13 +124,9 @@ fn do_has_key(key: k, dict: Dict(k, v)) -> Bool {
 
 /// Creates a fresh dict that contains no values.
 ///
-pub fn new() -> Dict(k, v) {
-  do_new()
-}
-
 @external(erlang, "maps", "new")
 @external(javascript, "../gleam_stdlib.mjs", "new_map")
-fn do_new() -> Dict(k, v)
+pub fn new() -> Dict(k, v)
 
 /// Fetches a value from a dict for a given key.
 ///
@@ -149,13 +145,9 @@ fn do_new() -> Dict(k, v)
 /// // -> Error(Nil)
 /// ```
 ///
-pub fn get(from: Dict(k, v), get: k) -> Result(v, Nil) {
-  do_get(from, get)
-}
-
 @external(erlang, "gleam_stdlib", "map_get")
 @external(javascript, "../gleam_stdlib.mjs", "map_get")
-fn do_get(dict: Dict(k, v), key: k) -> Result(v, Nil)
+pub fn get(from: Dict(k, v), get: k) -> Result(v, Nil)
 
 /// Inserts a value into the dict with the given key.
 ///
@@ -216,12 +208,8 @@ fn do_map_values(f: fn(k, v) -> a, dict: Dict(k, v)) -> Dict(k, a) {
 /// // -> ["a", "b"]
 /// ```
 ///
-pub fn keys(dict: Dict(k, v)) -> List(k) {
-  do_keys(dict)
-}
-
 @external(erlang, "maps", "keys")
-fn do_keys(dict: Dict(k, v)) -> List(k) {
+pub fn keys(dict: Dict(k, v)) -> List(k) {
   let list_of_pairs = to_list(dict)
   do_keys_loop(list_of_pairs, [])
 }
@@ -253,12 +241,8 @@ fn do_keys_loop(list: List(#(k, v)), acc: List(k)) -> List(k) {
 /// // -> [0, 1]
 /// ```
 ///
-pub fn values(dict: Dict(k, v)) -> List(v) {
-  do_values(dict)
-}
-
 @external(erlang, "maps", "values")
-fn do_values(dict: Dict(k, v)) -> List(v) {
+pub fn values(dict: Dict(k, v)) -> List(v) {
   let list_of_pairs = to_list(dict)
   do_values_loop(list_of_pairs, [])
 }
@@ -363,12 +347,8 @@ fn do_take_loop(
 /// // -> from_list([#("a", 0), #("b", 2), #("c", 3)])
 /// ```
 ///
-pub fn merge(into dict: Dict(k, v), from new_entries: Dict(k, v)) -> Dict(k, v) {
-  do_merge(dict, new_entries)
-}
-
 @external(erlang, "maps", "merge")
-fn do_merge(dict: Dict(k, v), new_entries: Dict(k, v)) -> Dict(k, v) {
+pub fn merge(into dict: Dict(k, v), from new_entries: Dict(k, v)) -> Dict(k, v) {
   new_entries
   |> to_list
   |> fold_inserts(dict)

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -115,13 +115,9 @@ fn put_expected(error: DecodeError, expected: String) -> DecodeError {
 /// // -> "String"
 /// ```
 ///
-pub fn classify(data: Dynamic) -> String {
-  do_classify(data)
-}
-
 @external(erlang, "gleam_stdlib", "classify_dynamic")
 @external(javascript, "../gleam_stdlib.mjs", "classify_dynamic")
-fn do_classify(a: Dynamic) -> String
+pub fn classify(data: Dynamic) -> String
 
 /// Checks to see whether a `Dynamic` value is an int, and returns that int if it
 /// is.

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -29,13 +29,9 @@ import gleam/order.{type Order}
 /// // -> Error(Nil)
 /// ```
 ///
-pub fn parse(string: String) -> Result(Float, Nil) {
-  do_parse(string)
-}
-
 @external(erlang, "gleam_stdlib", "parse_float")
 @external(javascript, "../gleam_stdlib.mjs", "parse_float")
-fn do_parse(a: String) -> Result(Float, Nil)
+pub fn parse(string: String) -> Result(Float, Nil)
 
 /// Returns the string representation of the provided `Float`.
 ///
@@ -46,13 +42,9 @@ fn do_parse(a: String) -> Result(Float, Nil)
 /// // -> "2.3"
 /// ```
 ///
-pub fn to_string(x: Float) -> String {
-  do_to_string(x)
-}
-
 @external(erlang, "gleam_stdlib", "float_to_string")
 @external(javascript, "../gleam_stdlib.mjs", "float_to_string")
-fn do_to_string(a: Float) -> String
+pub fn to_string(x: Float) -> String
 
 /// Restricts a `Float` between a lower and upper bound.
 ///
@@ -196,13 +188,9 @@ pub fn max(a: Float, b: Float) -> Float {
 /// // -> 3.0
 /// ```
 ///
-pub fn ceiling(x: Float) -> Float {
-  do_ceiling(x)
-}
-
 @external(erlang, "math", "ceil")
 @external(javascript, "../gleam_stdlib.mjs", "ceiling")
-fn do_ceiling(a: Float) -> Float
+pub fn ceiling(x: Float) -> Float
 
 /// Rounds the value to the next lowest whole number as a `Float`.
 ///
@@ -213,13 +201,9 @@ fn do_ceiling(a: Float) -> Float
 /// // -> 2.0
 /// ```
 ///
-pub fn floor(x: Float) -> Float {
-  do_floor(x)
-}
-
 @external(erlang, "math", "floor")
 @external(javascript, "../gleam_stdlib.mjs", "floor")
-fn do_floor(a: Float) -> Float
+pub fn floor(x: Float) -> Float
 
 /// Rounds the value to the nearest whole number as an `Int`.
 ///
@@ -235,12 +219,8 @@ fn do_floor(a: Float) -> Float
 /// // -> 3
 /// ```
 ///
-pub fn round(x: Float) -> Int {
-  do_round(x)
-}
-
 @external(erlang, "erlang", "round")
-fn do_round(x: Float) -> Int {
+pub fn round(x: Float) -> Int {
   case x >=. 0.0 {
     True -> js_round(x)
     _ -> 0 - js_round(negate(x))
@@ -259,13 +239,9 @@ fn js_round(a: Float) -> Int
 /// // -> 2
 /// ```
 ///
-pub fn truncate(x: Float) -> Int {
-  do_truncate(x)
-}
-
 @external(erlang, "erlang", "trunc")
 @external(javascript, "../gleam_stdlib.mjs", "truncate")
-fn do_truncate(a: Float) -> Int
+pub fn truncate(x: Float) -> Int
 
 /// Converts the value to a given precision as a `Float`.
 /// The precision is the number of allowed decimal places.

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -104,13 +104,9 @@ pub fn square_root(x: Int) -> Result(Float, Nil) {
 /// // -> Error(Nil)
 /// ```
 ///
-pub fn parse(string: String) -> Result(Int, Nil) {
-  do_parse(string)
-}
-
 @external(erlang, "gleam_stdlib", "parse_int")
 @external(javascript, "../gleam_stdlib.mjs", "parse_int")
-fn do_parse(a: String) -> Result(Int, Nil)
+pub fn parse(string: String) -> Result(Int, Nil)
 
 /// Parses a given string as an int in a given base if possible.
 /// Supports only bases 2 to 36, for values outside of which this function returns an `Error(Nil)`.
@@ -162,13 +158,9 @@ fn do_base_parse(a: String, b: Int) -> Result(Int, Nil)
 /// // -> "2"
 /// ```
 ///
-pub fn to_string(x: Int) {
-  do_to_string(x)
-}
-
 @external(erlang, "erlang", "integer_to_binary")
 @external(javascript, "../gleam_stdlib.mjs", "to_string")
-fn do_to_string(a: Int) -> String
+pub fn to_string(x: Int) -> String
 
 /// Prints a given int to a string using the base number provided.
 /// Supports only bases 2 to 36, for values outside of which this function returns an `Error(Nil)`.
@@ -283,13 +275,9 @@ pub fn to_base36(x: Int) -> String {
 /// // -> -3.0
 /// ```
 ///
-pub fn to_float(x: Int) -> Float {
-  do_to_float(x)
-}
-
 @external(erlang, "erlang", "float")
 @external(javascript, "../gleam_stdlib.mjs", "identity")
-fn do_to_float(a: Int) -> Float
+pub fn to_float(x: Int) -> Float
 
 /// Restricts an int between a lower and upper bound.
 ///

--- a/src/gleam/io.gleam
+++ b/src/gleam/io.gleam
@@ -12,13 +12,9 @@ import gleam/string
 /// // Hi mum
 /// ```
 ///
-pub fn print(string: String) -> Nil {
-  do_print(string)
-}
-
 @external(erlang, "gleam_stdlib", "print")
 @external(javascript, "../gleam_stdlib.mjs", "print")
-fn do_print(string string: String) -> Nil
+pub fn print(string: String) -> Nil
 
 /// Writes a string to standard error (stderr).
 ///
@@ -32,13 +28,9 @@ fn do_print(string string: String) -> Nil
 /// // Hi pop
 /// ```
 ///
-pub fn print_error(string: String) -> Nil {
-  do_print_error(string)
-}
-
 @external(erlang, "gleam_stdlib", "print_error")
 @external(javascript, "../gleam_stdlib.mjs", "print_error")
-fn do_print_error(string string: String) -> Nil
+pub fn print_error(string: String) -> Nil
 
 /// Writes a string to standard output (stdout), appending a newline to the end.
 ///
@@ -50,13 +42,9 @@ fn do_print_error(string string: String) -> Nil
 /// // Hi mum
 /// ```
 ///
-pub fn println(string: String) -> Nil {
-  do_println(string)
-}
-
 @external(erlang, "gleam_stdlib", "println")
 @external(javascript, "../gleam_stdlib.mjs", "console_log")
-fn do_println(string string: String) -> Nil
+pub fn println(string: String) -> Nil
 
 /// Writes a string to standard error (stderr), appending a newline to the end.
 ///
@@ -68,13 +56,9 @@ fn do_println(string string: String) -> Nil
 /// // Hi pop
 /// ```
 ///
-pub fn println_error(string: String) -> Nil {
-  do_println_error(string)
-}
-
 @external(erlang, "gleam_stdlib", "println_error")
 @external(javascript, "../gleam_stdlib.mjs", "console_error")
-fn do_println_error(string string: String) -> Nil
+pub fn println_error(string: String) -> Nil
 
 /// Writes a value to standard error (stderr) yielding Gleam syntax.
 ///

--- a/src/gleam/regex.gleam
+++ b/src/gleam/regex.gleam
@@ -57,18 +57,11 @@ pub type Options {
 /// ```
 ///
 @deprecated("Please use the gleam_regexp package instead")
+@external(erlang, "gleam_stdlib", "compile_regex")
+@external(javascript, "../gleam_stdlib.mjs", "compile_regex")
 pub fn compile(
   pattern: String,
   with options: Options,
-) -> Result(Regex, CompileError) {
-  do_compile(pattern, options)
-}
-
-@external(erlang, "gleam_stdlib", "compile_regex")
-@external(javascript, "../gleam_stdlib.mjs", "compile_regex")
-fn do_compile(
-  pattern: String,
-  with with: Options,
 ) -> Result(Regex, CompileError)
 
 /// Creates a new `Regex`.
@@ -115,13 +108,9 @@ pub fn from_string(pattern: String) -> Result(Regex, CompileError) {
 /// ```
 ///
 @deprecated("Please use the gleam_regexp package instead")
-pub fn check(with regex: Regex, content string: String) -> Bool {
-  do_check(regex, string)
-}
-
 @external(erlang, "gleam_stdlib", "regex_check")
 @external(javascript, "../gleam_stdlib.mjs", "regex_check")
-fn do_check(regex: Regex, string: String) -> Bool
+pub fn check(with regex: Regex, content string: String) -> Bool
 
 /// Splits a string.
 ///
@@ -134,13 +123,9 @@ fn do_check(regex: Regex, string: String) -> Bool
 /// ```
 ///
 @deprecated("Please use the gleam_regexp package instead")
-pub fn split(with regex: Regex, content string: String) -> List(String) {
-  do_split(regex, string)
-}
-
 @external(erlang, "gleam_stdlib", "regex_split")
 @external(javascript, "../gleam_stdlib.mjs", "regex_split")
-fn do_split(regex: Regex, string: String) -> List(String)
+pub fn split(with regex: Regex, content string: String) -> List(String)
 
 /// Collects all matches of the regular expression.
 ///
@@ -195,13 +180,9 @@ fn do_split(regex: Regex, string: String) -> List(String)
 /// ```
 ///
 @deprecated("Please use the gleam_regexp package instead")
-pub fn scan(with regex: Regex, content string: String) -> List(Match) {
-  do_scan(regex, string)
-}
-
 @external(erlang, "gleam_stdlib", "regex_scan")
 @external(javascript, "../gleam_stdlib.mjs", "regex_scan")
-fn do_scan(regex: Regex, string: String) -> List(Match)
+pub fn scan(with regex: Regex, content string: String) -> List(Match)
 
 /// Creates a new `String` by replacing all substrings that match the regular
 /// expression.

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -46,13 +46,9 @@ pub fn is_empty(str: String) -> Bool {
 /// // -> 0
 /// ```
 ///
-pub fn length(string: String) -> Int {
-  do_length(string)
-}
-
 @external(erlang, "string", "length")
 @external(javascript, "../gleam_stdlib.mjs", "string_length")
-fn do_length(a: String) -> Int
+pub fn length(string: String) -> Int
 
 /// Reverses a `String`.
 ///
@@ -67,10 +63,6 @@ fn do_length(a: String) -> Int
 /// ```
 ///
 pub fn reverse(string: String) -> String {
-  do_reverse(string)
-}
-
-fn do_reverse(string: String) -> String {
   string
   |> string_tree.from_string
   |> string_tree.reverse
@@ -114,13 +106,9 @@ pub fn replace(
 /// // -> "x-files"
 /// ```
 ///
-pub fn lowercase(string: String) -> String {
-  do_lowercase(string)
-}
-
 @external(erlang, "string", "lowercase")
 @external(javascript, "../gleam_stdlib.mjs", "lowercase")
-fn do_lowercase(a: String) -> String
+pub fn lowercase(string: String) -> String
 
 /// Creates a new `String` with all the graphemes in the input `String` converted to
 /// uppercase.
@@ -134,13 +122,9 @@ fn do_lowercase(a: String) -> String
 /// // -> "SKINNER"
 /// ```
 ///
-pub fn uppercase(string: String) -> String {
-  do_uppercase(string)
-}
-
 @external(erlang, "string", "uppercase")
 @external(javascript, "../gleam_stdlib.mjs", "uppercase")
-fn do_uppercase(a: String) -> String
+pub fn uppercase(string: String) -> String
 
 /// Compares two `String`s to see which is "larger" by comparing their graphemes.
 ///
@@ -330,13 +314,9 @@ pub fn contains(does haystack: String, contain needle: String) -> Bool
 /// // -> False
 /// ```
 ///
-pub fn starts_with(string: String, prefix: String) -> Bool {
-  do_starts_with(string, prefix)
-}
-
 @external(erlang, "gleam_stdlib", "string_starts_with")
 @external(javascript, "../gleam_stdlib.mjs", "starts_with")
-fn do_starts_with(a: String, b: String) -> Bool
+pub fn starts_with(string: String, prefix: String) -> Bool
 
 /// Checks whether the first `String` ends with the second one.
 ///
@@ -347,13 +327,9 @@ fn do_starts_with(a: String, b: String) -> Bool
 /// // -> True
 /// ```
 ///
-pub fn ends_with(string: String, suffix: String) -> Bool {
-  do_ends_with(string, suffix)
-}
-
 @external(erlang, "gleam_stdlib", "string_ends_with")
 @external(javascript, "../gleam_stdlib.mjs", "ends_with")
-fn do_ends_with(a: String, b: String) -> Bool
+pub fn ends_with(string: String, suffix: String) -> Bool
 
 /// Creates a list of `String`s by splitting a given string on a given substring.
 ///
@@ -391,17 +367,10 @@ pub fn split(x: String, on substring: String) -> List(String) {
 /// // -> Error(Nil)
 /// ```
 ///
+@external(javascript, "../gleam_stdlib.mjs", "split_once")
 pub fn split_once(
   string: String,
   on substring: String,
-) -> Result(#(String, String), Nil) {
-  do_split_once(string, substring)
-}
-
-@external(javascript, "../gleam_stdlib.mjs", "split_once")
-fn do_split_once(
-  string: String,
-  substring: String,
 ) -> Result(#(String, String), Nil) {
   case erl_split(string, substring) {
     [first, rest] -> Ok(#(first, rest))
@@ -484,12 +453,8 @@ fn repeat_loop(string: String, times: Int, acc: String) -> String {
 /// // -> "home/evan/Desktop"
 /// ```
 ///
-pub fn join(strings: List(String), with separator: String) -> String {
-  do_join(strings, separator)
-}
-
 @external(javascript, "../gleam_stdlib.mjs", "join")
-fn do_join(strings: List(String), separator: String) -> String {
+pub fn join(strings: List(String), with separator: String) -> String {
   strings
   |> list.intersperse(with: separator)
   |> concat
@@ -639,12 +604,8 @@ fn padding(size: Int, pad_string: String) -> String {
 /// // -> "hats"
 /// ```
 ///
-pub fn trim(string: String) -> String {
-  do_trim(string)
-}
-
 @external(javascript, "../gleam_stdlib.mjs", "trim")
-fn do_trim(string: String) -> String {
+pub fn trim(string: String) -> String {
   erl_trim(string, Both)
 }
 
@@ -680,12 +641,8 @@ pub fn trim_left(string: String) -> String {
 /// // -> "hats  \n"
 /// ```
 ///
-pub fn trim_start(string: String) -> String {
-  do_trim_start(string)
-}
-
 @external(javascript, "../gleam_stdlib.mjs", "trim_start")
-fn do_trim_start(string: String) -> String {
+pub fn trim_start(string: String) -> String {
   erl_trim(string, Leading)
 }
 
@@ -712,12 +669,8 @@ pub fn trim_right(string: String) -> String {
 /// // -> "  hats"
 /// ```
 ///
-pub fn trim_end(string: String) -> String {
-  do_trim_end(string)
-}
-
 @external(javascript, "../gleam_stdlib.mjs", "trim_end")
-fn do_trim_end(string: String) -> String {
+pub fn trim_end(string: String) -> String {
   erl_trim(string, Trailing)
 }
 
@@ -740,13 +693,9 @@ fn do_trim_end(string: String) -> String {
 /// // -> Error(Nil)
 /// ```
 ///
-pub fn pop_grapheme(string: String) -> Result(#(String, String), Nil) {
-  do_pop_grapheme(string)
-}
-
 @external(erlang, "gleam_stdlib", "string_pop_grapheme")
 @external(javascript, "../gleam_stdlib.mjs", "pop_grapheme")
-fn do_pop_grapheme(string string: String) -> Result(#(String, String), Nil)
+pub fn pop_grapheme(string: String) -> Result(#(String, String), Nil)
 
 /// Converts a `String` to a list of
 /// [graphemes](https://en.wikipedia.org/wiki/Grapheme).
@@ -874,13 +823,9 @@ pub fn utf_codepoint(value: Int) -> Result(UtfCodepoint, Nil) {
 /// // -> 128156
 /// ```
 ///
-pub fn utf_codepoint_to_int(cp: UtfCodepoint) -> Int {
-  do_utf_codepoint_to_int(cp)
-}
-
 @external(erlang, "gleam_stdlib", "identity")
 @external(javascript, "../gleam_stdlib.mjs", "utf_codepoint_to_int")
-fn do_utf_codepoint_to_int(cp cp: UtfCodepoint) -> Int
+pub fn utf_codepoint_to_int(cp: UtfCodepoint) -> Int
 
 /// Converts a `String` into `Option(String)` where an empty `String` becomes
 /// `None`.

--- a/src/gleam/string_tree.gleam
+++ b/src/gleam/string_tree.gleam
@@ -22,7 +22,7 @@ pub type StringTree
 /// trees together.
 ///
 pub fn new() -> StringTree {
-  do_from_strings([])
+  from_strings([])
 }
 
 /// Prepends a `String` onto the start of some `StringTree`.
@@ -49,79 +49,55 @@ pub fn prepend_tree(
   to tree: StringTree,
   prefix prefix: StringTree,
 ) -> StringTree {
-  do_append(prefix, tree)
+  append_tree(prefix, tree)
 }
 
 /// Appends some `StringTree` onto the end of another.
 ///
 /// Runs in constant time.
 ///
-pub fn append_tree(to tree: StringTree, suffix suffix: StringTree) -> StringTree {
-  do_append(tree, suffix)
-}
-
 @external(erlang, "gleam_stdlib", "iodata_append")
 @external(javascript, "../gleam_stdlib.mjs", "add")
-fn do_append(a: StringTree, b: StringTree) -> StringTree
+pub fn append_tree(to tree: StringTree, suffix suffix: StringTree) -> StringTree
 
 /// Converts a list of strings into a `StringTree`.
 ///
 /// Runs in constant time.
 ///
-pub fn from_strings(strings: List(String)) -> StringTree {
-  do_from_strings(strings)
-}
-
 @external(erlang, "gleam_stdlib", "identity")
 @external(javascript, "../gleam_stdlib.mjs", "concat")
-fn do_from_strings(a: List(String)) -> StringTree
+pub fn from_strings(strings: List(String)) -> StringTree
 
 /// Joins a list of trees into a single tree.
 ///
 /// Runs in constant time.
 ///
-pub fn concat(trees: List(StringTree)) -> StringTree {
-  do_concat(trees)
-}
-
 @external(erlang, "gleam_stdlib", "identity")
 @external(javascript, "../gleam_stdlib.mjs", "concat")
-fn do_concat(trees: List(StringTree)) -> StringTree
+pub fn concat(trees: List(StringTree)) -> StringTree
 
 /// Converts a string into a `StringTree`.
 ///
 /// Runs in constant time.
 ///
-pub fn from_string(string: String) -> StringTree {
-  do_from_string(string)
-}
-
 @external(erlang, "gleam_stdlib", "identity")
 @external(javascript, "../gleam_stdlib.mjs", "identity")
-fn do_from_string(string: String) -> StringTree
+pub fn from_string(string: String) -> StringTree
 
 /// Turns a `StringTree` into a `String`
 ///
 /// This function is implemented natively by the virtual machine and is highly
 /// optimised.
 ///
-pub fn to_string(tree: StringTree) -> String {
-  do_to_string(tree)
-}
-
 @external(erlang, "unicode", "characters_to_binary")
 @external(javascript, "../gleam_stdlib.mjs", "identity")
-fn do_to_string(tree: StringTree) -> String
+pub fn to_string(tree: StringTree) -> String
 
 /// Returns the size of the `StringTree` in bytes.
 ///
-pub fn byte_size(tree: StringTree) -> Int {
-  do_byte_size(tree)
-}
-
 @external(erlang, "erlang", "iolist_size")
 @external(javascript, "../gleam_stdlib.mjs", "length")
-fn do_byte_size(tree: StringTree) -> Int
+pub fn byte_size(tree: StringTree) -> Int
 
 /// Joins the given trees into a new tree separated with the given string.
 ///
@@ -134,33 +110,21 @@ pub fn join(trees: List(StringTree), with sep: String) -> StringTree {
 /// Converts a `StringTree` to a new one where the contents have been
 /// lowercased.
 ///
-pub fn lowercase(tree: StringTree) -> StringTree {
-  do_lowercase(tree)
-}
-
 @external(erlang, "string", "lowercase")
 @external(javascript, "../gleam_stdlib.mjs", "lowercase")
-fn do_lowercase(tree: StringTree) -> StringTree
+pub fn lowercase(tree: StringTree) -> StringTree
 
 /// Converts a `StringTree` to a new one where the contents have been
 /// uppercased.
 ///
-pub fn uppercase(tree: StringTree) -> StringTree {
-  do_uppercase(tree)
-}
-
 @external(erlang, "string", "uppercase")
 @external(javascript, "../gleam_stdlib.mjs", "uppercase")
-fn do_uppercase(tree: StringTree) -> StringTree
+pub fn uppercase(tree: StringTree) -> StringTree
 
 /// Converts a `StringTree` to a new one with the contents reversed.
 ///
-pub fn reverse(tree: StringTree) -> StringTree {
-  do_reverse(tree)
-}
-
 @external(erlang, "string", "reverse")
-fn do_reverse(tree: StringTree) -> StringTree {
+pub fn reverse(tree: StringTree) -> StringTree {
   tree
   |> to_string
   |> do_to_graphemes
@@ -173,16 +137,12 @@ fn do_to_graphemes(string: String) -> List(String)
 
 /// Splits a `StringTree` on a given pattern into a list of trees.
 ///
-pub fn split(tree: StringTree, on pattern: String) -> List(StringTree) {
-  do_split(tree, pattern)
-}
-
 type Direction {
   All
 }
 
 @external(javascript, "../gleam_stdlib.mjs", "split")
-fn do_split(tree: StringTree, pattern: String) -> List(StringTree) {
+pub fn split(tree: StringTree, on pattern: String) -> List(StringTree) {
   erl_split(tree, pattern, All)
 }
 

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -50,12 +50,8 @@ pub type Uri {
 /// // )
 /// ```
 ///
-pub fn parse(uri_string: String) -> Result(Uri, Nil) {
-  do_parse(uri_string)
-}
-
 @external(erlang, "gleam_stdlib", "uri_parse")
-fn do_parse(uri_string: String) -> Result(Uri, Nil) {
+pub fn parse(uri_string: String) -> Result(Uri, Nil) {
   // This parses a uri_string following the regex defined in
   // https://tools.ietf.org/html/rfc3986#appendix-B
   //
@@ -525,13 +521,9 @@ fn extra_required(list: List(a), remaining: Int) -> Int {
 /// // -> Ok([#("a", "1"), #("b", "2")])
 /// ```
 ///
-pub fn parse_query(query: String) -> Result(List(#(String, String)), Nil) {
-  do_parse_query(query)
-}
-
 @external(erlang, "gleam_stdlib", "parse_query")
 @external(javascript, "../gleam_stdlib.mjs", "parse_query")
-fn do_parse_query(a: String) -> Result(List(#(String, String)), Nil)
+pub fn parse_query(query: String) -> Result(List(#(String, String)), Nil)
 
 /// Encodes a list of key value pairs as a URI query string.
 ///
@@ -565,13 +557,9 @@ fn query_pair(pair: #(String, String)) -> StringTree {
 /// // -> "100%25%20great"
 /// ```
 ///
-pub fn percent_encode(value: String) -> String {
-  do_percent_encode(value)
-}
-
 @external(erlang, "gleam_stdlib", "percent_encode")
 @external(javascript, "../gleam_stdlib.mjs", "percent_encode")
-fn do_percent_encode(a: String) -> String
+pub fn percent_encode(value: String) -> String
 
 /// Decodes a percent encoded string.
 ///
@@ -582,13 +570,9 @@ fn do_percent_encode(a: String) -> String
 /// // -> Ok("100% great+fun")
 /// ```
 ///
-pub fn percent_decode(value: String) -> Result(String, Nil) {
-  do_percent_decode(value)
-}
-
 @external(erlang, "gleam_stdlib", "percent_decode")
 @external(javascript, "../gleam_stdlib.mjs", "percent_decode")
-fn do_percent_decode(a: String) -> Result(String, Nil)
+pub fn percent_decode(value: String) -> Result(String, Nil)
 
 /// Splits the path section of a URI into it's constituent segments.
 ///


### PR DESCRIPTION
As discussed [on discord](https://discord.com/channels/768594524158427167/768594524158427170/1311459444537692261). This PR removes most of the `do_*` functions, and makes the public functions external directly. There were a few cases where the Gleam argument order was different to the argument order of the external function that was being called, and so I had to leave it (e.g. `dict.filter`)