### PR TITLE
Optimise option functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - The performance of various functions in the `list` module has been improved.
+- Fixed the implementation of `option.values` and `option.all` to be tail
+  recursive.
 
 ## v0.59.0 - 2025-04-07
 

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -51,6 +51,7 @@ fn all_loop(list: List(Option(a)), acc: List(a)) -> Option(List(a)) {
 
 // This is copied from the list module and not imported as importing it would
 // result in a circular dependency!
+@external(erlang, "lists", "reverse")
 fn reverse(list: List(a)) -> List(a) {
   reverse_and_prepend(list, [])
 }

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -43,16 +43,22 @@ pub fn all(list: List(Option(a))) -> Option(List(a)) {
 
 fn all_loop(list: List(Option(a)), acc: List(a)) -> Option(List(a)) {
   case list {
-    [] -> Some(acc)
-    [first, ..rest] -> {
-      let accumulate = fn(acc, item) {
-        case acc, item {
-          Some(values), Some(value) -> Some([value, ..values])
-          _, _ -> None
-        }
-      }
-      accumulate(all_loop(rest, acc), first)
-    }
+    [] -> Some(reverse(acc))
+    [None, ..] -> None
+    [Some(first), ..rest] -> all_loop(rest, [first, ..acc])
+  }
+}
+
+// This is copied from the list module and not imported as importing it would
+// result in a circular dependency!
+fn reverse(list: List(a)) -> List(a) {
+  reverse_and_prepend(list, [])
+}
+
+fn reverse_and_prepend(list prefix: List(a), to suffix: List(a)) -> List(a) {
+  case prefix {
+    [] -> suffix
+    [first, ..rest] -> reverse_and_prepend(list: rest, to: [first, ..suffix])
   }
 }
 
@@ -344,15 +350,8 @@ pub fn values(options: List(Option(a))) -> List(a) {
 
 fn values_loop(list: List(Option(a)), acc: List(a)) -> List(a) {
   case list {
-    [] -> acc
-    [first, ..rest] -> {
-      let accumulate = fn(acc, item) {
-        case item {
-          Some(value) -> [value, ..acc]
-          None -> acc
-        }
-      }
-      accumulate(values_loop(rest, acc), first)
-    }
+    [] -> reverse(acc)
+    [None, ..rest] -> values_loop(rest, acc)
+    [Some(first), ..rest] -> values_loop(rest, [first, ..acc])
   }
 }

--- a/src/gleam/result.gleam
+++ b/src/gleam/result.gleam
@@ -346,7 +346,7 @@ pub fn lazy_or(
 /// ```
 ///
 pub fn all(results: List(Result(a, e))) -> Result(List(a), e) {
-  list.try_map(results, fn(x) { x })
+  list.try_map(results, fn(result) { result })
 }
 
 /// Given a list of results, returns a pair where the first element is a list
@@ -425,7 +425,7 @@ pub fn replace_error(result: Result(a, e), error: f) -> Result(a, f) {
 /// ```
 ///
 pub fn values(results: List(Result(a, e))) -> List(a) {
-  list.filter_map(results, fn(r) { r })
+  list.filter_map(results, fn(result) { result })
 }
 
 /// Updates a value held within the `Error` of a result by calling a given function


### PR DESCRIPTION
In this PR I've changed the implementation of the `option.values` and `option.all` functions to be tail recursive.
