### PR TITLE
Improve performance of `string.drop_start`

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -232,13 +232,9 @@ pub fn crop(from string: String, before substring: String) -> String
 /// ```
 ///
 pub fn drop_start(from string: String, up_to num_graphemes: Int) -> String {
-  case num_graphemes > 0 {
-    False -> string
-    True ->
-      case pop_grapheme(string) {
-        Ok(#(_, string)) -> drop_start(string, num_graphemes - 1)
-        Error(Nil) -> string
-      }
+  case num_graphemes <= 0 {
+    True -> string
+    False -> slice(string, num_graphemes, length(string))
   }
 }
 


### PR DESCRIPTION
The proposed implementation takes the same form as the current `string.drop_end` implementation:

`string.drop_start`

```gleam
pub fn drop_start(from string: String, up_to num_graphemes: Int) -> String {
  case num_graphemes <= 0 {
    True -> string
    False -> slice(string, num_graphemes, length(string))
  }
}
```

`string.drop_end`

```gleam
pub fn drop_end(from string: String, up_to num_graphemes: Int) -> String {
  case num_graphemes < 0 {
    True -> string
    False -> slice(string, 0, length(string) - num_graphemes)
  }
}
```

Configuring and running `glychee` to test the Erlang target:

```gleam
import gleam/string
import glychee/benchmark
import glychee/configuration

pub fn main() {
  configuration.initialize()
  configuration.set_pair(configuration.Warmup, 2)

  let small = 100
  let medium = 100_000
  let large = 100_000_000

  benchmark.run(
    [
      benchmark.Function(label: "string.drop_start", callable: fn(test_data) {
        let #(text, drop_count) = test_data
        fn() { string.drop_start(text, drop_count) }
      }),
      benchmark.Function(label: "custom_drop_start", callable: fn(test_data) {
        let #(text, drop_count) = test_data
        fn() { custom_drop_start(text, drop_count) }
      }),
    ],
    [
      benchmark.Data(label: "small", data: #(
        string.repeat("a", small),
        small - 1,
      )),
      benchmark.Data(label: "medium", data: #(
        string.repeat("a", medium),
        medium - 1,
      )),
      benchmark.Data(label: "large", data: #(
        string.repeat("a", large),
        large - 1,
      )),
    ],
  )
}

pub fn custom_drop_start(
  from string: String,
  up_to num_graphemes: Int,
) -> String {
  case num_graphemes <= 0 {
    True -> string
    False -> string.slice(string, num_graphemes, string.length(string))
  }
}
```

```md
================================================================================
==== data set: small
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Apple M3 Max
Number of Available Cores: 16
Available memory: 64 GB
Elixir 1.18.4
Erlang 28.0.2
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 4 s
memory time: 8 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 36 s

Benchmarking custom_drop_start ...
Benchmarking string.drop_start ...
Calculating statistics...
Formatting results...

Name                        ips        average  deviation         median         99th %
custom_drop_start        2.01 M        0.50 μs  ±3598.04%        0.46 μs        0.58 μs
string.drop_start        0.28 M        3.54 μs   ±248.19%        3.33 μs        6.42 μs

Comparison:
custom_drop_start        2.01 M
string.drop_start        0.28 M - 7.13x slower +3.04 μs

Memory usage statistics:

Name                 Memory usage
custom_drop_start         0.52 KB
string.drop_start        18.54 KB - 35.95x memory usage +18.02 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name              Reduction count
custom_drop_start             156
string.drop_start             904 - 5.79x reduction count +748

**All measurements for reduction count were the same**


================================================================================
==== data set: medium
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Apple M3 Max
Number of Available Cores: 16
Available memory: 64 GB
Elixir 1.18.4
Erlang 28.0.2
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 4 s
memory time: 8 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 36 s

Benchmarking custom_drop_start ...
Benchmarking string.drop_start ...
Calculating statistics...
Formatting results...

Name                        ips        average  deviation         median         99th %
custom_drop_start        3.27 K        0.31 ms    ±19.02%        0.30 ms        0.33 ms
string.drop_start        0.30 K        3.32 ms     ±5.59%        3.25 ms        3.97 ms

Comparison:
custom_drop_start        3.27 K
string.drop_start        0.30 K - 10.85x slower +3.01 ms

Memory usage statistics:

Name                 Memory usage
custom_drop_start      0.00050 MB
string.drop_start        17.55 MB - 34849.59x memory usage +17.55 MB

**All measurements for memory usage were the same**

Reduction count statistics:

Name              Reduction count
custom_drop_start        112.55 K
string.drop_start        911.15 K - 8.10x reduction count +798.60 K

**All measurements for reduction count were the same**


================================================================================
==== data set: large
================================================================================

Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS
CPU Information: Apple M3 Max
Number of Available Cores: 16
Available memory: 64 GB
Elixir 1.18.4
Erlang 28.0.2
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 4 s
memory time: 8 s
reduction time: 4 s
parallel: 1
inputs: none specified
Estimated total run time: 36 s

Benchmarking custom_drop_start ...
Benchmarking string.drop_start ...
Calculating statistics...
Formatting results...

Name                        ips        average  deviation         median         99th %
custom_drop_start          2.99         0.33 s    ±14.40%         0.30 s         0.42 s
string.drop_start         0.167         5.98 s     ±0.00%         5.98 s         5.98 s

Comparison:
custom_drop_start          2.99
string.drop_start         0.167 - 17.90x slower +5.65 s

Memory usage statistics:

Name                 Memory usage
custom_drop_start      0.00000 GB
string.drop_start        17.14 GB - 34848485.95x memory usage +17.14 GB

**All measurements for memory usage were the same**

Reduction count statistics:

Name              Reduction count
custom_drop_start        112.50 M
string.drop_start        911.16 M - 8.10x reduction count +798.66 M

**All measurements for reduction count were the same**
```

Configuring and running `mitata` to test the JavaScript target:

*Note, I had to scale the values down, as the larger numbers kept crashing on JavaScript testing*

```js
import { bench, run, group } from "mitata";
import { drop_start as stdlib_drop_start } from "./build/dev/javascript/gleam_stdlib/gleam/string.mjs";
import { custom_drop_start } from "./build/dev/javascript/bench/bench.mjs";

const small = 100;
const medium = 1_000;
const large = 10_000;

const smallData = {
  text: "a".repeat(small),
  dropCount: small - 1,
};

const mediumData = {
  text: "a".repeat(medium),
  dropCount: medium - 1,
};

const largeData = {
  text: "a".repeat(large),
  dropCount: large - 1,
};

group("small", () => {
  bench("string.drop_start", () => {
    stdlib_drop_start(smallData.text, smallData.dropCount);
  });

  bench("custom_drop_start", () => {
    custom_drop_start(smallData.text, smallData.dropCount);
  });
});

group("medium", () => {
  bench("string.drop_start", () => {
    stdlib_drop_start(mediumData.text, mediumData.dropCount);
  });

  bench("custom_drop_start", () => {
    custom_drop_start(mediumData.text, mediumData.dropCount);
  });
});

group("large", () => {
  bench("string.drop_start", () => {
    stdlib_drop_start(largeData.text, largeData.dropCount);
  });

  bench("custom_drop_start", () => {
    custom_drop_start(largeData.text, largeData.dropCount);
  });
});

await run({
  warmup: 2,
});
```

```md
clk: ~3.94 GHz
cpu: Apple M3 Max
runtime: node 24.6.0 (arm64-darwin)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• small
------------------------------------------- -------------------------------
string.drop_start            157.65 µs/iter 109.38 µs         ▆█▅▃
                      (77.17 µs … 21.75 ms) 134.58 µs        █████▄
                    (424.00  b … 442.09 kb)  53.25 kb ▁▄▆▆██████████▇▅▃▃▂▂▁

custom_drop_start             11.31 µs/iter  11.30 µs  ██   █
                      (11.11 µs … 11.78 µs)  11.77 µs ▅██▅▅ █             ▅
                    (  1.61 kb …   5.61 kb)   1.97 kb █████▁█▁▁▁▁▁▁▁▁▁▁▁▁▁█

• medium
------------------------------------------- -------------------------------
string.drop_start              1.70 ms/iter   1.43 ms              ▃▄█
                       (1.07 ms … 53.72 ms)   1.53 ms    ▃        ▅███▅▃
                    (523.23 kb … 529.44 kb) 523.26 kb ▁▅▅█▇▄▂▁▁▂▂▃███████▂▃

custom_drop_start             82.81 µs/iter  81.38 µs     █
                     (74.71 µs … 450.58 µs) 101.13 µs     █
                    ( 36.71 kb … 460.70 kb) 172.96 kb ▁▁▁▁██▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁

• large
------------------------------------------- -------------------------------
string.drop_start             41.95 ms/iter  42.15 ms   ██       █
                      (41.62 ms … 42.36 ms)  42.36 ms ▅ ██▅    ▅ █  ▅  ▅  ▅
                    (  5.11 mb …   5.11 mb)   5.11 mb █▁███▁▁▁▁█▁█▁▁█▁▁█▁▁█

custom_drop_start            802.32 µs/iter 803.33 µs   █
                    (778.96 µs … 951.42 µs) 918.08 µs  ██▆
                    (  1.68 mb …   1.68 mb)   1.68 mb ▄████▄▃▂▁▁▁▁▁▁▂▂▂▂▁▁▁
```