### PR TITLE
Fix decode.recursive documentation

### DIFF
--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -969,9 +969,6 @@ pub fn failure(zero: a, expected: String) -> Decoder(a) {
 /// build-in `string` decoder) you would define it like so:
 ///
 /// ```gleam
-/// import gleam/dynamic
-/// import decode/decode
-///
 /// pub fn string_decoder() -> decode.Decoder(String) {
 ///   let default = ""
 ///   decode.new_primitive_decoder("String", fn(data) {
@@ -1003,9 +1000,6 @@ pub fn new_primitive_decoder(
 /// then you may not need to use this function.
 ///
 /// ```gleam
-/// import gleam/dynamic
-/// import gleam/dynamic/decode
-///
 /// type Nested {
 ///   Nested(List(Nested))
 ///   Value(String)

--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -995,26 +995,26 @@ pub fn new_primitive_decoder(
   })
 }
 
-/// Create a decoder that can refer to itself, useful for decoding for deeply
+/// Create a decoder that can refer to itself, useful for decoding deeply
 /// nested data.
 ///
 /// Attempting to create a recursive decoder without this function could result
-/// in an infinite loop. If you are using `field` or other `use`able function
+/// in an infinite loop. If you are using `field` or other `use`able functions
 /// then you may not need to use this function.
 ///
 /// ```gleam
 /// import gleam/dynamic
-/// import decode/zero.{type Decoder}
+/// import gleam/dynamic/decode
 ///
 /// type Nested {
 ///   Nested(List(Nested))
 ///   Value(String)
 /// }
 ///
-/// fn nested_decoder() -> Decoder(Nested) {
-///   use <- zero.recursive
-///   zero.one_of(zero.string |> zero.map(Value), [
-///     zero.list(nested_decoder()) |> zero.map(Nested),
+/// fn nested_decoder() -> decode.Decoder(Nested) {
+///   use <- decode.recursive
+///   decode.one_of(decode.string |> decode.map(Value), [
+///     decode.list(nested_decoder()) |> decode.map(Nested),
 ///   ])
 /// }
 /// ```


### PR DESCRIPTION
Just a quick fix to the documentation for `dynamic/decode`. Specifically removing references to the `decode/zero` package and fixing some typos.