### PR TITLE
improve performance of string.append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `debug` function in the `io` module has been deprecated in favour of
   the `echo` keyword.
+- The performance of `string.append` has been improved.
 
 ## v0.58.0 - 2025-03-23
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -371,10 +371,7 @@ fn erl_split(a: String, b: String) -> List(String)
 /// ```
 ///
 pub fn append(to first: String, suffix second: String) -> String {
-  first
-  |> string_tree.from_string
-  |> string_tree.append(second)
-  |> string_tree.to_string
+  first <> second
 }
 
 /// Creates a new `String` by joining many `String`s together.


### PR DESCRIPTION
I do not know why this was implemented using string_builder. Maybe I'm missing some context here?

Anyways here are some numbers. Each benchmarked run is 1000 string appends.


```
# javascript: length(first) / length(second)
# we are most likely only measuring function call overhead here.
# javascript strings are ropes, so this string.append is always O(1).

10 / 10             stdlib string.append   116865.2340        0.0067        0.0139
10 / 10             gleam string.append   1376350.3739        0.0005        0.0007
10 / 100            stdlib string.append   107510.2501        0.0066        0.0139
10 / 100            gleam string.append   1373745.9937        0.0005        0.0008
10 / 1000           stdlib string.append   101007.7914        0.0066        0.0152
10 / 1000           gleam string.append   1372307.2543        0.0005        0.0008
100 / 10            stdlib string.append    95415.4526        0.0066        0.0140
100 / 10            gleam string.append   1374136.3649        0.0005        0.0008
100 / 100           stdlib string.append    89712.1456        0.0066        0.0144
100 / 100           gleam string.append   1374751.1028        0.0005        0.0008
100 / 1000          stdlib string.append    83863.2095        0.0066        0.0150
100 / 1000          gleam string.append   1391718.6805        0.0005        0.0008
1000 / 10           stdlib string.append    85492.3921        0.0066        0.0143
1000 / 10           gleam string.append   1421025.2242        0.0005        0.0011
1000 / 100          stdlib string.append    80491.8928        0.0066        0.0169
1000 / 100          gleam string.append   1299541.8860        0.0005        0.0010
1000 / 1000         stdlib string.append    76009.6139        0.0067        0.0152
1000 / 1000         gleam string.append   1374985.4121        0.0005        0.0009
```

```
# erlang

Input               Function                       IPS           Min           P99
10 / 10             stdlib string.append     2407.7021        0.3229        0.4792
10 / 10             gleam string.append      5599.0525        0.1004        0.2918
10 / 100            stdlib string.append     1603.9371        0.5544        0.6839
10 / 100            gleam string.append      5623.8484        0.1061        0.3827
10 / 1000           stdlib string.append      391.0354        2.3819        2.6484
10 / 1000           gleam string.append      5019.3428        0.1655        0.2464
100 / 10            stdlib string.append     1639.9263        0.5445        0.6819
100 / 10            gleam string.append      5725.8912        0.1052        0.4005
100 / 100           stdlib string.append     1231.5513        0.7397        0.8711
100 / 100           gleam string.append      7701.3191        0.1052        0.2463
100 / 1000          stdlib string.append      359.6126        2.5398        2.8848
100 / 1000          gleam string.append      4938.7782        0.1671        0.2516
1000 / 10           stdlib string.append      386.7746        2.4236        2.6813
1000 / 10           gleam string.append      5082.9875        0.1646        0.2451
1000 / 100          stdlib string.append      365.1348        2.5582        2.8677
1000 / 100          gleam string.append      4924.9987        0.1644        0.2501
1000 / 1000         stdlib string.append      215.0681        4.4469        4.7755
1000 / 1000         gleam string.append      4323.6020        0.1897        0.2868
```