### PR TITLE
Add `list.filter_not` 

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -331,6 +331,38 @@ fn filter_loop(list: List(a), fun: fn(a) -> Bool, acc: List(a)) -> List(a) {
 }
 
 /// Returns a new list containing only the elements from the first list for
+/// which the given function returns `False`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// filter_not([2, 4, 6, 1], fn(x) { x > 2 })
+/// // -> [2, 1]
+/// ```
+///
+/// ```gleam
+/// filter_not([2, 4, 6, 1], fn(x) { x < 6 })
+/// // -> [6]
+/// ```
+///
+pub fn filter_not(list: List(a), excluding predicate: fn(a) -> Bool) -> List(a) {
+  filter_not_loop(list, predicate, [])
+}
+
+fn filter_not_loop(list: List(a), fun: fn(a) -> Bool, acc: List(a)) -> List(a) {
+  case list {
+    [] -> reverse(acc)
+    [first, ..rest] -> {
+      let new_acc = case fun(first) {
+        False -> [first, ..acc]
+        True -> acc
+      }
+      filter_not_loop(rest, fun, new_acc)
+    }
+  }
+}
+
+/// Returns a new list containing only the elements from the first list for
 /// which the given functions returns `Ok(_)`.
 ///
 /// ## Examples

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -156,6 +156,24 @@ pub fn filter_test() {
   |> list.filter(fn(x) { x == -1 })
 }
 
+pub fn filter_not_test() {
+  []
+  |> list.filter_not(fn(_) { True })
+  |> should.equal([])
+
+  [0, 4, 5, 7, 3]
+  |> list.filter_not(fn(_) { True })
+  |> should.equal([])
+
+  [0, 4, 5, 7, 3]
+  |> list.filter_not(fn(x) { x > 4 })
+  |> should.equal([0, 4, 3])
+
+  [0, 4, 5, 7, 3]
+  |> list.filter_not(fn(x) { x < 4 })
+  |> should.equal([4, 5, 7])
+}
+
 pub fn filter_map_test() {
   [2, 4, 6, 1]
   |> list.filter_map(fn(x) { Ok(x + 1) })


### PR DESCRIPTION
Another simple convenience, also inspired by the so named Scala method
Quite useful to keep conciseness
when filtering out values with existing predicate functions

For example:
```
  some_list |> list.filter_not(string.is_empty)
  // rather than
  some_list |> list.filter(fn(s){ !string.is_empty(s) })
```