### PR TITLE
Add dict update function

### DIFF
--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -448,6 +448,35 @@ pub fn upsert(
   }
 }
 
+/// Creates a new dict with one entry updated using a given function.
+///
+/// If there was not an entry in the dict for the given key then the dict is
+/// returned unmodified.
+///
+/// ## Example
+///
+/// ```gleam
+/// let dict = from_list([#("a", 0)])
+/// let increment = fn(i) { i + 1 }
+///
+/// update(dict, "a", increment)
+/// // -> from_list([#("a", 1)])
+///
+/// update(dict, "b", increment)
+/// // -> from_list([#("a", 0)])
+/// ```
+///
+pub fn update(
+  in dict: Dict(k, v),
+  update key: k,
+  with fun: fn(v) -> v,
+) -> Dict(k, v) {
+  case get(dict, key) {
+    Ok(value) -> insert(dict, key, fun(value))
+    Error(_) -> dict
+  }
+}
+
 /// Combines all entries into a single value by calling a given function on each
 /// one.
 ///

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -207,6 +207,24 @@ pub fn upsert_test() {
   |> should.equal(dict.from_list([#("a", 0), #("b", 1), #("c", 2), #("z", 0)]))
 }
 
+pub fn update_test() {
+  let dict = dict.from_list([#("a", 0), #("b", 1), #("c", 2)])
+
+  let inc = fn(i) { i + 1 }
+
+  dict
+  |> dict.update("a", inc)
+  |> should.equal(dict.from_list([#("a", 1), #("b", 1), #("c", 2)]))
+
+  dict
+  |> dict.update("b", inc)
+  |> should.equal(dict.from_list([#("a", 0), #("b", 2), #("c", 2)]))
+
+  dict
+  |> dict.update("z", inc)
+  |> should.equal(dict.from_list([#("a", 0), #("b", 1), #("c", 2)]))
+}
+
 pub fn fold_test() {
   let dict = dict.from_list([#("a", 0), #("b", 1), #("c", 2), #("d", 3)])
 


### PR DESCRIPTION
This PR adds the dict `update` function. I'm not sure if this is something you'd
like to add, but I've had several cases where I thought the function could be
useful rather than having a "no-op" branch in the `None` case of `upsert`.

Let me know what you think.
