### PR TITLE
Fix dynamic/decode field function example

### DIFF
--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -503,7 +503,7 @@ pub fn decode_error(
 /// let decoder = {
 ///   use name <- decode.field("name", string)
 ///   use email <- decode.field("email", string)
-///   SignUp(name: name, email: email)
+///   decode.success(SignUp(name: name, email: email))
 /// }
 ///
 /// let result = decode.run(data, decoder)


### PR DESCRIPTION
Hi!

There is a missing `decode.success` in this example.
Thanks for the new API by the way, it's lovely.