### PR TITLE
add option.flat_map

### DIFF
--- a/src/gleam/option.gleam
+++ b/src/gleam/option.gleam
@@ -208,6 +208,33 @@ pub fn map(over option: Option(a), with fun: fn(a) -> b) -> Option(b) {
   }
 }
 
+/// Transforms a value inside an Option by applying a function that itself returns an Option,
+/// then flattens the nested result into a single Option.
+///
+/// ## Examples
+///
+/// ```gleam
+/// flat_map(Some(1), fn(x) { Some(x + 1) })
+/// // -> Some(2)
+/// ```
+///
+/// ```gleam
+/// flat_map(Some(1), fn(x) { None })
+/// // -> None
+/// ```
+///
+/// ```gleam
+/// flat_map(None, fn(x) { Some(x + 1) })
+/// // -> None
+/// ```
+///
+pub fn flat_map(
+  over option: Option(a),
+  with fun: fn(a) -> Option(b),
+) -> Option(b) {
+  flatten(map(option, fun))
+}
+
 /// Merges a nested `Option` into a single layer.
 ///
 /// ## Examples

--- a/test/gleam/option_test.gleam
+++ b/test/gleam/option_test.gleam
@@ -91,3 +91,11 @@ pub fn lazy_or_option_test() {
 pub fn values_test() {
   assert option.values([Some(1), None, Some(3)]) == [1, 3]
 }
+
+pub fn flat_map_test() {
+  assert option.flat_map(Some(1), fn(x) { Some(x + 1) }) == Some(2)
+
+  assert option.flat_map(Some(1), fn(_) { None }) == None
+
+  assert option.flat_map(None, fn(x) { Some(x + 1) }) == None
+}


### PR DESCRIPTION
Hello! I noticed that `list` had a `flat_map`, but not `option`, so I added one.