### PR TITLE
Various changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug that would result in `list.unique` having quadratic runtime.
+- Fixed the implementation of `list.key_set` to be tail recursive.
 
 ## v0.53.0 - 2025-01-23
 

--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -78,7 +78,7 @@ fn is_utf8_loop(bits: BitArray) -> Bool {
 fn is_utf8_loop(bits: BitArray) -> Bool {
   case to_string(bits) {
     Ok(_) -> True
-    _ -> False
+    Error(_) -> False
   }
 }
 
@@ -111,7 +111,7 @@ fn unsafe_to_string(a: BitArray) -> String
 pub fn concat(bit_arrays: List(BitArray)) -> BitArray
 
 /// Encodes a BitArray into a base 64 encoded string.
-/// 
+///
 /// If the bit array does not contain a whole number of bytes then it is padded
 /// with zero bits prior to being encoded.
 ///

--- a/src/gleam/bytes_tree.gleam
+++ b/src/gleam/bytes_tree.gleam
@@ -68,7 +68,7 @@ pub fn prepend_tree(to second: BytesTree, prefix first: BytesTree) -> BytesTree 
 pub fn append_tree(to first: BytesTree, suffix second: BytesTree) -> BytesTree {
   case second {
     Many(trees) -> Many([first, ..trees])
-    _ -> Many([first, second])
+    Text(_) | Bytes(_) -> Many([first, second])
   }
 }
 

--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -349,7 +349,7 @@ pub fn run(data: Dynamic, decoder: Decoder(t)) -> Result(t, List(DecodeError)) {
   let #(maybe_invalid_data, errors) = decoder.function(data)
   case errors {
     [] -> Ok(maybe_invalid_data)
-    _ -> Error(errors)
+    [_, ..] -> Error(errors)
   }
 }
 
@@ -784,7 +784,7 @@ pub fn dict(
           // don't need to run the decoders, instead return the existing acc.
           case a.1 {
             [] -> fold_dict(a, k, v, key.function, value.function)
-            _ -> a
+            [_, ..] -> a
           }
         })
     }
@@ -897,7 +897,7 @@ pub fn collapse_errors(decoder: Decoder(a), name: String) -> Decoder(a) {
     let #(data, errors) as layer = decoder.function(dynamic_data)
     case errors {
       [] -> layer
-      _ -> #(data, decode_error(name, dynamic_data))
+      [_, ..] -> #(data, decode_error(name, dynamic_data))
     }
   })
 }
@@ -913,7 +913,7 @@ pub fn then(decoder: Decoder(a), next: fn(a) -> Decoder(b)) -> Decoder(b) {
     let #(data, _) as layer = decoder.function(dynamic_data)
     case errors {
       [] -> layer
-      _ -> #(data, errors)
+      [_, ..] -> #(data, errors)
     }
   })
 }
@@ -944,7 +944,7 @@ pub fn one_of(
     let #(_, errors) as layer = first.function(dynamic_data)
     case errors {
       [] -> layer
-      _ -> run_decoders(dynamic_data, layer, alternatives)
+      [_, ..] -> run_decoders(dynamic_data, layer, alternatives)
     }
   })
 }
@@ -961,7 +961,7 @@ fn run_decoders(
       let #(_, errors) as layer = decoder.function(data)
       case errors {
         [] -> layer
-        _ -> run_decoders(data, failure, decoders)
+        [_, ..] -> run_decoders(data, failure, decoders)
       }
     }
   }

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -1,19 +1,19 @@
 //// Functions for working with floats.
-//// 
+////
 //// ## Float representation
-//// 
+////
 //// Floats are represented as 64 bit floating point numbers on both the Erlang
 //// and JavaScript runtimes. The floating point behaviour is native to their
 //// respective runtimes, so their exact behaviour will be slightly different on
-//// the two runtimes. 
-//// 
+//// the two runtimes.
+////
 //// ### Infinity and NaN
