### PR TITLE
Fast and Lean JavaScript Dictionaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.erlang_version }}
-          gleam-version: "1.11.0"
+          gleam-version: "1.13.0"
       - run: gleam test --target erlang
       - run: gleam format --check src test
 
@@ -44,7 +44,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
-          gleam-version: "1.11.0"
+          gleam-version: "1.13.0"
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
@@ -62,7 +62,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
-          gleam-version: "1.11.0"
+          gleam-version: "1.13.0"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ matrix.bun_version }}
@@ -80,7 +80,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
-          gleam-version: "1.11.0"
+          gleam-version: "1.13.0"
       - uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno_version }}

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "gleam_stdlib"
 version = "0.67.1"
-gleam = ">= 1.11.0"
+gleam = ">= 1.13.0"
 licences = ["Apache-2.0"]
 description = "A standard library for the Gleam programming language"
 

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -376,14 +376,6 @@ function nextGeneration(dict) {
   return 1;
 }
 
-/*
- * Like `get`, but for transient values. Note that this function is not pure!
- */
-export function query(transient, key) {
-  const result = lookup(transient.root, key);
-  return result !== noElementMarker ? Result$Ok(result) : errorNil;
-}
-
 /**
  * Consume a transient, writing a new key/value pair into the dictionary it
  * represents. If the key already exists, it will be overwritten.
@@ -409,6 +401,12 @@ export function upsert(dict, key, fun) {
   const wrapped = (value) => fun(value === noElementMarker ? Option$None() : Option$Some(value));
   transient.root = doUpsert(transient, transient.root, key, wrapped, getHash(key), 0);
   return fromTransient(transient);
+}
+
+export function update_with(key, fun, init, transient) {
+  const wrapped = (value) => (value === noElementMarker ? init : fun(value));
+  transient.root = doUpsert(transient, transient.root, key, wrapped, getHash(key), 0);
+  return transient;
 }
 
 export function map(dict, fun) {

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -418,11 +418,11 @@ function doPut(transient, node, key, value, hash, shift) {
   }
 
   const bit = hashbit(hash, shift);
-  const nodeidx = data.length - 1 - index(nodemap, bit);
 
   // 2. Child Node
   // We have to check first if there is already a child node we have to traverse to.
   if ((nodemap & bit) !== 0) {
+    const nodeidx = data.length - 1 - index(nodemap, bit);
     const child = data[nodeidx];
     data[nodeidx] = doPut(transient, child, key, value, hash, shift + bits);
     return node;
@@ -472,6 +472,8 @@ function doPut(transient, node, key, value, hash, shift) {
   // When calculating the nodeidx, we measure with the length including those
   // 2 extra elements, but missing the one we haven't inserted yet, so we have
   // to correct for both of these with (1-2) = -1
+
+  const nodeidx = data.length - 1 - index(nodemap, bit);
 
   data.splice(dataidx, 2);
   data.splice(nodeidx - 1, 0, child);

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -301,7 +301,7 @@ export function make() {
 export function from(iterable) {
   let transient = toTransient(emptyDict);
   for (const [key, value] of iterable) {
-    transient = transientInsert(key, value, transient);
+    transient = destructiveTransientInsert(key, value, transient);
   }
   return fromTransient(transient);
 }
@@ -448,7 +448,7 @@ export function insert(dict, key, value) {
  *
  * Returns a new transient.
  */
