### PR TITLE
Improve performance of `string.repeat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- The performance of the `string.repeat` function has been improved. It now runs
+  in loglinear time.
+
 ## v0.62.1 - 2025-08-07
 
 - `string.inspect` now shows Erlang atoms as `atom.create("value")`, to match

--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -1,6 +1,7 @@
 //// Strings in Gleam are UTF-8 binaries. They can be written in your code as
 //// text surrounded by `"double quotes"`.
 
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/order
@@ -406,7 +407,7 @@ fn concat_loop(strings: List(String), accumulator: String) -> String {
 
 /// Creates a new `String` by repeating a `String` a given number of times.
 ///
-/// This function runs in linear time.
+/// This function runs in loglinear time.
 ///
 /// ## Examples
 ///
@@ -416,13 +417,28 @@ fn concat_loop(strings: List(String), accumulator: String) -> String {
 /// ```
 ///
 pub fn repeat(string: String, times times: Int) -> String {
-  repeat_loop(string, times, "")
+  repeat_loop(string, times, string, "")
 }
 
-fn repeat_loop(string: String, times: Int, acc: String) -> String {
+fn repeat_loop(
+  string: String,
+  times: Int,
+  current_acc: String,
+  acc: String,
+) -> String {
   case times <= 0 {
     True -> acc
-    False -> repeat_loop(string, times - 1, acc <> string)
+    False -> {
+      let acc = case int.bitwise_and(times, 1) {
+        1 -> acc <> current_acc
+        _ -> acc
+      }
+      let times = int.bitwise_shift_right(times, 1)
+      case times <= 0 {
+        True -> acc
+        False -> repeat_loop(string, times, acc, current_acc <> current_acc)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Improve performance of `string.repeat` by using a binary exponentiation algorithm to generate strings to concatenate, rather than growing the string a character at a time. O(n) -> O(log(n))

---

I was profiling some of my gleam code and noticed that `string.repeat` was the main slow down. I wrote this little bit of bench testing code:

```gleam
import gleam/list
import gleam/string
import gleam/time/timestamp

pub fn main() -> Nil {
  let repeats = [
    1,
    10,
    100,
    1000,
    10_000,
    100_000,
    1_000_000,
    10_000_000,
    100_000_000,
    1_000_000_000,
  ]

  list.each(repeats, fn(repeat) {
    let now = timestamp.system_time()
    let _ = string.repeat("a", repeat)
    echo timestamp.difference(now, timestamp.system_time())
  })
}
```

```sh
gleam run --target erlang
```

Erlang ran slow, but completed:

```
~/Desktop/profile_string_repeat> gleam run --target erlang
   Compiled in 0.01s
    Running profile_string_repeat.main
src/profile_string_repeat.gleam:22
Duration(0, 386084)
src/profile_string_repeat.gleam:22
Duration(0, 1292)
src/profile_string_repeat.gleam:22
Duration(0, 2083)
src/profile_string_repeat.gleam:22
Duration(0, 7750)
src/profile_string_repeat.gleam:22
Duration(0, 74166)
src/profile_string_repeat.gleam:22
Duration(0, 721458)
src/profile_string_repeat.gleam:22
Duration(0, 6508209)
src/profile_string_repeat.gleam:22
Duration(0, 67825042)
src/profile_string_repeat.gleam:22
Duration(0, 707198959)
src/profile_string_repeat.gleam:22
Duration(7, 211958583)
```

```sh
gleam run --target javascript
```

JavaScript ran slow, and crashed with a heap limit allocation failure:

```
~/Desktop/profile_string_repeat> gleam run --target javascript
   Compiled in 0.01s
    Running profile_string_repeat.main
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 1000000)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 3000000)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 34000000)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 444000000)
src/profile_string_repeat.gleam:22
Duration(seconds: 5, nanoseconds: 179000000)

<--- Last few GCs --->

[33284:0x148008000]    21760 ms: Mark-sweep 4043.7 (4129.6) -> 4043.7 (4129.6) MB, 2417.0 / 0.0 ms  (average mu = 0.154, current mu = 0.026) allocation failure; scavenge might not succeed
[33284:0x148008000]    24814 ms: Mark-sweep 4059.4 (4129.6) -> 4059.4 (4161.6) MB, 3052.4 / 0.0 ms  (average mu = 0.065, current mu = 0.000) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0x102ad91dc node::Abort() [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 2: 0x102ad93d8 node::ModifyCodeGenerationFromStrings(v8::Local<v8::Context>, v8::Local<v8::Value>, bool) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 3: 0x102c0d74c v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 4: 0x102c0d6fc v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 5: 0x102d6fe8c v8::internal::EmbedderStackStateScope::EmbedderStackStateScope(v8::internal::Heap*, v8::internal::EmbedderStackStateScope::Origin, cppgc::EmbedderStackState) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 6: 0x102d6ec24 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 7: 0x102d665e8 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 8: 0x102d66de4 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
 9: 0x102d51a40 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
10: 0x10300b7e8 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
11: 0x1032a110c Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_NoBuiltinExit [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
12: 0x1032a2148 Builtins_StringAdd_CheckNone [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
13: 0x109bab360
14: 0x109b67f4c
15: 0x10322c198 Builtins_InterpreterEntryTrampoline [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
16: 0x10322c198 Builtins_InterpreterEntryTrampoline [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
17: 0x10322c198 Builtins_InterpreterEntryTrampoline [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
18: 0x10322c198 Builtins_InterpreterEntryTrampoline [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
19: 0x1032600d0 Builtins_GeneratorPrototypeNext [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
20: 0x10322a4d0 Builtins_JSEntryTrampoline [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
21: 0x10322a164 Builtins_JSEntry [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
22: 0x102d0f0f4 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
23: 0x102d0f500 v8::internal::(anonymous namespace)::InvokeWithTryCatch(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
24: 0x102d0f61c v8::internal::Execution::TryCall(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*, v8::internal::Execution::MessageHandling, v8::internal::MaybeHandle<v8::internal::Object>*, bool) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
25: 0x102f6d4c4 v8::internal::SourceTextModule::ExecuteModule(v8::internal::Isolate*, v8::internal::Handle<v8::internal::SourceTextModule>) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
26: 0x102f6ccec v8::internal::SourceTextModule::InnerModuleEvaluation(v8::internal::Isolate*, v8::internal::Handle<v8::internal::SourceTextModule>, v8::internal::ZoneForwardList<v8::internal::Handle<v8::internal::SourceTextModule>>*, unsigned int*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
27: 0x102f6c77c v8::internal::SourceTextModule::Evaluate(v8::internal::Isolate*, v8::internal::Handle<v8::internal::SourceTextModule>) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
28: 0x102f33cd8 v8::internal::Module::Evaluate(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Module>) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
29: 0x102c14f58 v8::Module::Evaluate(v8::Local<v8::Context>) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
30: 0x102aa4fdc node::loader::ModuleWrap::Evaluate(v8::FunctionCallbackInfo<v8::Value> const&) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
31: 0x102c65e08 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
32: 0x102c659b4 v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
33: 0x102c65270 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
34: 0x1032a124c Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
35: 0x10322c198 Builtins_InterpreterEntryTrampoline [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
36: 0x10325def4 Builtins_AsyncFunctionAwaitResolveClosure [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
37: 0x1032ec838 Builtins_PromiseFulfillReactionJob [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
38: 0x10324fc4c Builtins_RunMicrotasks [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
39: 0x10322a3a4 Builtins_JSRunMicrotasksEntry [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
40: 0x102d0f0c4 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
41: 0x102d0f500 v8::internal::(anonymous namespace)::InvokeWithTryCatch(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
42: 0x102d0f674 v8::internal::Execution::TryRunMicrotasks(v8::internal::Isolate*, v8::internal::MicrotaskQueue*, v8::internal::MaybeHandle<v8::internal::Object>*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
43: 0x102d2e53c v8::internal::MicrotaskQueue::RunMicrotasks(v8::internal::Isolate*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
44: 0x102d2e3c0 v8::internal::MicrotaskQueue::PerformCheckpointInternal(v8::Isolate*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
45: 0x102a34a50 node::InternalCallbackScope::Close() [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
46: 0x102a346c4 node::InternalCallbackScope::~InternalCallbackScope() [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
47: 0x102adc588 node::fs::FileHandle::CloseReq::Resolve() [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
48: 0x102af0de0 node::fs::FileHandle::ClosePromise()::$_0::__invoke(uv_fs_s*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
49: 0x102ad5ee4 node::MakeLibuvRequestCallback<uv_fs_s, void (*)(uv_fs_s*)>::Wrapper(uv_fs_s*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
50: 0x104e72e0c uv__work_done [/opt/homebrew/Cellar/libuv/1.51.0/lib/libuv.1.dylib]
51: 0x104e766bc uv__async_io [/opt/homebrew/Cellar/libuv/1.51.0/lib/libuv.1.dylib]
52: 0x104e86bd0 uv__io_poll [/opt/homebrew/Cellar/libuv/1.51.0/lib/libuv.1.dylib]
53: 0x104e76b58 uv_run [/opt/homebrew/Cellar/libuv/1.51.0/lib/libuv.1.dylib]
54: 0x102a35518 node::SpinEventLoop(node::Environment*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
55: 0x102b10dbc node::NodeMainInstance::Run(int*, node::Environment*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
56: 0x102b10ac8 node::NodeMainInstance::Run() [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
57: 0x102aaa73c node::LoadSnapshotDataAndRun(node::SnapshotData const**, node::InitializationResult const*) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
58: 0x102aaa908 node::Start(int, char**) [/opt/homebrew/Cellar/node@18/18.20.8/bin/node]
59: 0x194c92b98 start [/usr/lib/dyld]
```

I checked out the source code and noticed it performed character-by-character concatenation to build the final string of repeated characters:

```gleam
pub fn repeat(string: String, times times: Int) -> String {
  repeat_loop(string, times, "")
}

fn repeat_loop(string: String, times: Int, acc: String) -> String {
  case times <= 0 {
    True -> acc
    False -> repeat_loop(string, times - 1, acc <> string)
  }
}
```

After the code swap

Erlang:

```
~/Desktop/profile_string_repeat> gleam run --target erlang
   Compiled in 0.01s
    Running profile_string_repeat.main
src/profile_string_repeat.gleam:22
Duration(0, 2125)
src/profile_string_repeat.gleam:22
Duration(0, 2208)
src/profile_string_repeat.gleam:22
Duration(0, 2000)
src/profile_string_repeat.gleam:22
Duration(0, 1458)
src/profile_string_repeat.gleam:22
Duration(0, 7333)
src/profile_string_repeat.gleam:22
Duration(0, 1417)
src/profile_string_repeat.gleam:22
Duration(0, 7125)
src/profile_string_repeat.gleam:22
Duration(0, 6708)
src/profile_string_repeat.gleam:22
Duration(0, 97250)
src/profile_string_repeat.gleam:22
Duration(0, 117291)
```

JavaScript:

```
~/Desktop/profile_string_repeat> gleam run --target javascript
  Compiling profile_string_repeat
   Compiled in 0.01s
    Running profile_string_repeat.main
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 1000000)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
src/profile_string_repeat.gleam:22
Duration(seconds: 0, nanoseconds: 0)
```