### PR TITLE
feat: add index_fold examples

### DIFF
--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -785,7 +785,9 @@ pub fn fold_right(
 ///
 /// ```gleam
 /// ["a", "b", "c"]
-/// |> index_fold("", fn(acc, item, index) { acc <> int.to_string(index) <> ":" <> item <> " " })
+/// |> index_fold("", fn(acc, item, index) {
+///      acc <> int.to_string(index) <> ":" <> item <> " "
+/// })
 /// // -> 0:a 1:b 2:c
 /// ```
 ///


### PR DESCRIPTION
Hey : ) Looking through the **list** module [docs](https://hexdocs.pm/gleam_stdlib/gleam/list.html#index_fold) yesterday I noticed that `index_fold` had a pretty vague example (the `{...}` placeholder). The function signature is clear, and probably enough for a lot of people, but it kinda lacks information about why, **in practice**, we would want to use the **index** parameter.

This adds 2 small examples (with lists of two different data types: strings and integers) that should be intuitive enough to understand the use case of `index_fold`. 