### PR TITLE
improve precision of `float.to_precision`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improved the precision of `float.to_precision`.
+
 ## v0.51.0 - 2024-12-22
 
 - `dynamic/decode` now has its own error type.

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -261,8 +261,16 @@ pub fn truncate(x: Float) -> Int
 /// ```
 ///
 pub fn to_precision(x: Float, precision: Int) -> Float {
-  let factor = do_power(10.0, do_to_float(-precision))
-  do_to_float(round(x /. factor)) *. factor
+  case precision <= 0 {
+    True -> {
+      let factor = do_power(10.0, do_to_float(-precision))
+      do_to_float(round(x /. factor)) *. factor
+    }
+    False -> {
+      let factor = do_power(10.0, do_to_float(precision))
+      do_to_float(round(x *. factor)) /. factor
+    }
+  }
 }
 
 @external(erlang, "erlang", "float")

--- a/test/gleam/float_test.gleam
+++ b/test/gleam/float_test.gleam
@@ -288,6 +288,12 @@ pub fn to_precision_test() {
 
   float.to_precision(435.3224, -0)
   |> should.equal(435.0)
+
+  float.to_precision(184.20000000000002, 2)
+  |> should.equal(184.2)
+
+  float.to_precision(12_345_678_912_345_678_912_345_678.0, -19)
+  |> should.equal(1_234_568.0e19)
 }
 
 pub fn min_test() {


### PR DESCRIPTION
significantly improve the precision when rounding with a positive precision. while factors greater than one can be accurately represented up to a large number (10, 100, 1000, ...), even a factor of 0.1 already introduces inaccuracies, since 0.1 cannot be accurately represented using floating-point numbers.

The added test cases show this behaviour; one of them always fails if both branches of the `case` were the same.

~ :purple_heart: