### PR TITLE
Improve `list.sample` docs and implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   Erlang character lists.
 - The deprecated `debug` function in the `io` module has been removed.
 - The deprecated `from` function in the `dynamic` module has been removed.
+- Fixed a bug in the `sample` function from the `list` module where it would end
+  up picking the same element twice from a given list.
 
 ## v0.60.0 - 2025-05-13
 

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2317,28 +2317,25 @@ fn max_loop(list, compare, max) {
 pub fn sample(from list: List(a), up_to n: Int) -> List(a) {
   let #(reservoir, rest) = build_reservoir(from: list, sized: n)
 
-  case rest {
-    // If we've already taken all the items there were in the list there's no
-    // need to do anything else, we return the entire reservoire.
-    [] -> dict.values(reservoir)
-    _ ->
-      case dict.is_empty(reservoir) {
-        // If the reservoire is empty that means we were asking to sample 0 or
-        // less items. That doesn't make much sense, so we just return an empty
-        // list.
-        True -> []
-        False -> {
-          let w = float.exponential(log_random() /. int.to_float(n))
-          dict.values(sample_loop(list, reservoir, n, w))
-        }
-      }
+  case dict.is_empty(reservoir) {
+    // If the reservoire is empty that means we were asking to sample 0 or
+    // less items. That doesn't make much sense, so we just return an empty
+    // list.
+    True -> []
+
+    // Otherwise we keep looping over the remaining part of the list replacing
+    // random elements in the reservoir.
+    False -> {
+      let w = float.exponential(log_random() /. int.to_float(n))
+      dict.values(sample_loop(rest, reservoir, n, w))
+    }
   }
 }
 
 fn sample_loop(
   list: List(a),
   reservoir: Dict(Int, a),
-  k: Int,
+  n: Int,
   w: Float,
 ) -> Dict(Int, a) {
   let skip = {
@@ -2349,9 +2346,9 @@ fn sample_loop(
   case drop(list, skip) {
     [] -> reservoir
     [first, ..rest] -> {
-      let reservoir = dict.insert(reservoir, int.random(k), first)
-      let w = w *. float.exponential(log_random() /. int.to_float(k))
-      sample_loop(rest, reservoir, k, w)
+      let reservoir = dict.insert(reservoir, int.random(n), first)
+      let w = w *. float.exponential(log_random() /. int.to_float(n))
+      sample_loop(rest, reservoir, n, w)
     }
   }
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2301,8 +2301,9 @@ fn max_loop(list, compare, max) {
   }
 }
 
-/// Take a random sample of k elements from a list using reservoir sampling via
-/// Algo L. Returns an empty list if the sample size is less than or equal to 0.
+/// Returns a random sample of up to n elements from a list using reservoir
+/// sampling via [Algorithm L](https://en.wikipedia.org/wiki/Reservoir_sampling#Optimal:_Algorithm_L).
+/// Returns an empty list if the sample size is less than or equal to 0.
 ///
 /// Order is not random, only selection is.
 ///

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2337,9 +2337,9 @@ pub fn sample(from list: List(a), up_to n: Int) -> List(a) {
 }
 
 fn sample_loop(
-  list,
+  list: List(a),
   reservoir: Dict(Int, a),
-  k,
+  k: Int,
   index: Int,
   w: Float,
 ) -> Dict(Int, a) {

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2329,10 +2329,38 @@ pub fn sample(from list: List(a), up_to n: Int) -> List(a) {
         True -> []
         False -> {
           let w = float.exponential(log_random() /. int.to_float(n))
-          sample_loop(list, reservoir, n, n, w) |> dict.values
+          dict.values(sample_loop(list, reservoir, n, w))
         }
       }
   }
+}
+
+fn sample_loop(
+  list: List(a),
+  reservoir: Dict(Int, a),
+  k: Int,
+  w: Float,
+) -> Dict(Int, a) {
+  let skip = {
+    let assert Ok(log) = float.logarithm(1.0 -. w)
+    float.round(float.floor(log_random() /. log))
+  }
+
+  case drop(list, skip) {
+    [] -> reservoir
+    [first, ..rest] -> {
+      let reservoir = dict.insert(reservoir, int.random(k), first)
+      let w = w *. float.exponential(log_random() /. int.to_float(k))
+      sample_loop(rest, reservoir, k, w)
+    }
+  }
+}
+
+const min_positive = 2.2250738585072014e-308
+
+fn log_random() -> Float {
+  let assert Ok(random) = float.logarithm(float.random() +. min_positive)
+  random
 }
 
 /// Builds the initial reservoir used by Algorithm L.
@@ -2366,34 +2394,4 @@ fn build_reservoir_loop(
         }
       }
   }
-}
-
-fn sample_loop(
-  list: List(a),
-  reservoir: Dict(Int, a),
-  k: Int,
-  index: Int,
-  w: Float,
-) -> Dict(Int, a) {
-  let skip = {
-    let assert Ok(log_result) = float.logarithm(1.0 -. w)
-    log_random() /. log_result |> float.floor |> float.round
-  }
-
-  let index = index + skip + 1
-
-  case drop(list, skip) {
-    [] -> reservoir
-    [first, ..rest] -> {
-      let reservoir = dict.insert(reservoir, int.random(k), first)
-      let w = w *. float.exponential(log_random() /. int.to_float(k))
-      sample_loop(rest, reservoir, k, index, w)
-    }
-  }
-}
-
-fn log_random() -> Float {
-  let min_positive = 2.2250738585072014e-308
-  let assert Ok(random) = float.logarithm(float.random() +. min_positive)
-  random
 }

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -2313,23 +2313,22 @@ fn max_loop(list, compare, max) {
 /// // -> [2, 4, 5]  // A random sample of 3 items
 /// ```
 ///
-pub fn sample(list: List(a), k: Int) -> List(a) {
-  case k <= 0 {
+pub fn sample(from list: List(a), up_to n: Int) -> List(a) {
+  case n <= 0 {
     True -> []
     False -> {
-      let #(reservoir, list) = split(list, k)
+      let #(reservoir, list) = split(list, n)
 
-      case length(reservoir) < k {
+      case length(reservoir) < n {
         True -> reservoir
         False -> {
           let reservoir =
             reservoir
-            |> map2(range(0, k - 1), _, fn(a, b) { #(a, b) })
+            |> map2(range(0, n - 1), _, fn(a, b) { #(a, b) })
             |> dict.from_list
 
-          let w = float.exponential(log_random() /. int.to_float(k))
-
-          sample_loop(list, reservoir, k, k, w) |> dict.values
+          let w = float.exponential(log_random() /. int.to_float(n))
+          sample_loop(list, reservoir, n, n, w) |> dict.values
         }
       }
     }

--- a/test/gleam/list_test.gleam
+++ b/test/gleam/list_test.gleam
@@ -970,36 +970,34 @@ pub fn max_test() {
 
 pub fn sample_test() {
   assert list.sample([], 3) == []
-
   assert list.sample([1, 2, 3], 0) == []
-
   assert list.sample([1, 2, 3], -1) == []
-
-  assert [1, 2]
-    |> list.sample(5)
-    |> list.sort(int.compare)
-    == [1, 2]
-
+  assert list.sort(list.sample([1, 2], 5), int.compare) == [1, 2]
   assert list.sample([1], 1) == [1]
 
-  let input = list.range(1, 100)
-  let sample = list.sample(input, 10)
-  assert list.length(sample) == 10
+  assert 10
+    == list.range(1, 100)
+    |> list.sample(10)
+    |> list.unique
+    |> list.length
 
-  let repeated = [1, 1, 1, 1, 1]
-  let sample = list.sample(repeated, 3)
-  assert list.all(sample, fn(x) { x == 1 })
+  assert [1, 1, 1, 1, 1]
+    |> list.sample(3)
+    |> list.all(fn(x) { x == 1 })
 
-  let input = list.range(1, 1000)
-  let sample = list.sample(input, 100)
+  // Some tests on a bigger sample.
+  let sample =
+    list.range(1, 1000)
+    |> list.sample(100)
+
   assert sample
     |> list.sort(int.compare)
     |> list.all(fn(x) { x >= 1 && x <= 1000 })
 
-  assert list.length(sample) == 100
+  assert 100 == list.length(list.unique(sample))
 
-  let min = list.fold(sample, 1000, int.min)
-  let max = list.fold(sample, 1, int.max)
+  let assert Ok(min) = list.reduce(sample, int.min)
+  let assert Ok(max) = list.reduce(sample, int.max)
   assert min >= 1
   assert max <= 1000
 }


### PR DESCRIPTION
A couple of improvements here:
- I've changed the `sample` labels to be consistent with similar stuff like `take` and `drop`, this should also make it easier to see that it might not always return `n` elements
- I've added a link to the algorithm L documentation
- The reservoir building is more efficient as it's no longer using `list.range` and `list.map2`, but building it in one go
- There was a bug in the sampling algorithm where it could end up taking the same item twice from the list so I've updated it and made the tests more specific