### PR TITLE
Update dynamic.classify example to use string instead of from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 - The performance of the `string.repeat` function has been improved. It now runs
   in loglinear time.
-
+- Updated documentation for `dynamic.classify` to reflect the removal of the
+  `dynamic.from` function.
+ 
 ## v0.62.1 - 2025-08-07
 
 - `string.inspect` now shows Erlang atoms as `atom.create("value")`, to match

--- a/src/gleam/dynamic.gleam
+++ b/src/gleam/dynamic.gleam
@@ -21,7 +21,7 @@ pub type Dynamic
 /// `gleam/dynamic/decode` module.
 ///
 /// ```gleam
-/// classify(from("Hello"))
+/// classify(string("Hello"))
 /// // -> "String"
 /// ```
 ///


### PR DESCRIPTION
The docstring for `dynamic.classify` has the example:

```gleam
classify(from("Hello"))
// -> "String"
```

which uses the old `from` function which has been removed. I have replaced it so it now has the example:

```gleam
classify(string("Hello"))
// -> "String"
```
