### PR TITLE
Add `string.non_empty`

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -24,6 +24,24 @@ pub fn is_empty(str: String) -> Bool {
   str == ""
 }
 
+/// Determines if a `String` is not empty.
+///
+/// ## Examples
+///
+/// ```gleam
+/// non_empty("")
+/// // -> False
+/// ```
+///
+/// ```gleam
+/// non_empty("the world")
+/// // -> True
+/// ```
+///
+pub fn non_empty(str: String) -> Bool {
+  str != ""
+}
+
 /// Gets the number of grapheme clusters in a given `String`.
 ///
 /// This function has to iterate across the whole string to count the number of

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -7,6 +7,20 @@ import gleam/result
 import gleam/should
 import gleam/string
 
+pub fn non_empty_test() {
+  string.non_empty("Gleam")
+  |> should.equal(True)
+
+  string.non_empty("ß↑e̊")
+  |> should.equal(True)
+
+  string.non_empty("👶🏿")
+  |> should.equal(True)
+
+  string.non_empty("")
+  |> should.equal(False)
+}
+
 pub fn length_test() {
   string.length("ß↑e̊")
   |> should.equal(3)


### PR DESCRIPTION
Just a simple convenience, inspired by the so named Scala method
Quite useful during a `filter` for example

```
  some_str_list |> list.filter(string.non_empty)
  
  // rather than calling a closure
  
  some_str_list |> list.filter(fn(s) { !string.is_empty(s) })
```
