### PR TITLE
Remove the fallback for NodeJS 14 from `string.replace()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The fallback code for older NodeJS versions in the JavaScript target
+  implementation of `string.replace` has been removed.
 - The `inspect` function in the `string` module will now print lists of ascii
   characters in a human readable format, to aid with debugging programs that use
   Erlang character lists.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -115,19 +115,7 @@ export function int_from_base_string(string, base) {
 }
 
 export function string_replace(string, target, substitute) {
-  if (typeof string.replaceAll !== "undefined") {
-    return string.replaceAll(target, substitute);
-  }
-  // Fallback for older Node.js versions:
-  // 1. <https://stackoverflow.com/a/1144788>
-  // 2. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping>
-  // TODO: This fallback could be remove once Node.js 14 is EOL
-  // aka <https://nodejs.org/en/about/releases/> on or after 2024-04-30
-  return string.replace(
-    // $& means the whole matched string
-    new RegExp(target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
-    substitute,
-  );
+  return string.replaceAll(target, substitute);
 }
 
 export function string_reverse(string) {


### PR DESCRIPTION
NodeJS 14 [has been EOL] for a little over two years now (with the last update to it being on 2023-02-16).

[has been EOL]: https://nodejs.org/en/about/previous-releases#:~:text=v14