### PR TITLE
Fix `string.drop_end` to handle zero gracefully

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -248,7 +248,7 @@ pub fn drop_start(from string: String, up_to num_graphemes: Int) -> String {
 /// ```
 ///
 pub fn drop_end(from string: String, up_to num_graphemes: Int) -> String {
-  case num_graphemes < 0 {
+  case num_graphemes <= 0 {
     True -> string
     False -> slice(string, 0, length(string) - num_graphemes)
   }

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -356,6 +356,8 @@ pub fn drop_start_test() {
   assert string.drop_start("gleam", up_to: 6) == ""
 
   assert string.drop_start("gleam", up_to: -2) == "gleam"
+
+  assert string.drop_start("gleam", up_to: 0) == "gleam"
 }
 
 pub fn drop_start_3499_test() {
@@ -369,6 +371,8 @@ pub fn drop_end_test() {
   assert string.drop_end("gleam", up_to: 5) == ""
 
   assert string.drop_end("gleam", up_to: -2) == "gleam"
+
+  assert string.drop_end("gleam", up_to: 0) == "gleam"
 }
 
 pub fn pad_start_test() {


### PR DESCRIPTION
Avoid calling `string.slice` when `num_graphemes` is equal to `0`, making `string.drop_end` constant for that case.
Nothing was broken before, but I added tests because I like testing right on the boundary.
Seems like too tiny of a change to mention in the `CHANGELOG.md`, so I skipped it.