-export function transientInsert(key, value, transient) {
+export function destructiveTransientInsert(key, value, transient) {
   const hash = getHash(key);
   transient.root = doInsert(transient, transient.root, key, value, hash, 0);
   return transient;
@@ -460,7 +460,7 @@ export function transientInsert(key, value, transient) {
  *
  * Returns a new transient.
  */
-export function transientUpdateWith(key, fun, value, transient) {
+export function destructiveTransientUpdateWith(key, fun, value, transient) {
   const hash = getHash(key);
 
   const existing = lookup(transient.root, key, hash);
@@ -553,7 +553,7 @@ function doInsert(transient, node, key, value, hash, shift) {
  * Consume a transient, removing a key if it exists.
  * Returns a new transient.
  */
-export function transientDelete(key, transient) {
+export function destructiveTransientDelete(key, transient) {
   transient.root = doDelete(transient, transient.root, key, getHash(key), 0);
   return transient;
 }

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -283,7 +283,7 @@ function lookup(node, key) {
       // We still need to check if the key matches, but if it does we know for
       // sure that this is the correct value, and if it doesn't that we don't
       // contain the value in question.
-      const dataidx = 2 * index(datamap, bit);
+      const dataidx = Math.imul(index(datamap, bit), 2);
       return isEqual(key, data[dataidx]) ? data[dataidx + 1] : noElementMarker;
     } else if (nodemap & bit) {
       // we found our hash inside the nodemap, so we can continue our search there.
@@ -367,7 +367,7 @@ function nextGeneration(dict) {
     node.generation = 0;
 
     // queue all other referenced nodes
-    const nodeStart = 2 * popcount(node.datamap);
+    const nodeStart = Math.imul(popcount(node.datamap), 2);
     for (let i = nodeStart; i < node.data.length; ++i) {
       queue.push(node.data[i]);
     }
@@ -420,7 +420,7 @@ export function map(dict, fun) {
     // order doesn't matter, so we can use push/pop for faster array usage.
     const { data, datamap } = queue.pop();
     // every node contains popcount(datamap) direct entries
-    const edgesStart = 2 * popcount(datamap);
+    const edgesStart = Math.imul(popcount(datamap), 2);
     for (let i = 0; i < edgesStart; i += 2) {
       // we copied the node while queueing it, so direct mutation here is safe.
       data[i + 1] = fun(data[i], data[i + 1]);
@@ -443,7 +443,7 @@ export function fold(dict, state, fun) {
     // order doesn't matter, so we can use push/pop for faster array usage.
     const { data, datamap } = queue.pop();
     // every node contains popcount(datamap) direct entries
-    const edgesStart = 2 * popcount(datamap);
+    const edgesStart = Math.imul(popcount(datamap), 2);
     for (let i = 0; i < edgesStart; i += 2) {
       state = fun(state, data[i], data[i + 1]);
     }
@@ -476,7 +476,7 @@ function doUpsert(transient, node, key, fun, hash, shift) {
 
   const bit = hashbit(hash, shift);
   const nodeidx = data.length - 1 - index(nodemap, bit);
-  const dataidx = 2 * index(datamap, bit);
+  const dataidx = Math.imul(index(datamap, bit), 2);
 
   // 2. Child Node
   // We have to check first if there is already a child node we have to traverse to.
@@ -589,7 +589,7 @@ function always(value) {
 function popcount(n) {
   n -= (n >>> 1) & 0x55555555;
   n = (n & 0x33333333) + ((n >>> 2) & 0x33333333);
-  return (((n + (n >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
+  return Math.imul((n + (n >>> 4)) & 0x0f0f0f0f, 0x01010101) >>> 24;
 }
 
 /**

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -3,12 +3,13 @@
  * These types can be checked using the typescript compiler with "checkjs" option.
  */
 
-import { isEqual } from "./gleam.mjs";
+import { isEqual, Result$Error, Result$Ok } from "./gleam.mjs";
+import { Option$Some, Option$None } from "./gleam/option.mjs";
+
+// -- HASH --------------------------------------------------------------------
 
 const referenceMap = /* @__PURE__ */ new WeakMap();
-const tempDataView = /* @__PURE__ */ new DataView(
-  /* @__PURE__ */ new ArrayBuffer(8),
-);
+const tempDataView = /* @__PURE__ */ new DataView(/* @__PURE__ */ new ArrayBuffer(8));
 let referenceUID = 0;
 /**
  * hash the object by reference using a weak map and incrementing uid
@@ -149,845 +150,459 @@ export function getHash(u) {
   }
 }
 
-/**
- * @template K,V
- * @typedef {ArrayNode<K,V> | IndexNode<K,V> | CollisionNode<K,V>} Node
- */
-/**
- * @template K,V
- * @typedef {{ type: typeof ENTRY, k: K, v: V }} Entry
- */
-/**
- * @template K,V
- * @typedef {{ type: typeof ARRAY_NODE, size: number, array: (undefined | Entry<K,V> | Node<K,V>)[] }} ArrayNode
- */
-/**
- * @template K,V
- * @typedef {{ type: typeof INDEX_NODE, bitmap: number, array: (Entry<K,V> | Node<K,V>)[] }} IndexNode
- */
-/**
- * @template K,V
- * @typedef {{ type: typeof COLLISION_NODE, hash: number, array: Entry<K, V>[] }} CollisionNode
- */
-/**
- * @typedef {{ val: boolean }} Flag
- */
-const SHIFT = 5; // number of bits you need to shift by to get the next bucket
-const BUCKET_SIZE = Math.pow(2, SHIFT);
-const MASK = BUCKET_SIZE - 1; // used to zero out all bits not in the bucket
-const MAX_INDEX_NODE = BUCKET_SIZE / 2; // when does index node grow into array node
-const MIN_ARRAY_NODE = BUCKET_SIZE / 4; // when does array node shrink to index node
-const ENTRY = 0;
-const ARRAY_NODE = 1;
-const INDEX_NODE = 2;
-const COLLISION_NODE = 3;
-
-/** @type {IndexNode<any,any>} */
-const EMPTY = {
-  type: INDEX_NODE,
-  bitmap: 0,
-  array: [],
-};
-/**
- * Mask the hash to get only the bucket corresponding to shift
- * @param {number} hash
- * @param {number} shift
- * @returns {number}
- */
-function mask(hash, shift) {
-  return (hash >>> shift) & MASK;
-}
+// -- DICT --------------------------------------------------------------------
 
 /**
- * Set only the Nth bit where N is the masked hash
- * @param {number} hash
- * @param {number} shift
- * @returns {number}
- */
-function bitpos(hash, shift) {
-  return 1 << mask(hash, shift);
-}
-
-/**
- * Count the number of 1 bits in a number
- * @param {number} x
- * @returns {number}
- */
-function bitcount(x) {
-  x -= (x >> 1) & 0x55555555;
-  x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
-  x = (x + (x >> 4)) & 0x0f0f0f0f;
-  x += x >> 8;
-  x += x >> 16;
-  return x & 0x7f;
-}
-
-/**
- * Calculate the array index of an item in a bitmap index node
- * @param {number} bitmap
- * @param {number} bit
- * @returns {number}
- */
-function index(bitmap, bit) {
-  return bitcount(bitmap & (bit - 1));
-}
-
-/**
- * Efficiently copy an array and set one value at an index
- * @template T
- * @param {T[]} arr
- * @param {number} at
- * @param {T} val
- * @returns {T[]}
- */
-function cloneAndSet(arr, at, val) {
-  const len = arr.length;
-  const out = new Array(len);
-  for (let i = 0; i < len; ++i) {
-    out[i] = arr[i];
-  }
-  out[at] = val;
-  return out;
-}
-
-/**
- * Efficiently copy an array and insert one value at an index
- * @template T
- * @param {T[]} arr
- * @param {number} at
- * @param {T} val
- * @returns {T[]}
- */
-function spliceIn(arr, at, val) {
-  const len = arr.length;
-  const out = new Array(len + 1);
-  let i = 0;
-  let g = 0;
-  while (i < at) {
-    out[g++] = arr[i++];
-  }
-  out[g++] = val;
-  while (i < len) {
-    out[g++] = arr[i++];
-  }
-  return out;
-}
-
-/**
- * Efficiently copy an array and remove one value at an index
- * @template T
- * @param {T[]} arr
- * @param {number} at
- * @returns {T[]}
- */
-function spliceOut(arr, at) {
-  const len = arr.length;
-  const out = new Array(len - 1);
-  let i = 0;
-  let g = 0;
-  while (i < at) {
-    out[g++] = arr[i++];
-  }
-  ++i;
-  while (i < len) {
-    out[g++] = arr[i++];
-  }
-  return out;
-}
-
-/**
- * Create a new node containing two entries
- * @template K,V
- * @param {number} shift
- * @param {K} key1
- * @param {V} val1
- * @param {number} key2hash
- * @param {K} key2
- * @param {V} val2
- * @returns {Node<K,V>}
- */
-function createNode(shift, key1, val1, key2hash, key2, val2) {
-  const key1hash = getHash(key1);
-  if (key1hash === key2hash) {
-    return {
-      type: COLLISION_NODE,
-      hash: key1hash,
-      array: [
-        { type: ENTRY, k: key1, v: val1 },
-        { type: ENTRY, k: key2, v: val2 },
-      ],
-    };
-  }
-  const addedLeaf = { val: false };
-  return assoc(
-    assocIndex(EMPTY, shift, key1hash, key1, val1, addedLeaf),
-    shift,
-    key2hash,
-    key2,
-    val2,
-    addedLeaf,
-  );
-}
-
-/**
- * @template T,K,V
- * @callback AssocFunction
- * @param {T} root
- * @param {number} shift
- * @param {number} hash
- * @param {K} key
- * @param {V} val
- * @param {Flag} addedLeaf
- * @returns {Node<K,V>}
- */
-/**
- * Associate a node with a new entry, creating a new node
- * @template T,K,V
- * @type {AssocFunction<Node<K,V>,K,V>}
- */
-function assoc(root, shift, hash, key, val, addedLeaf) {
-  switch (root.type) {
-    case ARRAY_NODE:
-      return assocArray(root, shift, hash, key, val, addedLeaf);
-    case INDEX_NODE:
-      return assocIndex(root, shift, hash, key, val, addedLeaf);
-    case COLLISION_NODE:
-      return assocCollision(root, shift, hash, key, val, addedLeaf);
-  }
-}
-/**
- * @template T,K,V
- * @type {AssocFunction<ArrayNode<K,V>,K,V>}
- */
-function assocArray(root, shift, hash, key, val, addedLeaf) {
-  const idx = mask(hash, shift);
-  const node = root.array[idx];
-  // if the corresponding index is empty set the index to a newly created node
-  if (node === undefined) {
-    addedLeaf.val = true;
-    return {
-      type: ARRAY_NODE,
-      size: root.size + 1,
-      array: cloneAndSet(root.array, idx, { type: ENTRY, k: key, v: val }),
-    };
-  }
-  if (node.type === ENTRY) {
-    // if keys are equal replace the entry
-    if (isEqual(key, node.k)) {
-      if (val === node.v) {
-        return root;
-      }
-      return {
-        type: ARRAY_NODE,
-        size: root.size,
-        array: cloneAndSet(root.array, idx, {
-          type: ENTRY,
-          k: key,
-          v: val,
-        }),
-      };
-    }
-    // otherwise upgrade the entry to a node and insert
-    addedLeaf.val = true;
-    return {
-      type: ARRAY_NODE,
-      size: root.size,
-      array: cloneAndSet(
-        root.array,
-        idx,
-        createNode(shift + SHIFT, node.k, node.v, hash, key, val),
-      ),
-    };
-  }
-  // otherwise call assoc on the child node
-  const n = assoc(node, shift + SHIFT, hash, key, val, addedLeaf);
-  // if the child node hasn't changed just return the old root
-  if (n === node) {
-    return root;
-  }
-  // otherwise set the index to the new node
-  return {
-    type: ARRAY_NODE,
-    size: root.size,
-    array: cloneAndSet(root.array, idx, n),
-  };
-}
-/**
- * @template T,K,V
- * @type {AssocFunction<IndexNode<K,V>,K,V>}
- */
-function assocIndex(root, shift, hash, key, val, addedLeaf) {
-  const bit = bitpos(hash, shift);
-  const idx = index(root.bitmap, bit);
-  // if there is already a item at this hash index..
-  if ((root.bitmap & bit) !== 0) {
-    // if there is a node at the index (not an entry), call assoc on the child node
-    const node = root.array[idx];
-    if (node.type !== ENTRY) {
-      const n = assoc(node, shift + SHIFT, hash, key, val, addedLeaf);
-      if (n === node) {
-        return root;
-      }
-      return {
-        type: INDEX_NODE,
-        bitmap: root.bitmap,
-        array: cloneAndSet(root.array, idx, n),
-      };
-    }
-    // otherwise there is an entry at the index
-    // if the keys are equal replace the entry with the updated value
-    const nodeKey = node.k;
-    if (isEqual(key, nodeKey)) {
-      if (val === node.v) {
-        return root;
-      }
-      return {
-        type: INDEX_NODE,
-        bitmap: root.bitmap,
-        array: cloneAndSet(root.array, idx, {
-          type: ENTRY,
-          k: key,
-          v: val,
-        }),
-      };
-    }
-    // if the keys are not equal, replace the entry with a new child node
-    addedLeaf.val = true;
-    return {
-      type: INDEX_NODE,
-      bitmap: root.bitmap,
-      array: cloneAndSet(
-        root.array,
-        idx,
-        createNode(shift + SHIFT, nodeKey, node.v, hash, key, val),
-      ),
-    };
-  } else {
-    // else there is currently no item at the hash index
-    const n = root.array.length;
-    // if the number of nodes is at the maximum, expand this node into an array node
-    if (n >= MAX_INDEX_NODE) {
-      // create a 32 length array for the new array node (one for each bit in the hash)
-      const nodes = new Array(32);
-      // create and insert a node for the new entry
-      const jdx = mask(hash, shift);
-      nodes[jdx] = assocIndex(EMPTY, shift + SHIFT, hash, key, val, addedLeaf);
-      let j = 0;
-      let bitmap = root.bitmap;
-      // place each item in the index node into the correct spot in the array node
-      // loop through all 32 bits / array positions
-      for (let i = 0; i < 32; i++) {
-        if ((bitmap & 1) !== 0) {
-          const node = root.array[j++];
-          nodes[i] = node;
-        }
-        // shift the bitmap to process the next bit
-        bitmap = bitmap >>> 1;
-      }
-      return {
-        type: ARRAY_NODE,
-        size: n + 1,
-        array: nodes,
-      };
-    } else {
-      // else there is still space in this index node
-      // simply insert a new entry at the hash index
-      const newArray = spliceIn(root.array, idx, {
-        type: ENTRY,
-        k: key,
-        v: val,
-      });
-      addedLeaf.val = true;
-      return {
-        type: INDEX_NODE,
-        bitmap: root.bitmap | bit,
-        array: newArray,
-      };
-    }
-  }
-}
-/**
- * @template T,K,V
- * @type {AssocFunction<CollisionNode<K,V>,K,V>}
- */
-function assocCollision(root, shift, hash, key, val, addedLeaf) {
-  // if there is a hash collision
-  if (hash === root.hash) {
-    const idx = collisionIndexOf(root, key);
-    // if this key already exists replace the entry with the new value
-    if (idx !== -1) {
-      const entry = root.array[idx];
-      if (entry.v === val) {
-        return root;
-      }
-      return {
-        type: COLLISION_NODE,
-        hash: hash,
-        array: cloneAndSet(root.array, idx, { type: ENTRY, k: key, v: val }),
-      };
-    }
-    // otherwise insert the entry at the end of the array
-    const size = root.array.length;
-    addedLeaf.val = true;
-    return {
-      type: COLLISION_NODE,
-      hash: hash,
-      array: cloneAndSet(root.array, size, { type: ENTRY, k: key, v: val }),
-    };
-  }
-  // if there is no hash collision, upgrade to an index node
-  return assoc(
-    {
-      type: INDEX_NODE,
-      bitmap: bitpos(root.hash, shift),
-      array: [root],
-    },
-    shift,
-    hash,
-    key,
-    val,
-    addedLeaf,
-  );
-}
-/**
- * Find the index of a key in the collision node's array
- * @template K,V
- * @param {CollisionNode<K,V>} root
- * @param {K} key
- * @returns {number}
- */
-function collisionIndexOf(root, key) {
-  const size = root.array.length;
-  for (let i = 0; i < size; i++) {
-    if (isEqual(key, root.array[i].k)) {
-      return i;
-    }
-  }
-  return -1;
-}
-/**
- * @template T,K,V
- * @callback FindFunction
- * @param {T} root
- * @param {number} shift
- * @param {number} hash
- * @param {K} key
- * @returns {undefined | Entry<K,V>}
- */
-/**
- * Return the found entry or undefined if not present in the root
- * @template K,V
- * @type {FindFunction<Node<K,V>,K,V>}
- */
-function find(root, shift, hash, key) {
-  switch (root.type) {
-    case ARRAY_NODE:
-      return findArray(root, shift, hash, key);
-    case INDEX_NODE:
-      return findIndex(root, shift, hash, key);
-    case COLLISION_NODE:
-      return findCollision(root, key);
-  }
-}
-/**
- * @template K,V
- * @type {FindFunction<ArrayNode<K,V>,K,V>}
- */
-function findArray(root, shift, hash, key) {
-  const idx = mask(hash, shift);
-  const node = root.array[idx];
-  if (node === undefined) {
-    return undefined;
-  }
-  if (node.type !== ENTRY) {
-    return find(node, shift + SHIFT, hash, key);
-  }
-  if (isEqual(key, node.k)) {
-    return node;
-  }
-  return undefined;
-}
-/**
- * @template K,V
- * @type {FindFunction<IndexNode<K,V>,K,V>}
- */
-function findIndex(root, shift, hash, key) {
-  const bit = bitpos(hash, shift);
-  if ((root.bitmap & bit) === 0) {
-    return undefined;
-  }
-  const idx = index(root.bitmap, bit);
-  const node = root.array[idx];
-  if (node.type !== ENTRY) {
-    return find(node, shift + SHIFT, hash, key);
-  }
-  if (isEqual(key, node.k)) {
-    return node;
-  }
-  return undefined;
-}
-/**
- * @template K,V
- * @param {CollisionNode<K,V>} root
- * @param {K} key
- * @returns {undefined | Entry<K,V>}
- */
-function findCollision(root, key) {
-  const idx = collisionIndexOf(root, key);
-  if (idx < 0) {
-    return undefined;
-  }
-  return root.array[idx];
-}
-/**
- * @template T,K,V
- * @callback WithoutFunction
- * @param {T} root
- * @param {number} shift
- * @param {number} hash
- * @param {K} key
- * @returns {undefined | Node<K,V>}
- */
-/**
- * Remove an entry from the root, returning the updated root.
- * Returns undefined if the node should be removed from the parent.
- * @template K,V
- * @type {WithoutFunction<Node<K,V>,K,V>}
- * */
-function without(root, shift, hash, key) {
-  switch (root.type) {
-    case ARRAY_NODE:
-      return withoutArray(root, shift, hash, key);
-    case INDEX_NODE:
-      return withoutIndex(root, shift, hash, key);
-    case COLLISION_NODE:
-      return withoutCollision(root, key);
-  }
-}
-/**
- * @template K,V
- * @type {WithoutFunction<ArrayNode<K,V>,K,V>}
- */
-function withoutArray(root, shift, hash, key) {
-  const idx = mask(hash, shift);
-  const node = root.array[idx];
-  if (node === undefined) {
-    return root; // already empty
-  }
-  let n = undefined;
-  // if node is an entry and the keys are not equal there is nothing to remove
-  // if node is not an entry do a recursive call
-  if (node.type === ENTRY) {
-    if (!isEqual(node.k, key)) {
-      return root; // no changes
-    }
-  } else {
-    n = without(node, shift + SHIFT, hash, key);
-    if (n === node) {
-      return root; // no changes
-    }
-  }
-  // if the recursive call returned undefined the node should be removed
-  if (n === undefined) {
-    // if the number of child nodes is at the minimum, pack into an index node
-    if (root.size <= MIN_ARRAY_NODE) {
-      const arr = root.array;
-      const out = new Array(root.size - 1);
-      let i = 0;
-      let j = 0;
-      let bitmap = 0;
-      while (i < idx) {
-        const nv = arr[i];
-        if (nv !== undefined) {
-          out[j] = nv;
-          bitmap |= 1 << i;
-          ++j;
-        }
-        ++i;
-      }
-      ++i; // skip copying the removed node
-      while (i < arr.length) {
-        const nv = arr[i];
-        if (nv !== undefined) {
-          out[j] = nv;
-          bitmap |= 1 << i;
-          ++j;
-        }
-        ++i;
-      }
-      return {
-        type: INDEX_NODE,
-        bitmap: bitmap,
-        array: out,
-      };
-    }
-    return {
-      type: ARRAY_NODE,
-      size: root.size - 1,
-      array: cloneAndSet(root.array, idx, n),
-    };
-  }
-  return {
-    type: ARRAY_NODE,
-    size: root.size,
-    array: cloneAndSet(root.array, idx, n),
-  };
-}
-/**
- * @template K,V
- * @type {WithoutFunction<IndexNode<K,V>,K,V>}
- */
-function withoutIndex(root, shift, hash, key) {
-  const bit = bitpos(hash, shift);
-  if ((root.bitmap & bit) === 0) {
-    return root; // already empty
-  }
-  const idx = index(root.bitmap, bit);
-  const node = root.array[idx];
-  // if the item is not an entry
-  if (node.type !== ENTRY) {
-    const n = without(node, shift + SHIFT, hash, key);
-    if (n === node) {
-      return root; // no changes
-    }
-    // if not undefined, the child node still has items, so update it
-    if (n !== undefined) {
-      return {
-        type: INDEX_NODE,
-        bitmap: root.bitmap,
-        array: cloneAndSet(root.array, idx, n),
-      };
-    }
-    // otherwise the child node should be removed
-    // if it was the only child node, remove this node from the parent
-    if (root.bitmap === bit) {
-      return undefined;
-    }
-    // otherwise just remove the child node
-    return {
-      type: INDEX_NODE,
-      bitmap: root.bitmap ^ bit,
-      array: spliceOut(root.array, idx),
-    };
-  }
-  // otherwise the item is an entry, remove it if the key matches
-  if (isEqual(key, node.k)) {
-    if (root.bitmap === bit) {
-      return undefined;
-    }
-    return {
-      type: INDEX_NODE,
-      bitmap: root.bitmap ^ bit,
-      array: spliceOut(root.array, idx),
-    };
-  }
-  return root;
-}
-/**
- * @template K,V
- * @param {CollisionNode<K,V>} root
- * @param {K} key
- * @returns {undefined | Node<K,V>}
- */
-function withoutCollision(root, key) {
-  const idx = collisionIndexOf(root, key);
-  // if the key not found, no changes
-  if (idx < 0) {
-    return root;
-  }
-  // otherwise the entry was found, remove it
-  // if it was the only entry in this node, remove the whole node
-  if (root.array.length === 1) {
-    return undefined;
-  }
-  // otherwise just remove the entry
-  return {
-    type: COLLISION_NODE,
-    hash: root.hash,
-    array: spliceOut(root.array, idx),
-  };
-}
-/**
- * @template K,V
- * @param {undefined | Node<K,V>} root
- * @param {(value:V,key:K)=>void} fn
- * @returns {void}
- */
-function forEach(root, fn) {
-  if (root === undefined) {
-    return;
-  }
-  const items = root.array;
-  const size = items.length;
-  for (let i = 0; i < size; i++) {
-    const item = items[i];
-    if (item === undefined) {
-      continue;
-    }
-    if (item.type === ENTRY) {
-      fn(item.v, item.k);
-      continue;
-    }
-    forEach(item, fn);
-  }
-}
-
-/**
- * Extra wrapper to keep track of Dict size and clean up the API
- * @template K,V
+ * An implementation of the CHAMP data structure, an optimised HAMT.
+ *
+ * See: M. J. Steindorfer, J.J. Vinju (2015). Optimizing Hash-Array Mapped Tries for
+ Fast and Lean Immutable JVM Collections. Available: https://michael.steindorfer.name/publications/oopsla15.pdf
  */
 export default class Dict {
-  /**
-   * @template V
-   * @param {Record<string,V>} o
-   * @returns {Dict<string,V>}
-   */
-  static fromObject(o) {
-    const keys = Object.keys(o);
-    /** @type Dict<string,V> */
-    let m = Dict.new();
-    for (let i = 0; i < keys.length; i++) {
-      const k = keys[i];
-      m = m.set(k, o[k]);
-    }
-    return m;
-  }
-
-  /**
-   * @template K,V
-   * @param {Map<K,V>} o
-   * @returns {Dict<K,V>}
-   */
-  static fromMap(o) {
-    /** @type Dict<K,V> */
-    let m = Dict.new();
-    o.forEach((v, k) => {
-      m = m.set(k, v);
-    });
-    return m;
-  }
-
-  static new() {
-    return new Dict(undefined, 0);
-  }
-
-  /**
-   * @param {undefined | Node<K,V>} root
-   * @param {number} size
-   */
-  constructor(root, size) {
-    this.root = root;
+  constructor(size, root) {
     this.size = size;
-  }
-  /**
-   * @template NotFound
-   * @param {K} key
-   * @param {NotFound} notFound
-   * @returns {NotFound | V}
-   */
-  get(key, notFound) {
-    if (this.root === undefined) {
-      return notFound;
-    }
-    const found = find(this.root, 0, getHash(key), key);
-    if (found === undefined) {
-      return notFound;
-    }
-    return found.v;
-  }
-  /**
-   * @param {K} key
-   * @param {V} val
-   * @returns {Dict<K,V>}
-   */
-  set(key, val) {
-    const addedLeaf = { val: false };
-    const root = this.root === undefined ? EMPTY : this.root;
-    const newRoot = assoc(root, 0, getHash(key), key, val, addedLeaf);
-    if (newRoot === this.root) {
-      return this;
-    }
-    return new Dict(newRoot, addedLeaf.val ? this.size + 1 : this.size);
-  }
-  /**
-   * @param {K} key
-   * @returns {Dict<K,V>}
-   */
-  delete(key) {
-    if (this.root === undefined) {
-      return this;
-    }
-    const newRoot = without(this.root, 0, getHash(key), key);
-    if (newRoot === this.root) {
-      return this;
-    }
-    if (newRoot === undefined) {
-      return Dict.new();
-    }
-    return new Dict(newRoot, this.size - 1);
-  }
-  /**
-   * @param {K} key
-   * @returns {boolean}
-   */
-  has(key) {
-    if (this.root === undefined) {
-      return false;
-    }
-    return find(this.root, 0, getHash(key), key) !== undefined;
-  }
-  /**
-   * @returns {[K,V][]}
-   */
-  entries() {
-    if (this.root === undefined) {
-      return [];
-    }
-    /** @type [K,V][] */
-    const result = [];
-    this.forEach((v, k) => result.push([k, v]));
-    return result;
-  }
-  /**
-   *
-   * @param {(val:V,key:K)=>void} fn
-   */
-  forEach(fn) {
-    forEach(this.root, fn);
-  }
-  hashCode() {
-    let h = 0;
-    this.forEach((v, k) => {
-      h = (h + hashMerge(getHash(v), getHash(k))) | 0;
-    });
-    return h;
-  }
-  /**
-   * @param {unknown} o
-   * @returns {boolean}
-   */
-  equals(o) {
-    if (!(o instanceof Dict) || this.size !== o.size) {
-      return false;
-    }
-
-    try {
-      this.forEach((v, k) => {
-        if (!isEqual(o.get(k, !v), v)) {
-          throw unequalDictSymbol;
-        }
-      });
-      return true;
-    } catch (e) {
-      if (e === unequalDictSymbol) {
-        return false;
-      }
-
-      throw e;
-    }
+    this.root = root;
   }
 }
 
-// This is thrown internally in Dict.equals() so that it returns false as soon
-// as a non-matching key is found
-const unequalDictSymbol = /* @__PURE__ */ Symbol();
+class Node {
+  #generation;
+
+  constructor(generation, datamap, nodemap, data) {
+    // The generation value for transient copy tracking.
+    this.#generation = generation;
+    // A node is a high-arity (32 in practice) hybrid tree node.
+    // Hybrid means that it stores data directly as well as pointers to child nodes.
+    //
+    // Each node contains 2 bitmaps:
+    // - The datamap has a bit set if that slot in the node contains direct data
+    // - The nodemap has a bit set if that slot in the node ctonains another node.
+    //
+    // Both are exclusive to on another, so datamap & nodemap == 0.
+    //
+    // Every key/hash value directly correlates to a specific bit by using a trie
+    // suffix (least significant bits first) encoding.
+    // For example, if the last 5 bits of the hash are 1101, the bit to check for
+    // that value is the 13th bit.
+    this.datamap = datamap;
+    this.nodemap = nodemap;
+    // The slots itself are stored in a single contiguous array that contains
+    // both direct k/v-pairs and child nodes.
+    //
+    // The direct children come first, followed by the child nodes in _reverse order_:
+    //
+    //              7654321
+    //     datamap: 1000100
+    //     nodemap:   10011
+    //     data: [key3, value3, key7, value7, child5, child2, child1]
+    //            ------------------------->  <---------------------
+    //                     datamap                    nodemap
+    //
+    // Every `1` bit in the datamap corresponds to a pair of [key, value] entries,
+    // and every `1` bit in the nodemap corresponds to a child node entry.
+    //
+    // Children are stored in reverse order to avoid having to store or calculate an
+    // "offset" value to skip over the direct children.
+    this.data = data;
+  }
+
+  get generation() {
+    // hide generation so it's not enumerable - this makes dicts
+    // supported by the default equality and hash codes without custom implementations.
+    return this.#generation;
+  }
+
+  set generation(value) {
+    this.#generation = value;
+  }
+}
+
+/// The power-of-2 branch factor for the dict. For example, a vlaue of `5` indicates a 32-ary tree.
+const bits = 5;
+const mask = (1 << bits) - 1;
+
+/// This symbol is used internally to avoid constructing results.
+const noElementMarker = Symbol();
+
+// Some commonly used constants throughout the code.
+const emptyNode = /* @__PURE__ */ new Node(0, 0, 0, []);
+const emptyDict = /* @__PURE__ */ new Dict(0, emptyNode);
+const errorNil = /* @__PURE__ */ Result$Error(undefined);
+
+/**
+ * Copies a node and its data array if it's from another generation, making it safe
+ * to mutate the node.
+ */
+function copyNode(node, generation) {
+  if (node.generation === generation) {
+    return node;
+  }
+
+  const { datamap, nodemap, data } = node;
+  return new Node(generation, datamap, nodemap, data.slice(0));
+}
+
+export function make() {
+  return emptyDict;
+}
+
+export function from(iterable) {
+  let transient = toTransient(emptyDict);
+  for (const [key, value] of iterable) {
+    transient = put(key, value, transient);
+  }
+  return fromTransient(transient);
+}
+
+export function size(dict) {
+  return dict.size;
+}
+
+export function get(dict, key) {
+  return lookup(dict.root, key);
+}
+
+function lookup(node, key) {
+  const hash = getHash(key);
+
+  for (let shift = 0; shift < 32; shift += bits) {
+    const { data, datamap, nodemap } = node;
+    const bit = hashbit(hash, shift);
+
+    if (datamap & bit) {
+      // we store this hash directly!
+      //
+      // this also means that there are no other values with the same
+      // hash prefix in this dict.
+      //
+      // We still need to check if the key matches, but if it does we know for
+      // sure that this is the correct value, and if it doesn't that we don't
+      // contain the value in question.
+      const dataidx = 2 * index(datamap, bit);
+      return isEqual(key, data[dataidx]) ? Result$Ok(data[dataidx + 1]) : errorNil;
+    } else if (nodemap & bit) {
+      // we found our hash inside the nodemap, so we can continue our search there.
+      node = data[data.length - 1 - index(nodemap, bit)];
+    } else {
+      // if the hash bit is not set in neither bitmaps, we immediately know that
+      // this key cannot be inside this dict.
+      return errorNil;
+    }
+  }
+
+  // our shift has exceeded 32 bits. Everything that follows is
+  // implicitely an overflow node and only contains direct children.
+  const overflow = node.data;
+  for (let i = 0; i < overflow.length; i += 2) {
+    if (isEqual(key, overflow[i])) {
+      return Result$Ok(overflow[i + 1]);
+    }
+  }
+
+  return errorNil;
+}
+
+/**
+ * We use "transient" values to allow for safer internal mutations of the data
+ * structure. This is an optimisation only. No mutable API is exposed to the user.
+ *
+ * Transients are to be treated as having a linear (single-use, think rust) type.
+ * A transient value becomes invalid as soon as it's passed to one of the functions.
+ *
+ * Internally, we track a "generation" value on each node. If the generation
+ * doesn't match the one for the current transient, we have to copy - the node
+ * could still be referenced by another dict instance!
+ * After that, no other references than the transient one exists, so it's safe
+ * to mutate in place.
+ */
+export function toTransient(dict) {
+  return {
+    generation: nextGeneration(dict),
+    root: dict.root,
+    size: dict.size,
+    dict: dict,
+  };
+}
+
+/**
+ * Consume a transient, producing a normal Dict again.
+ */
+export function fromTransient(transient) {
+  if (transient.root === transient.dict.root) {
+    return transient.dict;
+  }
+
+  return new Dict(transient.size, transient.root);
+}
+
+/**
+ * Find and allocate the next generation id.
+ *
+ * @template K,V
+ * @param {Dict<K,V>} dict
+ * @returns {number}
+ */
+function nextGeneration(dict) {
+  const root = dict.root;
+  if (root.generation < Number.MAX_SAFE_INTEGER) {
+    return root.generation + 1;
+  }
+
+  // we have reached MAX_SAFE_INTEGER generations -
+  // at this point, we have to walk the dictionary once to reset the counter
+  // on every node. This is safe since it's part of the contract for transient
+  // that only one of them exists at any given time.
+  //
+  const queue = [root];
+  while (queue.length) {
+    // order doesn't matter, so we can use push/pop for faster array usage.
+    const node = queue.pop();
+
+    // reset the generation to 0
+    node.generation = 0;
+
+    // queue all other referenced nodes
+    const nodeStart = 2 * popcount(node.datamap);
+    for (let i = nodeStart; i < node.data.length; ++i) {
+      queue.push(node.data[i]);
+    }
+  }
+
+  return 1;
+}
+
+/*
+ * Like `get`, but for transient values. Note that this function is not pure!
+ */
+export function query(transient, key) {
+  return lookup(transient.root, key);
+}
+
+/**
+ * Consume a transient, writing a new key/value pair into the dictionary it
+ * represents. If the key already exists, it will be overwritten.
+ *
+ * Returns a new transient.
+ */
+export function put(key, value, transient) {
+  transient.root = doUpsert(transient, transient.root, key, always(value), getHash(key), 0);
+  return transient;
+}
+
+/**
+ * Consume a transient, removing a key if it exists.
+ * Returns a new transient.
+ */
+export function remove(key, transient) {
+  return put(key, noElementMarker, transient);
+}
+
+export function upsert(dict, key, fun) {
+  // we can use our noElementMarker value to skip traversing the dictionary twice.
+  const transient = toTransient(dict);
+  const wrapped = (value) => fun(value === noElementMarker ? Option$None() : Option$Some(value));
+  transient.root = doUpsert(transient, transient.root, key, wrapped, getHash(key), 0);
+  return fromTransient(transient);
+}
+
+export function map(dict, fun) {
+  // map can never modify the structure, so we can walk the dictionary directly,
+  // but still move to a new generation to make sure we get a new copy of every node.
+  const generation = nextGeneration(dict);
+  const root = copyNode(dict.root, generation);
+  const queue = [root];
+
+  while (queue.length) {
+    // order doesn't matter, so we can use push/pop for faster array usage.
+    const { data, datamap } = queue.pop();
+    // every node contains popcount(datamap) direct entries
+    const edgesStart = 2 * popcount(datamap);
+    for (let i = 0; i < edgesStart; i += 2) {
+      // we copied the node while queueing it, so direct mutation here is safe.
+      data[i + 1] = fun(data[i], data[i + 1]);
+    }
+    // the remaining entries are other nodes we can queue
+    for (let i = edgesStart; i < data.length; ++i) {
+      // copy the node first to make it safe to mutate
+      data[i] = copyNode(data[i], generation);
+      queue.push(data[i]);
+    }
+  }
+
+  return new Dict(dict.size, root);
+}
+
+export function fold(dict, state, fun) {
+  const queue = [dict.root];
+
+  while (queue.length) {
+    // order doesn't matter, so we can use push/pop for faster array usage.
+    const { data, datamap } = queue.pop();
+    // every node contains popcount(datamap) direct entries
+    const edgesStart = 2 * popcount(datamap);
+    for (let i = 0; i < edgesStart; i += 2) {
+      state = fun(state, data[i], data[i + 1]);
+    }
+    // the remaining entries are child nodes we can queue.
+    for (let i = edgesStart; i < data.length; ++i) {
+      queue.push(data[i]);
+    }
+  }
+
+  return state;
+}
+
+/**
+ * Main helper function for insert/upsert/remove.
+ */
+function doUpsert(transient, node, key, fun, hash, shift) {
+  const { data, datamap, nodemap } = node;
+
+  // 1. Overflow Node
+  // overflow nodes only contain key/value-pairs. we walk the data linearly trying to find a match.
+  if (shift > 32) {
+    for (let i = 0; i < data.length; i += 2) {
+      if (isEqual(key, data[i])) {
+        return doUpdate(transient, node, fun, 0, i);
+      }
+    }
+
+    return doInsert(transient, node, key, fun, 0, data.length);
+  }
+
+  const bit = hashbit(hash, shift);
+  const nodeidx = data.length - 1 - index(nodemap, bit);
+  const dataidx = 2 * index(datamap, bit);
+
+  // 2. Child Node
+  // We have to check first if there is already a child node we have to traverse to.
+  if ((nodemap & bit) !== 0) {
+    const oldChild = data[nodeidx];
+    const newChild = doUpsert(transient, oldChild, key, fun, hash, shift + bits);
+    if (newChild === oldChild) {
+      return node;
+    }
+
+    // the node did change, so let's copy to incorporate that change.
+    node = copyNode(node, transient.generation);
+    if (newChild.nodemap !== 0 || newChild.data.length > 2) {
+      node.data[nodeidx] = newChild;
+    } else {
+      // this node only has a single data (k/v-pair) child.
+      // to restore the CHAMP invariant, we "pull" that pair up into ourselves.
+      // this ensures that every tree stays in its single optimal representation,
+      // and allows dicts to be structurally compared.
+      node.datamap |= bit;
+      node.nodemap &= ~bit;
+      // NOTE: the order here is important to avoid mutation bugs!
+      // Remove the old child node, and insert the data pair into ourselves.
+      node.data.splice(nodeidx, 1);
+      node.data.splice(dataidx, 0, newChild.data[0], newChild.data[1]);
+    }
+
+    return node;
+  }
+
+  // 3. New Data Node
+  // No child node and no data node exists yet, so we can potentially just insert a new value.
+  if ((datamap & bit) === 0) {
+    return doInsert(transient, node, key, fun, bit, dataidx);
+  }
+
+  // 4. Existing Data Node
+  // We have a match that we can update, or remove.
+  if (isEqual(key, data[dataidx])) {
+    return doUpdate(transient, node, fun, bit, dataidx);
+  }
+
+  // 5. Collision
+  // There is no child node, but a data node with the same hash, but with a different key.
+  // To resolve this, we push both nodes down one level.
+  let child = new Node(transient.generation, 0, 0, []);
+  child = doUpsert(transient, child, key, fun, hash, shift + bits);
+  if (!child.data.length) {
+    return node;
+  }
+
+  const otherKey = data[dataidx];
+  child = doUpsert(transient, child, otherKey, always(data[dataidx + 1]), getHash(otherKey), shift + bits);
+  // we inserted 2 elements, but implicitely deleted the one we pushed down from the datamap.
+  transient.size -= 1;
+
+  node = copyNode(node, transient.generation);
+  node.datamap &= ~bit;
+  node.nodemap |= bit;
+
+  // remove the old data pair, and insert the new child node.
+  // because we remove 2 elements first, our indices are off-by-one!
+  // When calculating the nodeidx, we measure with the length including those
+  // 2 extra elements, but missing the one we haven't inserted yet, so we have
+  // to correct for both of these with (1-2) = -1
+  node.data.splice(dataidx, 2);
+  node.data.splice(nodeidx - 1, 0, child);
+
+  return node;
+}
+
+function doUpdate(transient, node, fun, bit, index) {
+  node = copyNode(node, transient.generation);
+
+  const value = fun(node.data[index + 1]);
+
+  if (value === noElementMarker) {
+    node.data.splice(index, 2);
+    node.datamap &= ~bit;
+    transient.size -= 1;
+  } else {
+    node.data[index + 1] = value;
+  }
+
+  return node;
+}
+
+function doInsert(transient, node, key, fun, bit, index) {
+  const value = fun(noElementMarker);
+  if (value === noElementMarker) {
+    return node;
+  }
+
+  node = copyNode(node, transient.generation);
+
+  node.datamap |= bit;
+  node.data.splice(index, 0, key, value);
+  transient.size += 1;
+
+  return node;
+}
+
+function always(value) {
+  return (_) => value;
+}
+
+/**
+ * How many `1` bits are set in a 32-bit integer.
+ */
+function popcount(n) {
+  n -= (n >>> 1) & 0x55555555;
+  n = (n & 0x33333333) + ((n >>> 2) & 0x33333333);
+  return (((n + (n >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
+}
+
+/**
+ * Given a population bitmap and a bit selected from that map, returns
+ * how many less significant 1 bits there are.
+ *
+ * For example, index(10101, 100) returns 1, since there is a single less
+ * significant `1` bit. This translates to the 0-based "index" of that bit.
+ */
+function index(bitmap, bit) {
+  return popcount(bitmap & (bit - 1));
+}
+
+/**
+ * Extracts a single slice ofthe hash, and returns a bitmask for the resulting value.
+ * For example, if the slice returns 5, this function returns 10000 = 1 << 5.
+ */
+function hashbit(hash, shift) {
+  return 1 << ((hash >>> shift) & mask);
+}

--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -259,7 +259,12 @@ export function size(dict) {
 }
 
 export function get(dict, key) {
-  return lookup(dict.root, key);
+  const result = lookup(dict.root, key);
+  return result !== noElementMarker ? Result$Ok(result) : errorNil;
+}
+
+export function has(dict, key) {
+  return lookup(dict.root, key) !== noElementMarker;
 }
 
 function lookup(node, key) {
@@ -279,14 +284,14 @@ function lookup(node, key) {
       // sure that this is the correct value, and if it doesn't that we don't
       // contain the value in question.
       const dataidx = 2 * index(datamap, bit);
-      return isEqual(key, data[dataidx]) ? Result$Ok(data[dataidx + 1]) : errorNil;
+      return isEqual(key, data[dataidx]) ? data[dataidx + 1] : noElementMarker;
     } else if (nodemap & bit) {
       // we found our hash inside the nodemap, so we can continue our search there.
       node = data[data.length - 1 - index(nodemap, bit)];
     } else {
       // if the hash bit is not set in neither bitmaps, we immediately know that
       // this key cannot be inside this dict.
-      return errorNil;
+      return noElementMarker;
     }
   }
 
@@ -295,11 +300,11 @@ function lookup(node, key) {
   const overflow = node.data;
   for (let i = 0; i < overflow.length; i += 2) {
     if (isEqual(key, overflow[i])) {
-      return Result$Ok(overflow[i + 1]);
+      return overflow[i + 1];
     }
   }
 
-  return errorNil;
+  return noElementMarker;
 }
 
 /**
@@ -375,7 +380,8 @@ function nextGeneration(dict) {
  * Like `get`, but for transient values. Note that this function is not pure!
  */
 export function query(transient, key) {
-  return lookup(transient.root, key);
+  const result = lookup(transient.root, key);
+  return result !== noElementMarker ? Result$Ok(result) : errorNil;
 }
 
 /**

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -134,17 +134,13 @@ fn from_list_loop(
 /// // -> False
 /// ```
 ///
+@external(javascript, "../dict.mjs", "has")
 pub fn has_key(dict: Dict(k, v), key: k) -> Bool {
   do_has_key(key, dict)
 }
 
 @external(erlang, "maps", "is_key")
-fn do_has_key(key: k, dict: Dict(k, v)) -> Bool {
-  case get(dict, key) {
-    Ok(_) -> True
-    Error(_) -> False
-  }
-}
+fn do_has_key(key: k, dict: Dict(k, v)) -> Bool
 
 /// Creates a fresh dict that contains no values.
 ///

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -195,7 +195,7 @@ pub fn insert(into dict: Dict(k, v), for key: k, insert value: v) -> Dict(k, v) 
 fn do_insert(key: k, value: v, dict: Dict(k, v)) -> Dict(k, v)
 
 @external(erlang, "maps", "put")
-@external(javascript, "../dict.mjs", "transientInsert")
+@external(javascript, "../dict.mjs", "destructiveTransientInsert")
 fn transient_insert(
   key: k,
   value: v,
@@ -373,7 +373,7 @@ pub fn delete(from dict: Dict(k, v), delete key: k) -> Dict(k, v) {
 }
 
 @external(erlang, "maps", "remove")
-@external(javascript, "../dict.mjs", "transientDelete")
+@external(javascript, "../dict.mjs", "destructiveTransientDelete")
 fn transient_delete(a: k, b: TransientDict(k, v)) -> TransientDict(k, v)
 
 /// Creates a new dict from a given dict with all the same entries except any with
@@ -558,7 +558,7 @@ fn do_combine(
 }
 
 @external(erlang, "maps", "update_with")
-@external(javascript, "../dict.mjs", "transientUpdateWith")
+@external(javascript, "../dict.mjs", "destructiveTransientUpdateWith")
 fn transient_update_with(
   key: k,
   fun: fn(v) -> v,

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -16,6 +16,25 @@ import gleam/option.{type Option}
 ///
 pub type Dict(key, value)
 
+/// "TransientDict" is a mutable view on a dictionary used internally by the
+/// javascript target. No mutable API is exposed to the user.
+///
+/// Transients are to be treated as having a linear (single-use, think rust) type.
+/// A transient value becomes invalid as soon as it's passed to one of the functions.
+type TransientDict(key, value)
+
+/// Convert a normal Dict to a transient dict.
+/// A transient dict is a mutable copy of the original.
+@external(erlang, "gleam_stdlib", "identity")
+@external(javascript, "../dict.mjs", "toTransient")
+fn to_transient(dict: Dict(key, value)) -> TransientDict(key, value)
+
+/// Convert a transient dict back into a normal dict, freezing its contents.
+/// Using the transient after this point is highly unsafe and leads to undefined behavior.
+@external(erlang, "gleam_stdlib", "identity")
+@external(javascript, "../dict.mjs", "fromTransient")
+fn from_transient(transient: TransientDict(key, value)) -> Dict(key, value)
+
 /// Determines the number of key-value pairs in the dict.
 /// This function runs in constant time and does not need to iterate the dict.
 ///
@@ -32,7 +51,7 @@ pub type Dict(key, value)
 /// ```
 ///
 @external(erlang, "maps", "size")
-@external(javascript, "../gleam_stdlib.mjs", "map_size")
+@external(javascript, "../dict.mjs", "size")
 pub fn size(dict: Dict(k, v)) -> Int
 
 /// Determines whether or not the dict is empty.
@@ -76,8 +95,10 @@ pub fn is_empty(dict: Dict(k, v)) -> Bool {
 /// ```
 ///
 @external(erlang, "maps", "to_list")
-@external(javascript, "../gleam_stdlib.mjs", "map_to_list")
-pub fn to_list(dict: Dict(k, v)) -> List(#(k, v))
+pub fn to_list(dict: Dict(k, v)) -> List(#(k, v)) {
+  use acc, key, value <- fold(dict, from: [])
+  [#(key, value), ..acc]
+}
 
 /// Converts a list of 2-element tuples `#(key, value)` to a dict.
 ///
@@ -86,16 +107,16 @@ pub fn to_list(dict: Dict(k, v)) -> List(#(k, v))
 ///
 @external(erlang, "maps", "from_list")
 pub fn from_list(list: List(#(k, v))) -> Dict(k, v) {
-  from_list_loop(list, new())
+  from_list_loop(to_transient(new()), list)
 }
 
 fn from_list_loop(
-  over list: List(#(k, v)),
-  from initial: Dict(k, v),
+  transient: TransientDict(k, v),
+  list: List(#(k, v)),
 ) -> Dict(k, v) {
   case list {
-    [] -> initial
-    [#(key, value), ..rest] -> from_list_loop(rest, insert(initial, key, value))
+    [] -> from_transient(transient)
+    [#(key, value), ..rest] -> from_list_loop(put(key, value, transient), rest)
   }
 }
 
@@ -119,13 +140,16 @@ pub fn has_key(dict: Dict(k, v), key: k) -> Bool {
 
 @external(erlang, "maps", "is_key")
 fn do_has_key(key: k, dict: Dict(k, v)) -> Bool {
-  get(dict, key) != Error(Nil)
+  case get(dict, key) {
+    Ok(_) -> True
+    Error(_) -> False
+  }
 }
 
 /// Creates a fresh dict that contains no values.
 ///
 @external(erlang, "maps", "new")
-@external(javascript, "../gleam_stdlib.mjs", "new_map")
+@external(javascript, "../dict.mjs", "make")
 pub fn new() -> Dict(k, v)
 
 /// Fetches a value from a dict for a given key.
@@ -146,7 +170,7 @@ pub fn new() -> Dict(k, v)
 /// ```
 ///
 @external(erlang, "gleam_stdlib", "map_get")
-@external(javascript, "../gleam_stdlib.mjs", "map_get")
+@external(javascript, "../dict.mjs", "get")
 pub fn get(from: Dict(k, v), get: k) -> Result(v, Nil)
 
 /// Inserts a value into the dict with the given key.
@@ -167,12 +191,12 @@ pub fn get(from: Dict(k, v), get: k) -> Result(v, Nil)
 /// ```
 ///
 pub fn insert(into dict: Dict(k, v), for key: k, insert value: v) -> Dict(k, v) {
-  do_insert(key, value, dict)
+  to_transient(dict) |> put(key, value, _) |> from_transient
 }
 
 @external(erlang, "maps", "put")
-@external(javascript, "../gleam_stdlib.mjs", "map_insert")
-fn do_insert(key: k, value: v, dict: Dict(k, v)) -> Dict(k, v)
+@external(javascript, "../dict.mjs", "put")
+fn put(key: k, value: v, transient: TransientDict(k, v)) -> TransientDict(k, v)
 
 /// Updates all values in a given dict by calling a given function on each key
 /// and value.
@@ -185,15 +209,13 @@ fn do_insert(key: k, value: v, dict: Dict(k, v)) -> Dict(k, v)
 /// // -> from_list([#(3, 9), #(2, 8)])
 /// ```
 ///
+@external(javascript, "../dict.mjs", "map")
 pub fn map_values(in dict: Dict(k, v), with fun: fn(k, v) -> a) -> Dict(k, a) {
   do_map_values(fun, dict)
 }
 
 @external(erlang, "maps", "map")
-fn do_map_values(f: fn(k, v) -> a, dict: Dict(k, v)) -> Dict(k, a) {
-  let f = fn(dict, k, v) { insert(dict, k, f(k, v)) }
-  fold(dict, from: new(), with: f)
-}
+fn do_map_values(f: fn(k, v) -> a, dict: Dict(k, v)) -> Dict(k, a)
 
 /// Gets a list of all keys in a given dict.
 ///
@@ -210,21 +232,8 @@ fn do_map_values(f: fn(k, v) -> a, dict: Dict(k, v)) -> Dict(k, a) {
 ///
 @external(erlang, "maps", "keys")
 pub fn keys(dict: Dict(k, v)) -> List(k) {
-  do_keys_loop(to_list(dict), [])
-}
-
-fn do_keys_loop(list: List(#(k, v)), acc: List(k)) -> List(k) {
-  case list {
-    [] -> reverse_and_concat(acc, [])
-    [#(key, _value), ..rest] -> do_keys_loop(rest, [key, ..acc])
-  }
-}
-
-fn reverse_and_concat(remaining: List(a), accumulator: List(a)) -> List(a) {
-  case remaining {
-    [] -> accumulator
-    [first, ..rest] -> reverse_and_concat(rest, [first, ..accumulator])
-  }
+  use acc, key, _value <- fold(dict, [])
+  [key, ..acc]
 }
 
 /// Gets a list of all values in a given dict.
@@ -242,15 +251,8 @@ fn reverse_and_concat(remaining: List(a), accumulator: List(a)) -> List(a) {
 ///
 @external(erlang, "maps", "values")
 pub fn values(dict: Dict(k, v)) -> List(v) {
-  let list_of_pairs = to_list(dict)
-  do_values_loop(list_of_pairs, [])
-}
-
-fn do_values_loop(list: List(#(k, v)), acc: List(v)) -> List(v) {
-  case list {
-    [] -> reverse_and_concat(acc, [])
-    [#(_key, value), ..rest] -> do_values_loop(rest, [value, ..acc])
-  }
+  use acc, _key, value <- fold(dict, [])
+  [value, ..acc]
 }
 
 /// Creates a new dict from a given dict, minus any entries that a given function
@@ -279,14 +281,14 @@ pub fn filter(
 
 @external(erlang, "maps", "filter")
 fn do_filter(f: fn(k, v) -> Bool, dict: Dict(k, v)) -> Dict(k, v) {
-  let insert = fn(dict, k, v) {
-    case f(k, v) {
-      True -> insert(dict, k, v)
-      False -> dict
+  to_transient(new())
+  |> fold(over: dict, with: fn(transient, key, value) {
+    case f(key, value) {
+      True -> put(key, value, transient)
+      False -> transient
     }
-  }
-
-  fold(dict, from: new(), with: insert)
+  })
+  |> from_transient
 }
 
 /// Creates a new dict from a given dict, only including any entries for which the
@@ -312,23 +314,21 @@ pub fn take(from dict: Dict(k, v), keeping desired_keys: List(k)) -> Dict(k, v) 
 
 @external(erlang, "maps", "with")
 fn do_take(desired_keys: List(k), dict: Dict(k, v)) -> Dict(k, v) {
-  do_take_loop(dict, desired_keys, new())
+  do_take_loop(dict, desired_keys, to_transient(new()))
 }
 
 fn do_take_loop(
   dict: Dict(k, v),
   desired_keys: List(k),
-  acc: Dict(k, v),
+  acc: TransientDict(k, v),
 ) -> Dict(k, v) {
-  let insert = fn(taken, key) {
-    case get(dict, key) {
-      Ok(value) -> insert(taken, key, value)
-      Error(_) -> taken
-    }
-  }
   case desired_keys {
-    [] -> acc
-    [first, ..rest] -> do_take_loop(dict, rest, insert(acc, first))
+    [] -> from_transient(acc)
+    [key, ..rest] ->
+      case get(dict, key) {
+        Ok(value) -> do_take_loop(dict, rest, put(key, value, acc))
+        Error(_) -> do_take_loop(dict, rest, acc)
+      }
   }
 }
 
@@ -348,20 +348,11 @@ fn do_take_loop(
 ///
 @external(erlang, "maps", "merge")
 pub fn merge(into dict: Dict(k, v), from new_entries: Dict(k, v)) -> Dict(k, v) {
-  new_entries
-  |> to_list
-  |> fold_inserts(dict)
-}
-
-fn fold_inserts(new_entries: List(#(k, v)), dict: Dict(k, v)) -> Dict(k, v) {
-  case new_entries {
-    [] -> dict
-    [first, ..rest] -> fold_inserts(rest, insert_pair(dict, first))
-  }
-}
-
-fn insert_pair(dict: Dict(k, v), pair: #(k, v)) -> Dict(k, v) {
-  insert(dict, pair.0, pair.1)
+  to_transient(dict)
+  |> fold(over: new_entries, with: fn(transient, key, value) {
+    put(key, value, transient)
+  })
+  |> from_transient
 }
 
 /// Creates a new dict from a given dict with all the same entries except for the
@@ -380,12 +371,12 @@ fn insert_pair(dict: Dict(k, v), pair: #(k, v)) -> Dict(k, v) {
 /// ```
 ///
 pub fn delete(from dict: Dict(k, v), delete key: k) -> Dict(k, v) {
-  do_delete(key, dict)
+  to_transient(dict) |> remove(key, _) |> from_transient
 }
 
 @external(erlang, "maps", "remove")
-@external(javascript, "../gleam_stdlib.mjs", "map_remove")
-fn do_delete(a: k, b: Dict(k, v)) -> Dict(k, v)
+@external(javascript, "../dict.mjs", "remove")
+fn remove(a: k, b: TransientDict(k, v)) -> TransientDict(k, v)
 
 /// Creates a new dict from a given dict with all the same entries except any with
 /// keys found in a given list.
@@ -408,9 +399,21 @@ fn do_delete(a: k, b: Dict(k, v)) -> Dict(k, v)
 /// ```
 ///
 pub fn drop(from dict: Dict(k, v), drop disallowed_keys: List(k)) -> Dict(k, v) {
+  do_drop(disallowed_keys, dict)
+}
+
+@external(erlang, "maps", "without")
+fn do_drop(disallowed_keys: List(k), dict: Dict(k, v)) -> Dict(k, v) {
+  drop_loop(to_transient(dict), disallowed_keys)
+}
+
+fn drop_loop(
+  transient: TransientDict(k, v),
+  disallowed_keys: List(k),
+) -> Dict(k, v) {
   case disallowed_keys {
-    [] -> dict
-    [first, ..rest] -> drop(delete(dict, first), rest)
+    [] -> from_transient(transient)
+    [key, ..rest] -> drop_loop(remove(key, transient), rest)
   }
 }
 
@@ -437,6 +440,7 @@ pub fn drop(from dict: Dict(k, v), drop disallowed_keys: List(k)) -> Dict(k, v) 
 /// // -> from_list([#("a", 0), #("b", 0)])
 /// ```
 ///
+@external(javascript, "../dict.mjs", "upsert")
 pub fn upsert(
   in dict: Dict(k, v),
   update key: k,
@@ -473,24 +477,18 @@ pub fn upsert(
 /// // -> "abc"
 /// ```
 ///
+@external(javascript, "../dict.mjs", "fold")
 pub fn fold(
   over dict: Dict(k, v),
   from initial: acc,
   with fun: fn(acc, k, v) -> acc,
 ) -> acc {
-  fold_loop(to_list(dict), initial, fun)
+  let fun = fn(key, value, acc) { fun(acc, key, value) }
+  do_fold(fun, initial, dict)
 }
 
-fn fold_loop(
-  list: List(#(k, v)),
-  initial: acc,
-  fun: fn(acc, k, v) -> acc,
-) -> acc {
-  case list {
-    [] -> initial
-    [#(k, v), ..rest] -> fold_loop(rest, fun(initial, k, v), fun)
-  }
-}
+@external(erlang, "maps", "fold")
+fn do_fold(fun: fn(k, v, acc) -> acc, initial: acc, dict: Dict(k, v)) -> acc
 
 /// Calls a function for each key and value in a dict, discarding the return
 /// value.
@@ -540,9 +538,53 @@ pub fn combine(
   other: Dict(k, v),
   with fun: fn(v, v) -> v,
 ) -> Dict(k, v) {
-  use acc, key, value <- fold(over: dict, from: other)
-  case get(acc, key) {
-    Ok(other_value) -> insert(acc, key, fun(value, other_value))
-    Error(_) -> insert(acc, key, value)
+  do_combine(fn(_, l, r) { fun(l, r) }, dict, other)
+}
+
+@external(erlang, "maps", "merge_with")
+fn do_combine(
+  combine: fn(k, v, v) -> v,
+  left: Dict(k, v),
+  right: Dict(k, v),
+) -> Dict(k, v) {
+  let #(big, small, combine) = case size(left) >= size(right) {
+    True -> #(left, right, combine)
+    False -> #(right, left, fn(k, l, r) { combine(k, r, l) })
+  }
+
+  to_transient(big)
+  |> fold(over: small, with: fn(transient, key, value) {
+    case query(transient, key) {
+      Ok(existing) -> put(key, combine(key, existing, value), transient)
+      Error(_) -> put(key, value, transient)
+    }
+  })
+  |> from_transient
+}
+
+@external(erlang, "gleam_stdlib", "map_get")
+@external(javascript, "../dict.mjs", "query")
+fn query(transient: TransientDict(k, v), key: k) -> Result(v, Nil)
+
+@internal
+pub fn group(key: fn(v) -> k, list: List(v)) -> Dict(k, List(v)) {
+  group_loop(to_transient(new()), key, list)
+}
+
+fn group_loop(
+  transient: TransientDict(k, List(v)),
+  to_key: fn(v) -> k,
+  list: List(v),
+) -> Dict(k, List(v)) {
+  case list {
+    [] -> from_transient(transient)
+    [value, ..rest] -> {
+      let key = to_key(value)
+      case query(transient, key) {
+        Ok(existing) ->
+          group_loop(put(key, [value, ..existing], transient), to_key, rest)
+        Error(_) -> group_loop(put(key, [value], transient), to_key, rest)
+      }
+    }
   }
 }

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -186,9 +186,13 @@ pub fn get(from: Dict(k, v), get: k) -> Result(v, Nil)
 /// // -> from_list([#("a", 5)])
 /// ```
 ///
+@external(javascript, "../dict.mjs", "insert")
 pub fn insert(into dict: Dict(k, v), for key: k, insert value: v) -> Dict(k, v) {
-  to_transient(dict) |> put(key, value, _) |> from_transient
+  do_insert(key, value, dict)
 }
+
+@external(erlang, "maps", "put")
+fn do_insert(key: k, value: v, dict: Dict(k, v)) -> Dict(k, v)
 
 @external(erlang, "maps", "put")
 @external(javascript, "../dict.mjs", "put")
@@ -432,7 +436,6 @@ fn drop_loop(
 /// // -> from_list([#("a", 0), #("b", 0)])
 /// ```
 ///
-@external(javascript, "../dict.mjs", "upsert")
 pub fn upsert(
   in dict: Dict(k, v),
   update key: k,

--- a/src/gleam/dict.gleam
+++ b/src/gleam/dict.gleam
@@ -96,8 +96,7 @@ pub fn is_empty(dict: Dict(k, v)) -> Bool {
 ///
 @external(erlang, "maps", "to_list")
 pub fn to_list(dict: Dict(k, v)) -> List(#(k, v)) {
-  use acc, key, value <- fold(dict, from: [])
-  [#(key, value), ..acc]
+  fold(dict, from: [], with: fn(acc, key, value) { [#(key, value), ..acc] })
 }
 
 /// Converts a list of 2-element tuples `#(key, value)` to a dict.
@@ -232,8 +231,7 @@ fn do_map_values(f: fn(k, v) -> a, dict: Dict(k, v)) -> Dict(k, a)
 ///
 @external(erlang, "maps", "keys")
 pub fn keys(dict: Dict(k, v)) -> List(k) {
-  use acc, key, _value <- fold(dict, [])
-  [key, ..acc]
+  fold(dict, [], fn(acc, key, _value) { [key, ..acc] })
 }
 
 /// Gets a list of all values in a given dict.
@@ -251,8 +249,7 @@ pub fn keys(dict: Dict(k, v)) -> List(k) {
 ///
 @external(erlang, "maps", "values")
 pub fn values(dict: Dict(k, v)) -> List(v) {
-  use acc, _key, value <- fold(dict, [])
-  [value, ..acc]
+  fold(dict, [], fn(acc, _key, value) { [value, ..acc] })
 }
 
 /// Creates a new dict from a given dict, minus any entries that a given function

--- a/src/gleam/list.gleam
+++ b/src/gleam/list.gleam
@@ -296,25 +296,7 @@ pub fn rest(list: List(a)) -> Result(List(a), Nil) {
 /// ```
 ///
 pub fn group(list: List(v), by key: fn(v) -> k) -> Dict(k, List(v)) {
-  group_loop(list, key, dict.new())
-}
-
-fn group_loop(
-  list: List(v),
-  to_key: fn(v) -> k,
-  groups: Dict(k, List(v)),
-) -> Dict(k, List(v)) {
-  case list {
-    [] -> groups
-    [first, ..rest] -> {
-      let key = to_key(first)
-      let groups = case dict.get(groups, key) {
-        Error(_) -> dict.insert(groups, key, [first])
-        Ok(existing) -> dict.insert(groups, key, [first, ..existing])
-      }
-      group_loop(rest, to_key, groups)
-    }
-  }
+  dict.group(key, list)
 }
 
 /// Returns a new list containing only the elements from the first list for

--- a/test/gleeunit/should.gleam
+++ b/test/gleeunit/should.gleam
@@ -8,11 +8,11 @@ pub fn equal(a: t, b: t) -> Nil {
     True -> Nil
     _ ->
       panic as string.concat([
-        "\n",
-        string.inspect(a),
-        "\nshould equal\n",
-        string.inspect(b),
-      ])
+          "\n",
+          string.inspect(a),
+          "\nshould equal\n",
+          string.inspect(b),
+        ])
   }
 }
 
@@ -21,11 +21,11 @@ pub fn not_equal(a: t, b: t) -> Nil {
     True -> Nil
     _ ->
       panic as string.concat([
-        "\n",
-        string.inspect(a),
-        "\nshould not equal\n",
-        string.inspect(b),
-      ])
+          "\n",
+          string.inspect(a),
+          "\nshould not equal\n",
+          string.inspect(b),
+        ])
   }
 }
 


### PR DESCRIPTION
Hi! Sorry I did a bunch of benchmarks, so wall of text incoming.

tl;dr: The new version is much simpler and potentially faster, although it's not super obvious right now yet until we optimise other bits of the runtime. I think it's still overall an improvement.

---

This PR rewrites the Dict implementation for the JavaScript target, implementing the CHAMP (Compressed Hash Array Mapped Prefix-trees) data structure as described by  M.J. Steindorfer and J.J. Vinju in _Optimizing Hash-Array Mapped Tries for Fast and Lean Immutable JVM Collections_ (2015, [link](https://michael.steindorfer.name/publications/oopsla15.pdf)). It also adds some optimizations found in ClojureScript, attributed to Christopher Grand by P. Schluck and C. Rodgers in their 2017 Talk _Closure Hash Maps: Plenty of room at the bottom_ ([link](https://bobkonf.de/2017/schuck.html)). Namely, it adds internal "transient" objects that allow for mutating the dictionary in controlled ways internally.

The current implementation is already quite good, so only minor performance improvements could be achieved for most operations in practice; I did a lot of benchmarks to figure out what's going on and what's possible, so sorry for the wall of tables.

## Highlights

- 50% reduction in code size
- 10-30% faster `get` and `insert` operations
- O(log n) equality checks, orders of magnitude faster bulk operations and iteration

## Establishing a baseline

I think it's useful to look at the absolute best performance we could achieve first to know what we're up against. All benchmarks were done on an M4 Pro 14-core chip using Node 24.7 and Bun 1.21.2, with [mitata](https://www.npmjs.com/package/mitata) as the benchmark runner.

This measures the performance of raw [JavaScript Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) calls. Keep in mind that this is not a suitable replacement in practice, as it only supports strings or numbers as keys and does not provide a persistent/immutable API at all.

Without further ado, here's what we're up against:

|                  |    10 |   100 |    1k |   10k |  100k |    1m |
|------------------|------ |-------|-------|-------|-------|-------|
| node / get       | 7.6ns |  11ns |  14ns |  13ns |  17ns |  28ns |
| node / insert    |  54ns |  52ns |  53ns |  54ns |  54ns |  88ns |
| node / from_list | 400ns | 2.5us |  27us | 654us | 5.0ms |  57ms |
| node / fold      |  30ns | 223ns | 2.2us |  22us | 230us | 6.8ms |
| bun / get        | 4.6ns | 4.9ns | 6.3ns | 6.8ns | 8.4ns |  12ns |
| bun / insert     |  49ns |  53ns |  53ns |  54ns |  53ns |  74ns |
| bun / from_list  | 394ns | 4.3us |  35us | 345us | 4.2ms |  68ms |
| bun / fold       |   1us | 598ns |   6us |  61us | 561us |   6ms |

It looks like it takes around 10ns to get an element, and around 50ns to insert one. The exact numbers here aren't that interesting, but I think it always helps to have a target and intuition how fast things should/could be. Note that this is still quite slow compared to JIT-optimised object shapes! These can be accessed and updated within a fraction of a nano-second.

It's also useful to think about what these numbers mean: at the 4 GHz or so my processor claims, one cycle is 0.25ns. Most instructions take a bunch of cycles to retire, so we can simplify a ton and just say 1ns = 1 instruction on average. A number like 4ns (for `get`) means that the CPU executed a single-digit number of instructions to get the value we wanted! Sometimes adding a branch increased latency by ~5ns; there are certainly more low-level optimisations to be done by someone with deeper knowledge of the code v8 generates, but we are actually at the point of counting instructions here!

## Implementation

The rewritten dictionary is a faithful implementation of the version presented in Steindorfer and Vinjus paper, with the addition of transients to allow for fast updates. The class-based Javascript API has been fully removed; this allows the dictionary and the hash function to be dead-code-eliminated almost entirely even if it is referenced incidentally through `string.inspect` or `dynamic.classify`. Specialised algorithms for `map`, `insert`, and `has_key` are provided to speed up common dictionary operations. I cleaned up the FFI API to no longer have this additional layer of indirection through `gleam_stdlib.mjs`; I think having the dictionary self-contained inside it's own file makes the code easier to maintain. Many of the public functions in the dictionary module have been replaced by more efficient versions on both targets.

Instead of 4 different node types, the new version only has a single (+ a "deformed" version on hash collisions) internal node type, eliminating most of the incidental complexity found within the old implementation. Overall, the dictionary went from roughly 560 LOC to around 290, a reduction of almost 50%.

The new `delete` algorithm also respects the **CHAMP invariant**, effectively banning nested node paths that only hold a single entry. Instead, lone entries are "pulled up" into the parent node recursively whenever possible. As a consequence, all CHAMP trees are guaranteed to be in their single, canonical, compact tree representation. This is particularly interesting for equality checks: Instead of having to walk all elements of the dictionary, the nodes can be compared directly. Nodes that are reference-equal or have different bitmaps don't have to be compared further. Dictionaries don't have to have their own `equals` or `hashCode` implementation anymore, but standard structural equality not only works, but also improves the complexity from _O(n log n)_ to _O(log n)_ on average.

While iterating, key order can change compared to the old version with this PR. Since dictionaries don't guarantee any order, no effort has been put into preserving the order at all.

## Benchmarks

Result construction, `isEqual`, and the hash function contribute significantly to the runtime of various dict operations. To make things more directly comparable, I provide "real" numbers including their overhead as well as "adjusted" variants where all of these operations have been replaced by no-ops, or strict equality in the case of `isEqual`. These measure the performance of the data structure itself more directly, which also makes them more comparable to the "baseline" measurements provided above.

### `get`

| old / new        |        10 |       100 |        1k |       10k |      100k |        1m |
|------------------|-----------|-----------|-----------|-----------|-----------|-----------|
| node / real      |   93/85ns | 105/107ns | 121/120ns | 136/130ns | 198/187ns | 682/418ns |
| bun / real       |   42/35ns |   48/39ns |   55/44ns |   76/64ns | 165/130ns | 765/583ns |
| node / adjusted  | 6.0/5.0ns | 9.2/6.9ns |  12/7.0ns |   17/11ns |   52/19ns | 315/43ns |
| bun / adjusted   | 5.7/4.7ns |  12/3.2ns |9.5/3.2ns |   15/6.6ns |   55/15ns | 265/21ns |

Since `get` is so fast, I generated an array of 1000 random keys that I all fetched in a loop. The numbers reported are the average for 1 single `get` operation. Hopefully this avoids measuring artifacts and memory locality effects. It's hard to explain why using results would be relatively slower the bigger the dictionary gets. Interestingly, the same effect doesn't happen when fetching the same element 1000 times, or when fetching random elements but using object literals (`{ success: true, value: ... }`) for results:


| old / new        |        10 |       100 |        1k |       10k |      100k |        1m |
|------------------|-----------|-----------|-----------|-----------|-----------|-----------|
| node / same      |   87/80ns |   99/97ns | 103/102ns | 101/103ns | 104/109ns | 114/119ns |
| node / literal   |   26/25ns |   32/27ns |   32/26ns |   49/32ns |   96/78ns | 552/217ns |

Benchmarking hard :pensive: While we know that objects are faster than the current results, I also think it's unlikely that they would be _that_ much faster too.

In the the Lustre diff benchmark (which is mostly `get` and `has_key`), performance is improved by 2-3 times compared to v0.65.0, getting within within 30% of using native mutable maps, and even beating them for common cases:


Overall, without overhead `get` has been improved by roughly 30% for small dictionaries, and is up to 5 times faster for very large ones. The adjusted values compare favourably to even built-in maps using v8, suggesting that a custom persistent immutable data structures can be as fast as natively implemented data structures provided by the runtime. Since Buns maps are much more performant in this benchmark I suspect that v8's native implementation could also be improved. For Bun and JavaScriptCore, the new dictionary seems to be especially faster.


### `insert`

| old / new        |        10 |       100 |        1k |       10k |      100k |        1m |
|------------------|-----------|-----------|-----------|-----------|-----------|-----------|
| node / update    |   50/54ns |   89/93ns | 109/109ns | 128/122ns | 217/189ns | 629/422ns |
| bun / update     |   41/29ns |   87/72ns |  106/87ns | 148/114ns | 287/235ns | 799/615ns |
| node / insert    |   33/39ns |   48/46ns |  83/129ns |   94/89ns | 144/114ns | 345/234ns |
| bun / insert     |   37/37ns |   53/48ns |  99/120ns | 111/103ns | 181/131ns | 618/257ns |

Both old and new versions beat built-in maps consistently for single inserts into maps up to 100 elements. While performance of CHAMP starts to become better for the largest dictionaries, it is more affected by outliers in its internal structure, making the 1k elements case particularly slow. 

### `from_list`

| old / new        |        10 |       100 |        1k |       10k |      100k |        1m |
|------------------|-----------|-----------|-----------|-----------|-----------|-----------|
| node / real      | 295/251ns | 7.5/6.6us |   96/82us | 958/988us |   17/11ms | 259/139ms |
| bun / real       | 292/253ns | 8.8/6.2us |  104/59us | 1.2/0.8ms |   25/11ms | 392/148ms |
| node / adjusted  | 244/165ns | 4.2/4.5us |   52/42us | 801/419us |  14/7.4ms | 213/102ms |
| bun / adjusted   | 195/312ns | 5.0/6.6us |   65/70ns | 853/532us |  16/8.1ms |  259/91ms |

`from_list` shows the power of transients, making it over twice as fast than a copying implementation for large dictionaries. A version exceeding native Maps speed can be achieved, but would require making the single insert case slower.

### `fold`

| old / new        |        10 |       100 |        1k |       10k |      100k |        1m |
|------------------|-----------|-----------|-----------|-----------|-----------|-----------|
| node             |  210/15ns | 1.6/0.2us |  15/0.9us |  338/15us | 2.6/0.3ms |  51/2.0ms |
| bun              | 100/8.8ns | 1.2/0.2us |  12/0.9us |  110/14us | 1.9/0.4ms |  39/3.9ms |

The old `fold` implementation used `to_list` under the hood, so performance improved massively. Not only that, but the new dictionary can be iterated faster than built-in maps, too!

## Discussion

All of the tested operations perform at least equally as fast as the current implementation. Most show significant performance increases as the dictionaries get bigger, but (except for `insert`) this doesn't seem to come at a cost for small dictionaries. While CHAMP features some highly specialized update routines, it is still less than half the amount of code as the current version.

Eliminating additional overhead, we can see that CHAMP can be competitive with built-in maps for get and insert operations up to dictionaries of around 1000 elements. Many of the benchmarks show a significant overhead for both result construction and `isEquals`. Both versions of the dictionary readily beat built-in maps once iteration or persistence is involved.

## Future work

While the immediate space for optimizations has been thoroughly explored, there might still be improvements by finding better mutating algorithms, or by exploring caching with the MEMCHAMP variant. While equality already uses the internal structure of the map, I suspect that similar optimizations could be done to all set-like operations (`merge`, `union`, `intersection`, `difference`, etc), using the internal structure to quickly combine nodes instead of working on the element level.

Since bulk operations are particularly fast, I think adding the missing `merge_list` or `insert_from_list` function might be useful. To avoid the overhead from results, a function similar to `get_or_default` could be provided.

Moving dictionary into the compiler and parameterising it over the used `getHash` and `isEquals` function would allow the compiler to inject monomorphised versions of these functions for the concrete key type used, skipping the generic implementations alltogether. Long term, escape analysis or similar techniques could be used to insert transients automatically.

While working on the dictionary, I noticed that the tag is ignored for the hash code of all custom types, meaning that `Ok(0)` or `Error(0)` hash to the same value. This mostly affects variants without attached data, which all hash to `0`, causing the dictionary to degrade to a linear search. I'll open up a discussion at some point since I have some additional thought about the hash an equals functions ^^

## Related work

The results presented here and by Steindorfer and Vinju have been confirmed independently by the Scala, Closure and ClosureScript communities, all implementing a variant of CHAMP as their default `HashMap` implementation. I also referenced [this](https://github.com/lorenzotinfena/goji/blob/main/collections/trie/hamt.go) Go implementation for their handling of transients.

### Appendix: Benchmark Code

<details>
  <summary>Benchmark code</summary>

```js
import { run, bench, boxplot, lineplot, summary, do_not_optimize } from "mitata";
import * as New from "./build/dev/javascript/gleam_stdlib/gleam/dict.mjs";
import * as Old from "./old-dict.mjs";

import * as List from "./build/dev/javascript/gleam_stdlib/gleam/list.mjs";
import { toList } from "./build/dev/javascript/prelude.mjs";

lineplot(() => {
  summary(() => {
    bench(`new.get($size)`, function* (state) {
      const size = state.get("size");
      const dict = New.from_list(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () =>
          Array.from(
            { length: 1000 },
            () => 1 + Math.trunc(Math.random() * size),
          ),
        bench: (is) => {
          for (let i = 0; i < 1000; ++i) do_not_optimize(New.get(dict, is[i]));
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
    bench(`old.get($size)`, function* (state) {
      const size = state.get("size");
      const dict = Old.from_list(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () =>
          Array.from(
            { length: 1000 },
            () => 1 + Math.trunc(Math.random() * size),
          ),
        bench: (is) => {
          for (let i = 0; i < 1000; ++i) do_not_optimize(Old.get(dict, is[i]));
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
    bench(`map.get($size)`, function* (state) {
      const size = state.get("size");
      const dict = new Map(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () =>
          Array.from(
            { length: 1000 },
            () => 1 + Math.trunc(Math.random() * size),
          ),
        bench: (is) => {
          for (let i = 0; i < 1000; ++i) do_not_optimize(dict.get(is[i]));
        },
      };
    }).range("size", 10, 1000000, 10);
  });
});

lineplot(() => {
  summary(() => {
    bench(`old.insert($size)`, function* (state) {
      const size = state.get("size");
      const dict = Old.from_list(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () => 1 + Math.trunc(Math.random() * 0xffffff),
        bench: (x) => {
          for (let i = -1000; i < 0; ++i) do_not_optimize(Old.insert(dict, x, i));
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");

    bench(`new.insert($size)`, function* (state) {
      const size = state.get("size");
      const dict = New.from_list(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () => 1 + Math.trunc(Math.random() * 0xffffff),
        bench: (x) => {
          for (let i = -1000; i < 0; ++i) do_not_optimize(New.insert(dict, x, i));
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
    bench(`map.insert($size)`, function* (state) {
      const size = state.get("size");
      const dict = new Map(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () => Math.trunc(Math.random() * 0xffffff),
        bench: (i) => {
          dict.set(i, i);
          return do_not_optimize(dict);
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
  });
});

lineplot(() => {
  summary(() => {
    bench(`new.from_list($size)`, function* (state) {
      const size = state.get("size");

      const list = List.map(List.range(1, size), (i) => [i, i]);

      yield {
        [0]: () => list,
        bench: (list) => do_not_optimize(New.from_list(list)),
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");

    bench(`old.from_list($size)`, function* (state) {
      const size = state.get("size");

      const list = List.map(List.range(1, size), (i) => [i, i]);

      yield {
        [0]: () => list,
        bench: (list) => do_not_optimize(Old.from_list(list)),
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");

    bench(`map.from_list($size)`, function* (state) {
      const size = state.get("size");

      const list = List.map(List.range(1, size), (i) => [i, i]);

      yield {
        [0]: () => list,
        bench: (list) => do_not_optimize(new Map(list)),
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
  });
});

lineplot(() => {
  summary(() => {
    bench(`new.fold($size)`, function* (state) {
      const size = state.get("size");

      const dict = New.from_list(List.map(List.range(1, size), (i) => [i, i]));

      yield {
        [0]: () => dict,
        bench: (dict) => do_not_optimize(New.fold(dict, 0, (s, k, v) => s + v)),
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");

    bench(`old.fold($size)`, function* (state) {
      const size = state.get("size");

      const dict = Old.from_list(List.map(List.range(1, size), (i) => [i, i]));

      yield {
        [0]: () => dict,
        bench: (dict) => do_not_optimize(Old.fold(dict, 0, (s, k, v) => s + v)),
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");

    bench(`map.fold($size)`, function* (state) {
      const size = state.get("size");

      const dict = new Map(List.map(List.range(1, size), (i) => [i, i]));

      yield {
        [0]: () => dict,
        bench: (dict) => {
          let s = 0;
          for (const [k, v] of dict.entries()) {
            s = s + v;
          }
          return do_not_optimize(s);
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
  });
});

lineplot(() => {
  summary(() => {
    bench(`old.remove($size)`, function* (state) {
      const size = state.get("size");
      const dict = Old.from_list(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () => Math.trunc(Math.random() * size) + 1,
        bench: (x) => {
          do_not_optimize(Old.delete$(dict, x));
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");

    bench(`new.remove($size)`, function* (state) {
      const size = state.get("size");
      const dict = New.from_list(List.map(List.range(1, size), (i) => [i, i]));
      yield {
        [0]: () => Math.trunc(Math.random() * size) + 1,
        bench: (x) => {
          do_not_optimize(New.delete$(dict, x));
        },
      };
    })
      .range("size", 10, 1000000, 10)
      .gc("inner");
  });
});

await run();
```
</details>
