### PR TITLE
improve performance of `string.concat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - The `debug` function in the `io` module has been deprecated in favour of
   the `echo` keyword.
-- The performance of `string.append` has been improved.
+- The performance of `string.append` and `string.concat` have been improved.
 
 ## v0.58.0 - 2025-03-23
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -387,10 +387,16 @@ pub fn append(to first: String, suffix second: String) -> String {
 /// // -> "nevertheless"
 /// ```
 ///
+@external(erlang, "erlang", "list_to_binary")
 pub fn concat(strings: List(String)) -> String {
-  strings
-  |> string_tree.from_strings
-  |> string_tree.to_string
+  do_concat(strings, "")
+}
+
+fn do_concat(strings: List(String), accumulator: String) -> String {
+  case strings {
+    [string, ..strings] -> do_concat(strings, accumulator <> string)
+    [] -> accumulator
+  }
 }
 
 /// Creates a new `String` by repeating a `String` a given number of times.

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -389,12 +389,12 @@ pub fn append(to first: String, suffix second: String) -> String {
 ///
 @external(erlang, "erlang", "list_to_binary")
 pub fn concat(strings: List(String)) -> String {
-  do_concat(strings, "")
+  concat_loop(strings, "")
 }
 
-fn do_concat(strings: List(String), accumulator: String) -> String {
+fn concat_loop(strings: List(String), accumulator: String) -> String {
   case strings {
-    [string, ..strings] -> do_concat(strings, accumulator <> string)
+    [string, ..strings] -> concat_loop(strings, accumulator <> string)
     [] -> accumulator
   }
 }

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -141,6 +141,12 @@ pub fn concat_test() {
   |> should.equal("Hello, world!")
 }
 
+pub fn concat_emoji_test() {
+  ["💃🏿", "💇🏼‍♀️", "🧔‍♂️", "🧑‍🦼‍➡️"]
+  |> string.concat
+  |> should.equal("💃🏿💇🏼‍♀️🧔‍♂️🧑‍🦼‍➡️")
+}
+
 pub fn repeat_test() {
   "hi"
   |> string.repeat(times: 3)


### PR DESCRIPTION
On the javascript target, this is ~40% improvement:

```
# length of string / number of strings in array

Input               Function                       IPS           Min           P99
10 / 10             stdlib string.concat  1896794.4060        0.0001        0.0003
10 / 10              gleam string_concat  2612378.6181        0.0001        0.0002
10 / 100            stdlib string.concat   459578.7508        0.0011        0.0026
10 / 100             gleam string_concat   663753.4921        0.0008        0.0019
10 / 1000           stdlib string.concat    47628.1946        0.0112        0.0336
10 / 1000            gleam string_concat    82032.8985        0.0077        0.0148
100 / 10            stdlib string.concat  1984712.2048        0.0001        0.0002
100 / 10             gleam string_concat  2604517.0489        0.0001        0.0002
100 / 100           stdlib string.concat   386360.6371        0.0011        0.0031
100 / 100            gleam string_concat   591321.5937        0.0008        0.0017
100 / 1000          stdlib string.concat    40844.1851        0.0112        0.0238
100 / 1000           gleam string_concat    68658.9470        0.0075        0.0201
1000 / 10           stdlib string.concat  1724358.7846        0.0001        0.0003
1000 / 10            gleam string_concat  2171339.5042        0.0001        0.0002
1000 / 100          stdlib string.concat   311834.2839        0.0011        0.0036
1000 / 100           gleam string_concat   509043.3481        0.0008        0.0023
1000 / 1000         stdlib string.concat    35882.1961        0.0109        0.0225
1000 / 1000          gleam string_concat    61267.5468        0.0077        0.0183
```

On Erlang, `unicode:characters_to_binary` used by `string_tree.to_string` seems to be particularly bad, since it re-encodes all strings. We know that in Gleam, all valid `String` values are valid UTF-8, so this step is unecessary. The `list_to_binary` BIF provides a slight improvement over the Gleam implementation:

```
10 / 10             stdlib string.concat   967342.9709        0.0006        0.0017
10 / 10             gleam string_concat   2054804.3102        0.0003        0.0008
10 / 10             list_to_binary        1330880.1266        0.0003        0.0009
10 / 100            stdlib string.concat   255993.2017        0.0031        0.0109
10 / 100            gleam string_concat    387696.4730        0.0021        0.0047
10 / 100            list_to_binary         644307.1247        0.0012        0.0021
10 / 1000           stdlib string.concat    30293.6101        0.0294        0.0418
10 / 1000           gleam string_concat     52428.9424        0.0169        0.0267
10 / 1000           list_to_binary          82549.3895        0.0103        0.0185
100 / 10            stdlib string.concat   352852.4671        0.0022        0.0086
100 / 10            gleam string_concat   1203803.7230        0.0006        0.0013
100 / 10            list_to_binary        1279303.2843        0.0003        0.0007
100 / 100           stdlib string.concat    43525.0263        0.0197        0.0293
100 / 100           gleam string_concat    301868.9653        0.0028        0.0050
100 / 100           list_to_binary         578273.1777        0.0014        0.0063
100 / 1000          stdlib string.concat     3284.1257        0.2648        0.3441
100 / 1000          gleam string_concat     37033.6834        0.0197        0.0883
100 / 1000          list_to_binary          47524.2051        0.0121        0.0203
1000 / 10           stdlib string.concat    30316.3780        0.0185        0.0359
1000 / 10           gleam string_concat    704921.8990        0.0011        0.0022
1000 / 10           list_to_binary         716443.6538        0.0005        0.0045
1000 / 100          stdlib string.concat     3542.2003        0.2531        0.3528
1000 / 100          gleam string_concat     64833.9607        0.0053        0.0617
1000 / 100          list_to_binary         111208.7273        0.0038        0.0078
1000 / 1000         stdlib string.concat      365.2121        2.4123        2.8276
1000 / 1000         gleam string_concat     14496.7765        0.0622        0.0826
1000 / 1000         list_to_binary          14815.8318        0.0374        0.0554
```