### PR TITLE
improve performance of string.join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - The `debug` function in the `io` module has been deprecated in favour of
   the `echo` keyword.
-- The performance of `string.append` and `string.concat` have been improved.
+- The performance of `string.append`, `string.join`, and `string.concat` have
+  been improved.
 
 ## v0.58.0 - 2025-03-23
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -435,11 +435,11 @@ fn repeat_loop(string: String, times: Int, acc: String) -> String {
 pub fn join(strings: List(String), with separator: String) -> String {
   case strings {
     [] -> ""
-    [first, ..rest] -> do_join(rest, separator, first)
+    [first, ..rest] -> join_loop(rest, separator, first)
   }
 }
 
-fn do_join(
+fn join_loop(
   strings: List(String),
   separator: String,
   accumulator: String,
@@ -447,7 +447,7 @@ fn do_join(
   case strings {
     [] -> accumulator
     [string, ..strings] ->
-      do_join(strings, separator, accumulator <> separator <> string)
+      join_loop(strings, separator, accumulator <> separator <> string)
   }
 }
 

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -432,11 +432,23 @@ fn repeat_loop(string: String, times: Int, acc: String) -> String {
 /// // -> "home/evan/Desktop"
 /// ```
 ///
-@external(javascript, "../gleam_stdlib.mjs", "join")
 pub fn join(strings: List(String), with separator: String) -> String {
-  strings
-  |> list.intersperse(with: separator)
-  |> concat
+  case strings {
+    [] -> ""
+    [first, ..rest] -> do_join(rest, separator, first)
+  }
+}
+
+fn do_join(
+  strings: List(String),
+  separator: String,
+  accumulator: String,
+) -> String {
+  case strings {
+    [] -> accumulator
+    [string, ..strings] ->
+      do_join(strings, separator, accumulator <> separator <> string)
+  }
 }
 
 /// Pads the start of a `String` until it has a given length.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -205,17 +205,6 @@ export function split(xs, pattern) {
   return List.fromArray(xs.split(pattern));
 }
 
-export function join(xs, separator) {
-  const iterator = xs[Symbol.iterator]();
-  let result = iterator.next().value || "";
-  let current = iterator.next();
-  while (!current.done) {
-    result = result + separator + current.value;
-    current = iterator.next();
-  }
-  return result;
-}
-
 export function concat(xs) {
   let result = "";
   for (const x of xs) {

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -161,7 +161,27 @@ pub fn repeat_test() {
   |> should.equal("")
 }
 
-pub fn join_test() {
+pub fn join_0_test() {
+  []
+  |> string.join(with: ", ")
+  |> should.equal("")
+
+  []
+  |> string.join(with: "-")
+  |> should.equal("")
+}
+
+pub fn join_1_test() {
+  ["Hello"]
+  |> string.join(with: ", ")
+  |> should.equal("Hello")
+
+  ["Hello"]
+  |> string.join(with: "-")
+  |> should.equal("Hello")
+}
+
+pub fn join_2_test() {
   ["Hello", "world!"]
   |> string.join(with: ", ")
   |> should.equal("Hello, world!")
@@ -169,6 +189,16 @@ pub fn join_test() {
   ["Hello", "world!"]
   |> string.join(with: "-")
   |> should.equal("Hello-world!")
+}
+
+pub fn join_3_test() {
+  ["Hello", "there", "world!"]
+  |> string.join(with: ", ")
+  |> should.equal("Hello, there, world!")
+
+  ["Hello", "there", "world!"]
+  |> string.join(with: "-")
+  |> should.equal("Hello-there-world!")
 }
 
 pub fn trim_test() {


### PR DESCRIPTION
This is a similar situation to `string.concat`, however I do not know about a BIF we could use here so the Gleam implementation is actually best.

There is also a FFI version for Javascript, but even that is slower than a pure Gleam solution now, most likely due to the recent improvements to list pattern matching in 1.9.

For the benchmark numbers, I chose to join on `, `, since I believe a short character join string is the most common case.

Numbers!


```
# erlang - again string length / list length
Input               Function                       IPS           Min           P99
10 / 10             stdlib string.join     777191.7326        0.0009        0.0015
10 / 10             gleam string.join     1630428.8300        0.0005        0.0011
10 / 100            stdlib string.join     150520.7347        0.0054        0.0150
10 / 100            gleam string.join      244764.1153        0.0036        0.0058
10 / 1000           stdlib string.join      16522.4048        0.0514        0.0925
10 / 1000           gleam string.join       28194.7461        0.0313        0.0702
100 / 10            stdlib string.join     283124.6178        0.0025        0.0086
100 / 10            gleam string.join     1078351.4757        0.0008        0.0011
100 / 100           stdlib string.join      38820.4196        0.0222        0.0331
100 / 100           gleam string.join      213138.1997        0.0040        0.0058
100 / 1000          stdlib string.join       2427.9732        0.3004        0.4007
100 / 1000          gleam string.join       26382.4137        0.0338        0.0469
1000 / 10           stdlib string.join      44855.8251        0.0189        0.0279
1000 / 10           gleam string.join      656004.6761        0.0012        0.0030
1000 / 100          stdlib string.join       3466.0823        0.2569        0.3667
1000 / 100          gleam string.join      115357.6359        0.0070        0.0148
1000 / 1000         stdlib string.join        346.1668        2.6125        3.9133
1000 / 1000         gleam string.join        2725.6218        0.2280        0.5837
```

```
# javascript

Input               Function                       IPS           Min           P99
10 / 10             stdlib string.join    1971708.4696        0.0002        0.0004
10 / 10             gleam string.join     2568384.8514        0.0001        0.0003
10 / 100            stdlib string.join     357832.8593        0.0014        0.0030
10 / 100            gleam string.join      462116.0739        0.0012        0.0022
10 / 1000           stdlib string.join      37463.1275        0.0147        0.0318
10 / 1000           gleam string.join       51937.8002        0.0115        0.0211
100 / 10            stdlib string.join    1790550.0451        0.0001        0.0004
100 / 10            gleam string.join      807797.3019        0.0001        0.0002
100 / 100           stdlib string.join     318071.6749        0.0014        0.0031
100 / 100           gleam string.join      428962.5024        0.0012        0.0022
100 / 1000          stdlib string.join      32831.2719        0.0150        0.0294
100 / 1000          gleam string.join       46558.1323        0.0116        0.0210
1000 / 10           stdlib string.join    1667662.0459        0.0001        0.0004
1000 / 10           gleam string.join     2458001.2974        0.0001        0.0002
1000 / 100          stdlib string.join     263659.1989        0.0015        0.0028
1000 / 100          gleam string.join      366360.3739        0.0012        0.0022
1000 / 1000         stdlib string.join      28046.5656        0.0144        0.0302
1000 / 1000         gleam string.join       39795.7678        0.0114        0.0231
```
