### PR TITLE
Improve `string.inspect` for sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The printing of sets by `string.inspect` has been improved.
+
 ## v0.51.0 - 2024-12-22
 
 - `dynamic/decode` now has its own error type.

--- a/src/gleam/set.gleam
+++ b/src/gleam/set.gleam
@@ -1,6 +1,9 @@
 import gleam/dict.{type Dict}
 import gleam/list
+import gleam/pair
 import gleam/result
+import gleam/string
+import gleam/string_tree
 
 // A list is used as the dict value as an empty list has the smallest
 // representation in Erlang's binary format
@@ -404,4 +407,25 @@ pub fn each(set: Set(member), fun: fn(member) -> a) -> Nil {
     fun(member)
     nil
   })
+}
+
+@internal
+pub fn inspect(set: Set(member)) -> String {
+  fold(
+    set,
+    #(True, string_tree.from_string("set.from_list([")),
+    fn(acc, member) {
+      let member = string.inspect(member)
+      case acc.0 {
+        True -> #(False, acc.1 |> string_tree.append(member))
+        False -> #(
+          False,
+          acc.1 |> string_tree.append(", ") |> string_tree.append(member),
+        )
+      }
+    },
+  )
+  |> pair.second
+  |> string_tree.append("])")
+  |> string_tree.to_string
 }

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -349,6 +349,8 @@ inspect(false) ->
     "False";
 inspect(nil) ->
     "Nil";
+inspect(Data) when is_tuple(Data) andalso element(1, Data) =:= set ->
+    gleam@set:inspect(Data);
 inspect(Data) when is_map(Data) ->
     Fields = [
         [<<"#(">>, inspect(Key), <<", ">>, inspect(Value), <<")">>]

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -14,6 +14,7 @@ import { DecodeError } from "./gleam/dynamic.mjs";
 import { Some, None } from "./gleam/option.mjs";
 import { Eq, Gt, Lt } from "./gleam/order.mjs";
 import Dict from "./dict.mjs";
+import { new$ as set_new, inspect as set_inspect } from "./gleam/set.mjs";
 
 const Nil = undefined;
 const NOT_FOUND = {};
@@ -805,6 +806,7 @@ export function inspect(v) {
   if (v instanceof List) return inspectList(v);
   if (v instanceof UtfCodepoint) return inspectUtfCodepoint(v);
   if (v instanceof BitArray) return inspectBitArray(v);
+  if (v.constructor === set_new().constructor) return set_inspect(v);
   if (v instanceof CustomType) return inspectCustomType(v);
   if (v instanceof Dict) return inspectDict(v);
   if (v instanceof Set) return `//js(Set(${[...v].map(inspect).join(", ")}))`;

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -1,6 +1,7 @@
 import gleam/dict
 import gleam/option.{None, Some}
 import gleam/order
+import gleam/set
 import gleam/should
 import gleam/string
 
@@ -1395,4 +1396,10 @@ pub fn inspect_map_test() {
   dict.from_list([#("a", 1), #("b", 2)])
   |> string.inspect
   |> should.equal("dict.from_list([#(\"a\", 1), #(\"b\", 2)])")
+}
+
+pub fn inspect_set_test() {
+  set.from_list(["a", "b"])
+  |> string.inspect
+  |> should.equal("set.from_list([\"a\", \"b\"])")
 }


### PR DESCRIPTION
Now

```gleam
set.from_list(["a", "b"]) |> string.inspect
```

produces
```gleam
"set.from_list([\"a\", \"b\"])"
```