### PR TITLE
Fix `optionally_at` to handle Nil mid-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Improved `optionally_at` in `dynamic/decode` to decode nil values encountered
+  along its path to the default value.
+
 ## v0.55.0 - 2025-02-21
 
 - The performance of `dict.is_empty` has been improved.

--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -603,6 +603,10 @@ pub fn optional_field(
 /// an int then it'll also index into Erlang tuples and JavaScript arrays, and
 /// the first two elements of Gleam lists.
 ///
+/// If a nil value is encountered along the path, except at the final position,
+/// the provided default will be returned.  The `optional` function may be used
+/// to accept a nil value at the final location the path points to.
+///
 /// # Examples
 ///
 /// ```gleam
@@ -612,9 +616,24 @@ pub fn optional_field(
 ///   #("one", dict.from_list([])),
 /// ]))
 ///
+/// let result = decode.run(data, decoder)
+/// assert result == Ok(100)
 ///
-/// decode.run(data, decoder)
-/// // -> Ok(100)
+///
+/// let decoder =
+///   decode.optionally_at(
+///     ["first", "second", "third"],
+///     option.None,
+///     decode.optional(decode.int),
+///   )
+///
+/// let data =
+///   dynamic.from(
+///     dict.from_list([#("first", dict.from_list([#("second", Nil)]))]),
+///   )
+///
+/// let result = decode.run(data, decoder)
+/// assert result == Ok(option.None)
 /// ```
 ///
 pub fn optionally_at(

--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -439,19 +439,19 @@ fn optional_index(
     }
 
     [key, ..path] -> {
-      case bare_index(data, key) {
-        Ok(Some(data)) -> {
-          optional_index(path, [key, ..position], inner, data, handle_miss)
-        }
-        Ok(None) -> {
+      case is_null(data) {
+        True -> {
           handle_miss(data, [key, ..position])
         }
-        Error(kind) -> {
-          case is_null(data) {
-            True -> {
+        False -> {
+          case bare_index(data, key) {
+            Ok(Some(data)) -> {
+              optional_index(path, [key, ..position], inner, data, handle_miss)
+            }
+            Ok(None) -> {
               handle_miss(data, [key, ..position])
             }
-            False -> {
+            Error(kind) -> {
               let #(default, _) = inner(data)
               #(default, [DecodeError(kind, dynamic.classify(data), [])])
               |> push_path(list.reverse(position))

--- a/test/gleam/dynamic/decode_test.gleam
+++ b/test/gleam/dynamic/decode_test.gleam
@@ -923,6 +923,24 @@ pub fn optionally_at_nil_in_path_error_test() {
   |> should.equal(100)
 }
 
+pub fn optionally_at_nil_target_error_test() {
+  dynamic.from(
+    dict.from_list([
+      #(
+        "first",
+        dict.from_list([#("second", dict.from_list([#("third", Nil)]))]),
+      ),
+    ]),
+  )
+  |> decode.run(decode.optionally_at(
+    ["first", "second", "third"],
+    100,
+    decode.int,
+  ))
+  |> should.be_error
+  |> should.equal([DecodeError("Int", "Nil", ["first", "second", "third"])])
+}
+
 @external(erlang, "maps", "from_list")
 @external(javascript, "../../gleam_stdlib_test_ffi.mjs", "object")
 fn make_object(items: List(#(String, t))) -> Dynamic

--- a/test/gleam/dynamic/decode_test.gleam
+++ b/test/gleam/dynamic/decode_test.gleam
@@ -912,6 +912,17 @@ pub fn optionally_at_no_path_error_test() {
   |> should.equal(100)
 }
 
+pub fn optionally_at_nil_in_path_error_test() {
+  dynamic.from(dict.from_list([#("first", dict.from_list([#("second", Nil)]))]))
+  |> decode.run(decode.optionally_at(
+    ["first", "second", "third"],
+    100,
+    decode.int,
+  ))
+  |> should.be_ok
+  |> should.equal(100)
+}
+
 @external(erlang, "maps", "from_list")
 @external(javascript, "../../gleam_stdlib_test_ffi.mjs", "object")
 fn make_object(items: List(#(String, t))) -> Dynamic


### PR DESCRIPTION
This is a fix for the decoding error mentioned in https://github.com/gleam-lang/gleam/discussions/4202#discussioncomment-12013168

It modifies `optionally_at` to treat a mid-path Nil as a missing value, instead of a decode error.  This PR does not change the behavior of Nil being present at the target of the path.

Example problem, given a decoder containing:

    use str_val <- decode.then(decode.optionally_at(
      ["a", "b", "c"],
      None,
      optional(string),
    ))

And the following 3 JSON inputs:

```json
{"a": {}}
{"a": {"b": {}}}
{"a": {"b": null}}
```

The first two will decode to None as expected, but the third case will fail:

```
runtime error: let assert

Pattern match failed, no pattern matched the value.

unmatched value:
  Error(UnableToDecode([DecodeError("Dict", "Atom", ["a", "b"])]))
```
