### PR TITLE
Fix inconsistent `query_to_string` with `+`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.66.0 - 2025-10-21
 
 - The `tap` function from the `function` module has been deprecated.
+- `uri.query_to_string` now correctly handles `+` in query params.
 
 ## v0.65.0 - 2025-09-29
 

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -556,7 +556,13 @@ pub fn query_to_string(query: List(#(String, String))) -> String {
 }
 
 fn query_pair(pair: #(String, String)) -> StringTree {
-  string_tree.from_strings([percent_encode(pair.0), "=", percent_encode(pair.1)])
+  [percent_encode_query(pair.0), "=", percent_encode_query(pair.1)]
+  |> string_tree.from_strings
+}
+
+fn percent_encode_query(part: String) -> String {
+  percent_encode(part)
+  |> string.replace(each: "+", with: "%2B")
 }
 
 /// Encodes a string into a percent encoded representation.

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -413,6 +413,12 @@ pub fn query_to_string_test() {
   assert query_string == "weebl%20bob=1&city=%C3%B6rebro"
 }
 
+pub fn query_to_string_special_characters_test() {
+  let query_string =
+    uri.query_to_string([#("weebl bob", "1+1-1*1.1~1!1'1(1);%")])
+  assert query_string == "weebl%20bob=1%2B1-1*1.1~1!1'1(1)%3B%25"
+}
+
 pub fn empty_query_to_string_test() {
   let query_string = uri.query_to_string([])
   assert query_string == ""
@@ -555,6 +561,13 @@ pub fn parse_segments_test() {
   assert uri.path_segments("/../bob") == ["bob"]
   assert uri.path_segments("../bob") == ["bob"]
   assert uri.path_segments("/weebl/../bob") == ["bob"]
+}
+
+pub fn query_to_string_parse_query_opposite_unreserved_marks_test() {
+  let queries = [#("weebl bob", "1+1-1*1.1~1!1'1(1);%"), #("city", "örebro")]
+  let query_string = uri.query_to_string(queries)
+  let parsed = uri.parse_query(query_string)
+  assert parsed == Ok(queries)
 }
 
 pub fn origin1_test() {


### PR DESCRIPTION
Hi!

Currently, the documentation indicates in `uri.parse_query` "The opposite operation is `uri.query_to_string`."
In `uri.query_to_string`, we can read "The opposite operation is `uri.parse_query`.".

Unfortunately, when writing this

```gleam
pub fn main() {
  let queries = [#("example", "1 + 1")]
  let converted = uri.query_to_string(queries)
  let parsed = uri.parse_query(converted)
  assert parsed == Ok(queries)
}
```

The code fails. It fails because — from my understanding — while `+` is an allowed character in query strings in the form `%2B`, `uri.query_to_string` does not follows the URI query string convertion and instead replaces `%2B` with `+`. Indeed, outside of query strings, `+` has another meaning, and should not be converted. It makes sense to not convert it in `uri.percent_encode`, but it should be in `uri.query_to_string`. 

The above code, when changing `1 + 1` to `1 %2B 1` works. I think it's not the desired behaviour here, and it's confusing for developers. From my understanding, when manipulating query strings as keyed lists, the value associated with the key can be any string, including one with `+`. Using `uri.query_to_string` without the knowledge that `+` won't be perserved in percent encoding lead to hard to find bugs.

---

The proposition here is to properly encode the query strings, and to add a test case with the special characters, where some of them are "unreserved characters", like `~` for example.

I wanted to directly open the PR to talk about that with some code to illustrate, but anything can be changed or the PR can be closed if you estimate it's not desired in the standard library. 🙂 
In any case, I think it is important to find a way to communicate how to use URI correctly, as it can be confusing to understand when to use `percent_encode`, etc. when the framework/libraries you're using is not doing the hard work for you. I wanted to write some documentation but I couldn't find a proper place to do it. Do you have any recommandation on that topic?

---

For information, that bug surfaced when we had to handle `+` in query strings in our application, and currently we're just happily using `uri.query_to_string` before setting the query string in a `uri.Uri`. We could simply run the `string.replace(_, each: "+", with: "%2B")`, but I suspect others could end up with the same issue, and struggle to understand why it bugs, as `uri.query_to_string` is not the exact opposite function of `uri.parse_query`. 😄