### PR TITLE
Improve the performance of `list.strict_zip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Comparing two `Dict`s of equal size has been optimised on the JavaScript
   target.
 
-- Improved the performance of `drop_start`.
+- Improved the performance of `string.drop_start`.
 
 - Improved the performance of `list.strict_zip`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Improved the performance of `drop_start`.
 
+- Improved the performance of `list.strict_zip`.
+
 ## v0.45.0 - 2024-11-28
 
 - The performance of `string.trim`, `string.trim_start`, and `string.trim_end`

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -1087,9 +1087,19 @@ pub fn strict_zip(
   list: List(a),
   with other: List(b),
 ) -> Result(List(#(a, b)), Nil) {
-  case length(of: list) == length(of: other) {
-    True -> Ok(zip(list, other))
-    False -> Error(Nil)
+  strict_zip_loop(list, other, [])
+}
+
+fn strict_zip_loop(
+  one: List(a),
+  other: List(b),
+  acc: List(#(a, b)),
+) -> Result(List(#(a, b)), Nil) {
+  case one, other {
+    [], [] -> Ok(acc |> reverse)
+    [], _ | _, [] -> Error(Nil)
+    [first_one, ..rest_one], [first_other, ..rest_other] ->
+      strict_zip_loop(rest_one, rest_other, [#(first_one, first_other), ..acc])
   }
 }
 


### PR DESCRIPTION
Avoid calling `list.length` on the lists being zipped.