### PR TITLE
Adds base32 encode/decode support

### DIFF
--- a/src/gleam/bit_array.gleam
+++ b/src/gleam/bit_array.gleam
@@ -153,6 +153,29 @@ pub fn base64_url_decode(encoded: String) -> Result(BitArray, Nil) {
   |> base64_decode()
 }
 
+/// Encodes a `BitArray` into a base 32 encoded string.
+///
+/// If the bit array does not contain a whole number of bytes then it is padded
+/// with zero bits prior to being encoded.
+///
+@external(erlang, "gleam_stdlib", "base_encode32")
+@external(javascript, "../gleam_stdlib.mjs", "encode32")
+pub fn base32_encode(input: BitArray, padding: Bool) -> String
+
+/// Decodes a base 32 encoded string into a `BitArray`.
+///
+pub fn base32_decode(encoded: String) -> Result(BitArray, Nil) {
+  let padded = case byte_size(from_string(encoded)) % 8 {
+    0 -> encoded
+    n -> string.append(encoded, string.repeat("=", 8 - n))
+  }
+  decode32(padded)
+}
+
+@external(erlang, "gleam_stdlib", "base_decode32")
+@external(javascript, "../gleam_stdlib.mjs", "decode32")
+fn decode32(a: String) -> Result(BitArray, Nil)
+
 /// Encodes a `BitArray` into a base 16 encoded string.
 ///
 /// If the bit array does not contain a whole number of bytes then it is padded

--- a/test/gleam/bit_array_test.gleam
+++ b/test/gleam/bit_array_test.gleam
@@ -212,6 +212,72 @@ pub fn decode64_crash_regression_1_test() {
     == Error(Nil)
 }
 
+pub fn base32_encode_test() {
+  assert bit_array.base32_encode(<<>>, True) == ""
+
+  assert bit_array.base32_encode(<<"f":utf8>>, True) == "MY======"
+
+  assert bit_array.base32_encode(<<"fo":utf8>>, True) == "MZXQ===="
+
+  assert bit_array.base32_encode(<<"foo":utf8>>, True) == "MZXW6==="
+
+  assert bit_array.base32_encode(<<"foob":utf8>>, True) == "MZXW6YQ="
+
+  assert bit_array.base32_encode(<<"fooba":utf8>>, True) == "MZXW6YTB"
+
+  assert bit_array.base32_encode(<<"foobar":utf8>>, True) == "MZXW6YTBOI======"
+
+  assert bit_array.base32_encode(<<"f":utf8>>, False) == "MY"
+
+  assert bit_array.base32_encode(<<"fo":utf8>>, False) == "MZXQ"
+
+  assert bit_array.base32_encode(<<"foo":utf8>>, False) == "MZXW6"
+
+  assert bit_array.base32_encode(<<"foob":utf8>>, False) == "MZXW6YQ"
+
+  assert bit_array.base32_encode(<<"fooba":utf8>>, False) == "MZXW6YTB"
+
+  assert bit_array.base32_encode(<<"foobar":utf8>>, False) == "MZXW6YTBOI"
+
+  assert bit_array.base32_encode(<<-1:7>>, True) == "7Y======"
+
+  assert bit_array.base32_encode(<<-1:7>>, False) == "7Y"
+}
+
+pub fn base32_decode_test() {
+  assert bit_array.base32_decode("") == Ok(<<>>)
+
+  assert bit_array.base32_decode("MY======") == Ok(<<"f":utf8>>)
+
+  assert bit_array.base32_decode("MZXQ====") == Ok(<<"fo":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6===") == Ok(<<"foo":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6YQ=") == Ok(<<"foob":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6YTB") == Ok(<<"fooba":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6YTBOI======") == Ok(<<"foobar":utf8>>)
+
+  assert bit_array.base32_decode("MY") == Ok(<<"f":utf8>>)
+
+  assert bit_array.base32_decode("MZXQ") == Ok(<<"fo":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6") == Ok(<<"foo":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6YQ") == Ok(<<"foob":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6YTB") == Ok(<<"fooba":utf8>>)
+
+  assert bit_array.base32_decode("MZXW6YTBOI") == Ok(<<"foobar":utf8>>)
+
+  assert bit_array.base32_decode("mzxw6ytboi======") == Ok(<<"foobar":utf8>>)
+
+  assert bit_array.base32_decode("!)") == Error(Nil)
+
+  assert bit_array.base32_decode("=AAAAAAA") == Error(Nil)
+}
+
 pub fn base16_encode_test() {
   assert bit_array.base16_encode(<<"":utf8>>) == ""
 


### PR DESCRIPTION
# Issue
#863 

## Summary
Add base32 encode/decode to `gleam/bit_array` to complement existing base16/base64 (RFC 4648).

 Works on Erlang and JavaScript targets.

## Changes
### Public API
* `base32_encode(input: BitArray, padding: Bool) -> String`
* `base32_decode(encoded: String) -> Result(BitArray, Nil)`

### FFI
Erlang: `base_encode32/2`, `base_decode32/1`
JavaScript: `encode32(bit_array, padding)`, `decode32(s)`

## Tests
`base32_encode_test` and `base32_decode_test` (RFC 4648 vectors, partial-bit, lowercase acceptance, invalid inputs)

## Behavior
* **Alphabet**: A–Z, 2–7 (RFC 4648)
* **Encoding**: optional `=` padding; pads bit arrays to full bytes
* **Decoding**: accepts upper/lowercase and missing padding; rejects invalid chars and interior `=`

## Notes
* No breaking changes; naming aligns with existing base encoders.
* All tests pass on Erlang and JavaScript (Deno) targets.

## Additional Notes
* This is my first significant Gleam contribution, please feel free to provide feedback and let me know about any issues.