### PR TITLE
add `max` to gleam/list

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2311,3 +2311,55 @@ fn do_shuffle_by_pair_indexes(
     float.compare(a_pair.0, b_pair.0)
   })
 }
+
+/// Takes a list and a comparator, and returns the maximum element in the list
+///
+///
+/// ## Example
+///
+/// ```gleam
+/// range(1, 10) |> list.max(int.compare)
+/// // -> Ok(10)
+/// ```
+///
+/// ```gleam
+/// ["a", "c", "b"] |> list.max(string.compare)
+/// // -> Ok("c")
+/// ```
+pub fn max(
+  over list: List(a),
+  with compare: fn(a, a) -> Order,
+) -> Result(a, Nil) {
+  reduce(over: list, with: fn(acc, other) {
+    case compare(acc, other) {
+      order.Gt -> acc
+      _ -> other
+    }
+  })
+}
+
+/// Takes a list and a comparator, and returns the minimum element in the list
+///
+///
+/// ## Example
+///
+/// ```gleam
+/// range(1, 10) |> list.int(int.compare)
+/// // -> Ok(1)
+/// ```
+///
+/// ```gleam
+/// ["a", "c", "b"] |> list.int(string.compare)
+/// // -> Ok("a")
+/// ```
+pub fn min(
+  over list: List(a),
+  with compare: fn(a, a) -> Order,
+) -> Result(a, Nil) {
+  reduce(over: list, with: fn(acc, other) {
+    case compare(acc, other) {
+      order.Lt -> acc
+      _ -> other
+    }
+  })
+}

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2337,29 +2337,3 @@ pub fn max(
     }
   })
 }
-
-/// Takes a list and a comparator, and returns the minimum element in the list
-///
-///
-/// ## Example
-///
-/// ```gleam
-/// range(1, 10) |> list.int(int.compare)
-/// // -> Ok(1)
-/// ```
-///
-/// ```gleam
-/// ["a", "c", "b"] |> list.int(string.compare)
-/// // -> Ok("a")
-/// ```
-pub fn min(
-  over list: List(a),
-  with compare: fn(a, a) -> Order,
-) -> Result(a, Nil) {
-  reduce(over: list, with: fn(acc, other) {
-    case compare(acc, other) {
-      order.Lt -> acc
-      _ -> other
-    }
-  })
-}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1299,21 +1299,3 @@ pub fn max_test() {
   |> list.max(string.compare)
   |> should.equal(Ok("c"))
 }
-
-pub fn min_test() {
-  []
-  |> list.min(int.compare)
-  |> should.equal(Error(Nil))
-
-  [1, 3, 2]
-  |> list.min(int.compare)
-  |> should.equal(Ok(1))
-
-  [-1.0, 1.2, 1.104]
-  |> list.min(float.compare)
-  |> should.equal(Ok(-1.0))
-
-  ["a", "c", "b"]
-  |> list.min(string.compare)
-  |> should.equal(Ok("a"))
-}

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -1281,3 +1281,39 @@ pub fn shuffle_test() {
   list.range(0, recursion_test_cycles)
   |> list.shuffle()
 }
+
+pub fn max_test() {
+  []
+  |> list.max(int.compare)
+  |> should.equal(Error(Nil))
+
+  [1, 3, 2]
+  |> list.max(int.compare)
+  |> should.equal(Ok(3))
+
+  [-1.0, 1.2, 1.104]
+  |> list.max(float.compare)
+  |> should.equal(Ok(1.2))
+
+  ["a", "c", "b"]
+  |> list.max(string.compare)
+  |> should.equal(Ok("c"))
+}
+
+pub fn min_test() {
+  []
+  |> list.min(int.compare)
+  |> should.equal(Error(Nil))
+
+  [1, 3, 2]
+  |> list.min(int.compare)
+  |> should.equal(Ok(1))
+
+  [-1.0, 1.2, 1.104]
+  |> list.min(float.compare)
+  |> should.equal(Ok(-1.0))
+
+  ["a", "c", "b"]
+  |> list.min(string.compare)
+  |> should.equal(Ok("a"))
+}


### PR DESCRIPTION
Inspired by my advent of code 2024 experiences. I often find myself reinventing `list.min` and `list.max` with `fold` and `reduce`, so I thought maybe it'd be nice to just promote these.

PR Adds `list.min` and `list.max` to `gleam/list`.

Like the name suggests, it returns the max/min element in the list, using the passed in comparator. These are slightly higher level abstractions than `reduce` as it takes in comparator functions, which can help with ergonomics at many places.