### PR TITLE
Add `map` for pair

### DIFF
--- a/src/gleam/pair.gleam
+++ b/src/gleam/pair.gleam
@@ -70,6 +70,20 @@ pub fn map_second(of pair: #(a, b), with fun: fn(b) -> c) -> #(a, c) {
   #(a, fun(b))
 }
 
+/// Returns a new pair with both elements having had `with` applied to them.
+///
+/// ## Examples
+///
+/// ```gleam
+/// #(1, 2) |> map(fn(n) { n * 2 })
+/// // -> #(2, 4)
+/// ```
+///
+pub fn map(of pair: #(a, a), with fun: fn(a) -> b) -> #(b, b) {
+  let #(a, b) = pair
+  #(fun(a), fun(b))
+}
+
 /// Returns a new pair with the given elements. This can also be done using the dedicated
 /// syntax instead: `new(1, 2) == #(1, 2)`.
 ///


### PR DESCRIPTION
I have found myself wanting to apply a function to both values in a pair, so I ended up with code like the following
```gleam
some_pair |> pair.map_first(my_function) |> pair.map_second(my_function)
```
This feels very clumsy to me, and I would love to instead write
```gleam
my_pair |> pair.map(double)
```
in order to map both values in the pair.

I couldn't find any discussion about this in the issues or PRs, so figured I'd see if there is interest in adding this to the standard library.

If `map` doesn't sound right, We could change it to `map_both`?

