### PR TITLE
`gleam/dynamic/decode` bugfixings

### DIFF
--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -552,14 +552,15 @@ pub fn optional_field(
   next: fn(t) -> Decoder(final),
 ) -> Decoder(final) {
   Decoder(function: fn(data) {
-    let #(out, errors1) = case bare_index(data, key) {
-      Ok(Some(data)) -> field_decoder.function(data)
-      Ok(None) -> #(default, [])
-      Error(kind) -> {
-        #(default, [DecodeError(kind, dynamic.classify(data), [])])
-        |> push_path([key])
+    let #(out, errors1) =
+      case bare_index(data, key) {
+        Ok(Some(data)) -> field_decoder.function(data)
+        Ok(None) -> #(default, [])
+        Error(kind) -> #(default, [
+          DecodeError(kind, dynamic.classify(data), []),
+        ])
       }
-    }
+      |> push_path([key])
     let #(out, errors2) = next(out).function(data)
     #(out, list.append(errors1, errors2))
   })

--- a/src/gleam_stdlib_decode_ffi.mjs
+++ b/src/gleam_stdlib_decode_ffi.mjs
@@ -99,7 +99,7 @@ export function int(data) {
 
 export function string(data) {
   if (typeof data === "string") return new Ok(data);
-  return new Error(0);
+  return new Error("");
 }
 
 export function is_null(data) {

--- a/test/gleam/dynamic/decode_test.gleam
+++ b/test/gleam/dynamic/decode_test.gleam
@@ -6,6 +6,7 @@ import gleam/int
 import gleam/option
 import gleam/result
 import gleam/should
+import gleam/string
 
 pub type User {
   User(
@@ -174,6 +175,53 @@ pub fn subfield_wrong_inner_error_test() {
   })
   |> should.be_error
   |> should.equal([DecodeError("String", "Int", ["name"])])
+}
+
+pub fn optional_field_wrong_inner_error_test() {
+  let data = dynamic.from(dict.from_list([#("a", Nil)]))
+  decode.run(data, {
+    use bar <- decode.optional_field("a", "", decode.string)
+    decode.success(bar)
+  })
+  |> should.be_error
+  |> should.equal([DecodeError("String", "Nil", ["a"])])
+}
+
+pub fn sub_optional_field_wrong_inner_error_test() {
+  let data =
+    dynamic.from(dict.from_list([#("a", dict.from_list([#("b", Nil)]))]))
+  decode.run(data, {
+    use bar <- decode.optional_field("a", "", {
+      use foo <- decode.optional_field("b", "", decode.string)
+      decode.success(foo)
+    })
+    decode.success(bar)
+  })
+  |> should.be_error
+  |> should.equal([DecodeError("String", "Nil", ["a", "b"])])
+}
+
+pub fn optional_field_wrong_inner_error_type_test() {
+  let data = dynamic.from(dict.from_list([#("a", 0)]))
+  decode.run(data, {
+    use bar <- decode.optional_field("a", "", decode.string)
+    decode.success(bar)
+  })
+  |> should.be_error
+  |> should.equal([DecodeError("String", "Int", ["a"])])
+}
+
+pub fn string_map_ok_test() {
+  dynamic.from("tEsT")
+  |> decode.run(decode.string |> decode.map(string.lowercase))
+  |> should.be_ok
+  |> should.equal("test")
+}
+
+pub fn string_map_error_test() {
+  dynamic.from(0)
+  |> decode.run(decode.string |> decode.map(string.lowercase))
+  |> should.be_error
 }
 
 pub fn string_ok_test() {


### PR DESCRIPTION
Hi!

- String decoders are false in JS FFI, leading to inconsistent code, and potentially runtime errors (`decode.string |> decode.map(string.lowercase)` creates a runtime error).
- Closes #806.