### PR TITLE
Add implementation for string.casefold

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -126,6 +126,26 @@ pub fn lowercase(string: String) -> String
 @external(javascript, "../gleam_stdlib.mjs", "uppercase")
 pub fn uppercase(string: String) -> String
 
+/// Converts `String` to a case-agnostic comparable string.
+///
+/// Preferred over `lowercase` or `uppercase` for case-insensitive
+/// equality comparisons since Unicode case is also folded.
+///
+/// Note that this will produce different results on the
+/// Erlang and Javascript targets. To ensure consistent
+/// results across targets at a slight performance cost,
+/// call `lowercase` on the result of `casefold`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// casefold("Ω and ẞ SHARP S")
+/// // -> "ω and ss sharp s"
+/// ```
+@external(erlang, "string", "casefold")
+@external(javascript, "../gleam_stdlib.mjs", "casefold")
+pub fn casefold(string: String) -> String
+
 /// Compares two `String`s to see which is "larger" by comparing their graphemes.
 ///
 /// This does not compare the size or length of the given `String`s.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -169,6 +169,10 @@ export function uppercase(string) {
   return string.toUpperCase();
 }
 
+export function casefold(string) {
+  return string.toLowerCase().toUpperCase();
+}
+
 export function less_than(a, b) {
   return a < b;
 }


### PR DESCRIPTION
Adds an implementation of string.casefold for both Erlang and Javascript targets.

The Javascript implementation was inspired by
commonmark.js:

https://github.com/commonmark/commonmark.js/blob/7b4177d04ff7933419a7da098be048cb44f5aedf/lib/inlines.js#L101