### PR TITLE
Use erlang's lists:append/1 for list.flatten

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -701,8 +701,9 @@ pub fn prepend(to list: List(a), this item: a) -> List(a) {
 
 /// Joins a list of lists into a single list.
 ///
-/// This function traverses all elements twice.
-///
+/// This function traverses all elements twice on the Javascript target.
+/// This function traverses all elements once on the Erlang target.
+/// 
 /// ## Examples
 ///
 /// ```gleam
@@ -710,6 +711,7 @@ pub fn prepend(to list: List(a), this item: a) -> List(a) {
 /// // -> [1, 2, 3]
 /// ```
 ///
+@external(erlang, "lists", "append")
 pub fn flatten(lists: List(List(a))) -> List(a) {
   flatten_loop(lists, [])
 }


### PR DESCRIPTION
Erlang actually provides a BIF for flatten (called append) that allows it to only traverse each element once instead of twice. 