### PR TITLE
Fix print when using bundlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `io.print` on browser environments, ensuring `process.stdout.write` exists
+- Fix `io.print` when bundling to the Browser using bundlers like `Vite`, `Webpack`, etc. where the `process` object exsits but not `process.stdout.write`.
 
 ## v0.52.0 - 2025-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix `io.print` on browser environments, ensuring `process.stdout.write` exists
+
 ## v0.52.0 - 2025-01-04
 
 - Improved the precision of `float.to_precision`.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -342,7 +342,7 @@ export function bit_array_to_string(bit_array) {
 }
 
 export function print(string) {
-  if (typeof process === "object") {
+  if (typeof process === "object" && process.stdout?.write) {
     process.stdout.write(string); // We can write without a trailing newline
   } else if (typeof Deno === "object") {
     Deno.stdout.writeSync(new TextEncoder().encode(string)); // We can write without a trailing newline


### PR DESCRIPTION
First of all, I really appreciate all the work that the core members have put into gleam, it's a super fun and refreshing language.

This PR should fix `io.print` when targeting javascript and compiling with bundlers like vite, where the process object exists but doesn't contain a `stdout` object.