### PR TITLE
Fix a few typos

### DIFF
--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -70,7 +70,7 @@ pub fn list(a: List(Dynamic)) -> Dynamic
 /// Create a dynamic value from a list, converting it to a sequential runtime
 /// format rather than the regular list format.
 ///
-/// On Erlang this will be a tuple, on JavaScript this wil be an array.
+/// On Erlang this will be a tuple, on JavaScript this will be an array.
 ///
 @external(erlang, "erlang", "list_to_tuple")
 @external(javascript, "../gleam_stdlib.mjs", "list_to_array")
@@ -79,7 +79,8 @@ pub fn array(a: List(Dynamic)) -> Dynamic
 /// Create a dynamic value made an unordered series of keys and values, where
 /// the keys are unique.
 ///
-/// On Erlang this will be a map, on JavaScript this wil be a Gleam dict object.
+/// On Erlang this will be a map, on JavaScript this will be a Gleam dict
+/// object.
 ///
 pub fn properties(entries: List(#(Dynamic, Dynamic))) -> Dynamic {
   cast(dict.from_list(entries))
@@ -87,7 +88,7 @@ pub fn properties(entries: List(#(Dynamic, Dynamic))) -> Dynamic {
 
 /// A dynamic value representing nothing.
 ///
-/// On Erlang this will be the atom `nil`, on JavaScript this wil be
+/// On Erlang this will be the atom `nil`, on JavaScript this will be
 /// `undefined`.
 ///
 pub fn nil() -> Dynamic {

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -133,7 +133,7 @@ pub fn reverse(list: List(a)) -> List(a) {
 }
 
 /// Reverses a list and prepends it to another list.
-/// This function runs in linear time, proportional to the lenght of the list
+/// This function runs in linear time, proportional to the length of the list
 /// to prepend.
 ///
 fn reverse_and_prepend(list prefix: List(a), to suffix: List(a)) -> List(a) {
@@ -701,9 +701,9 @@ pub fn prepend(to list: List(a), this item: a) -> List(a) {
 
 /// Joins a list of lists into a single list.
 ///
-/// This function traverses all elements twice on the Javascript target.
+/// This function traverses all elements twice on the JavaScript target.
 /// This function traverses all elements once on the Erlang target.
-/// 
+///
 /// ## Examples
 ///
 /// ```gleam

--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -6,9 +6,9 @@
 ///
 /// ## `Option` and `Result`
 ///
-/// In other languages failible functions may return either `Result` or
+/// In other languages fallible functions may return either `Result` or
 /// `Option` depending on whether there is more information to be given about the
-/// failure. In Gleam all failible functions return `Result`, and `Nil` is used
+/// failure. In Gleam all fallible functions return `Result`, and `Nil` is used
 /// as the error if there is no extra detail to give. This consistency removes
 /// the boilerplate that would otherwise be needed to convert between `Option`
 /// and `Result` types, and makes APIs more predictable.

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -586,7 +586,7 @@ pub fn trim_end(string: String) -> String {
 ///
 /// There is a notable overhead to using this function, so you may not want to
 /// use it in a tight loop. If you wish to efficiently parse a string you may
-/// want to use alternatives such as the [splitter package]( https://hex.pm/packages/splitter).
+/// want to use alternatives such as the [splitter package](https://hex.pm/packages/splitter).
 ///
 /// ## Examples
 ///

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -651,7 +651,7 @@ export function byte_size(string) {
   return new TextEncoder().encode(string).length;
 }
 
-// In Javascript bitwise operations convert numbers to a sequence of 32 bits
+// In JavaScript bitwise operations convert numbers to a sequence of 32 bits
 // while Erlang uses arbitrary precision.
 // To get around this problem and get consistent results use BigInt and then
 // downcast the value back to a Number value.


### PR DESCRIPTION
Just a few random typos I found when reading the source code with a spell checker enabled in my editor.

Aside: https://github.com/gleam-lang/stdlib/blob/a108983548a0bc66a1fa36ca008361b0fb8a86a1/src/gleam_stdlib.mjs#L123-L124 NodeJS 14 has been EOL for a little over two years now.