-//// 
+////
 //// Under the JavaScript runtime, exceeding the maximum (or minimum)
 //// representable value for a floating point value will result in Infinity (or
 //// -Infinity). Should you try to divide two infinities you will get NaN as a
-//// result. 
-//// 
+//// result.
+////
 //// When running on BEAM, exceeding the maximum (or minimum) representable
 //// value for a floating point value will raise an error.
 ////
@@ -240,7 +240,7 @@ pub fn floor(x: Float) -> Float
 pub fn round(x: Float) -> Int {
   case x >=. 0.0 {
     True -> js_round(x)
-    _ -> 0 - js_round(negate(x))
+    False -> 0 - js_round(negate(x))
   }
 }
 
@@ -311,7 +311,7 @@ fn do_to_float(a: Int) -> Float
 pub fn absolute_value(x: Float) -> Float {
   case x >=. 0.0 {
     True -> x
-    _ -> 0.0 -. x
+    False -> 0.0 -. x
   }
 }
 
@@ -409,7 +409,7 @@ pub fn sum(numbers: List(Float)) -> Float {
 
 fn sum_loop(numbers: List(Float), initial: Float) -> Float {
   case numbers {
-    [x, ..rest] -> sum_loop(rest, x +. initial)
+    [first, ..rest] -> sum_loop(rest, first +. initial)
     [] -> initial
   }
 }
@@ -424,15 +424,12 @@ fn sum_loop(numbers: List(Float), initial: Float) -> Float {
 /// ```
 ///
 pub fn product(numbers: List(Float)) -> Float {
-  case numbers {
-    [] -> 1.0
-    _ -> product_loop(numbers, 1.0)
-  }
+  product_loop(numbers, 1.0)
 }
 
 fn product_loop(numbers: List(Float), initial: Float) -> Float {
   case numbers {
-    [x, ..rest] -> product_loop(rest, x *. initial)
+    [first, ..rest] -> product_loop(rest, first *. initial)
     [] -> initial
   }
 }

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -65,8 +65,7 @@ pub fn absolute_value(x: Int) -> Int {
 /// ```
 ///
 pub fn power(base: Int, of exponent: Float) -> Result(Float, Nil) {
-  base
-  |> to_float()
+  to_float(base)
   |> float.power(exponent)
 }
 
@@ -85,8 +84,7 @@ pub fn power(base: Int, of exponent: Float) -> Result(Float, Nil) {
 /// ```
 ///
 pub fn square_root(x: Int) -> Result(Float, Nil) {
-  x
-  |> to_float()
+  to_float(x)
   |> float.square_root()
 }
 
@@ -420,7 +418,7 @@ pub fn sum(numbers: List(Int)) -> Int {
 
 fn sum_loop(numbers: List(Int), initial: Int) -> Int {
   case numbers {
-    [x, ..rest] -> sum_loop(rest, x + initial)
+    [first, ..rest] -> sum_loop(rest, first + initial)
     [] -> initial
   }
 }
@@ -435,15 +433,12 @@ fn sum_loop(numbers: List(Int), initial: Int) -> Int {
 /// ```
 ///
 pub fn product(numbers: List(Int)) -> Int {
-  case numbers {
-    [] -> 1
-    _ -> product_loop(numbers, 1)
-  }
+  product_loop(numbers, 1)
 }
 
 fn product_loop(numbers: List(Int), initial: Int) -> Int {
   case numbers {
-    [x, ..rest] -> product_loop(rest, x * initial)
+    [first, ..rest] -> product_loop(rest, first * initial)
     [] -> initial
   }
 }
@@ -535,8 +530,8 @@ fn undigits_loop(numbers: List(Int), base: Int, acc: Int) -> Result(Int, Nil) {
 ///
 pub fn random(max: Int) -> Int {
   { float.random() *. to_float(max) }
-  |> float.floor()
-  |> float.round()
+  |> float.floor
+  |> float.round
 }
 
 /// Performs a truncated integer division.

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -44,14 +44,14 @@ pub fn all(list: List(Option(a))) -> Option(List(a)) {
 fn all_loop(list: List(Option(a)), acc: List(a)) -> Option(List(a)) {
   case list {
     [] -> Some(acc)
-    [x, ..rest] -> {
+    [first, ..rest] -> {
       let accumulate = fn(acc, item) {
         case acc, item {
           Some(values), Some(value) -> Some([value, ..values])
           _, _ -> None
         }
       }
-      accumulate(all_loop(rest, acc), x)
+      accumulate(all_loop(rest, acc), first)
     }
   }
 }
@@ -109,7 +109,7 @@ pub fn is_none(option: Option(a)) -> Bool {
 pub fn to_result(option: Option(a), e) -> Result(a, e) {
   case option {
     Some(a) -> Ok(a)
-    _ -> Error(e)
+    None -> Error(e)
   }
 }
 
@@ -130,7 +130,7 @@ pub fn to_result(option: Option(a), e) -> Result(a, e) {
 pub fn from_result(result: Result(a, e)) -> Option(a) {
   case result {
     Ok(a) -> Some(a)
-    _ -> None
+    Error(_) -> None
   }
 }
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -148,7 +148,7 @@ pub fn compare(a: String, b: String) -> order.Order {
     _ ->
       case less_than(a, b) {
         True -> order.Lt
-        _ -> order.Gt
+        False -> order.Gt
       }
   }
 }
@@ -716,7 +716,7 @@ pub fn to_graphemes(string: String) -> List(String) {
 fn to_graphemes_loop(string: String, acc: List(String)) -> List(String) {
   case pop_grapheme(string) {
     Ok(#(grapheme, rest)) -> to_graphemes_loop(rest, [grapheme, ..acc])
-    _ -> acc
+    Error(_) -> acc
   }
 }
 
@@ -911,7 +911,7 @@ pub fn last(string: String) -> Result(String, Nil) {
 pub fn capitalise(string: String) -> String {
   case pop_grapheme(string) {
     Ok(#(first, rest)) -> append(to: uppercase(first), suffix: lowercase(rest))
-    _ -> ""
+    Error(_) -> ""
   }
 }
 

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -628,11 +628,11 @@ fn remove_dot_segments_loop(
 pub fn to_string(uri: Uri) -> String {
   let parts = case uri.fragment {
     Some(fragment) -> ["#", fragment]
-    _ -> []
+    None -> []
   }
   let parts = case uri.query {
     Some(query) -> ["?", query, ..parts]
-    _ -> parts
+    None -> parts
   }
   let parts = [uri.path, ..parts]
   let parts = case uri.host, string.starts_with(uri.path, "/") {

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -441,7 +441,7 @@ pub fn find_map_test() {
   |> list.find_map(with: fn(x) {
     case x == recursion_test_cycles {
       True -> Ok(recursion_test_cycles)
-      _ -> Error(Nil)
+      False -> Error(Nil)
     }
   })
 }

--- a/test/gleam/should.gleam
+++ b/test/gleam/should.gleam
@@ -41,7 +41,8 @@ pub fn not_equal(a: a, b: a) -> Nil {
 pub fn be_ok(a: Result(a, e)) -> a {
   case a {
     Ok(e) -> e
-    _ -> panic as { string.concat(["\n", string.inspect(a), "\nshould be ok"]) }
+    Error(_) ->
+      panic as { string.concat(["\n", string.inspect(a), "\nshould be ok"]) }
   }
 }
 


### PR DESCRIPTION
reading through the stdlib code I noticed a couple of inconsistencies and code patterns that didn't look great to me. A recap of the changes introduced by this PR:
- I've made sure that pattern matching on lists follows the usual `[first, ..rest]` pattern instead of using single letter variables
- Fixed the implementation of `list.key_set` to be tail recursive
- Removed trailing spaces from various lines
- Stop using the catch all pattern when pattern matching on `Result`s, `Bool`s or `List`s
- I've removed the `reverse_loop` function in favour of the better named `reverse_and_prepend` one to use internally in the list module, they did the same thing