### PR TITLE
Proposal: Change the semantics of bitwise operations to be fully platform-dependent

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -763,33 +763,28 @@ export function byte_size(string) {
   return new TextEncoder().encode(string).length;
 }
 
-// In Javascript bitwise operations convert numbers to a sequence of 32 bits
-// while Erlang uses arbitrary precision.
-// To get around this problem and get consistent results use BigInt and then
-// downcast the value back to a Number value.
-
 export function bitwise_and(x, y) {
-  return Number(BigInt(x) & BigInt(y));
+  return x & y;
 }
 
 export function bitwise_not(x) {
-  return Number(~BigInt(x));
+  return ~x;
 }
 
 export function bitwise_or(x, y) {
-  return Number(BigInt(x) | BigInt(y));
+  return x | y;
 }
 
 export function bitwise_exclusive_or(x, y) {
-  return Number(BigInt(x) ^ BigInt(y));
+  return x ^ y;
 }
 
 export function bitwise_shift_left(x, y) {
-  return Number(BigInt(x) << BigInt(y));
+  return x << y;
 }
 
 export function bitwise_shift_right(x, y) {
-  return Number(BigInt(x) >> BigInt(y));
+  return x >> y;
 }
 
 export function inspect(v) {


### PR DESCRIPTION
Hello!!

in my array implementation, I use bitwise operations for internal index calculations. Bitwise operations are generally considered to be quite low-level, but extremely fast in comparison. They can be therefore be thought of a micro-optimisation; for example a left shift `a >> b` is a hardware implementation for the equivalent

```gleam
let assert Ok(b2) = int.power(2, b)
float.truncate(float.floor(a /. b2))
```

From my understanding, number semantics are platform-defined, except that Gleam defines division by zero to equal zero. Floating point numbers have slightly different semantics, since Erlang is not fully compliant with  IEEE 754. Integers in Erlang have arbitrary precision, while standard floating point numbers are used on the Javascript target, even though a native `BigInt` type would exist on that target. It is well-known that while whole integers can be accurately represented for up to 53 bit using 64-bit floating-point numbers, bitwise operations are defined using the semantics of 32-bit integers in the ECMAScript standard.

The current implementation of bitwise operations for Javascript instead tries to support the full range of valid integers, up to 53-bit. To that end, it converts all inputs to BigInts and back, which implies a significant overhead. These are notably the only sets of operations that try to preserve integer semantics beyond what the platform defines; I could not find another use of `BigInt` for any other operation in the standard library. This does not what I'd have expected for these reasons:

- I would have expected for bitwise operations to follow the semantics of the platform
- I would have expected bitwise operations to be useful as a micro-optimisation, and in particular not imply memory allocations.

If this is unacceptable, I think a range check that falls back to a mathematically equivalent expression defined on floating-point numbers (as outlined above) would overall still be faster and easier to optimise for engines.

thanks ~ :purple_heart: 

(I have left the tests intentionally broken for now)