### PR TITLE
Make int.modulo and float.modulo docs clearer

### DIFF
--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -456,6 +456,8 @@ pub fn random() -> Float
 /// Returns division of the inputs as a `Result`: If the given divisor equals
 /// `0`, this function returns an `Error`.
 ///
+/// The computed value will always have the same sign as the `divisor`.
+///
 /// ## Examples
 ///
 /// ```gleam

--- a/src/gleam/int.gleam
+++ b/src/gleam/int.gleam
@@ -594,8 +594,8 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// Returns division of the inputs as a `Result`: If the given divisor equals
 /// `0`, this function returns an `Error`.
 ///
-/// Most the time you will want to use the `%` operator instead of this
-/// function.
+/// Note that this is different from `int.remainder` and `%` in that the
+/// computed value will always have the same sign as the `divisor`.
 ///
 /// ## Examples
 ///
@@ -622,6 +622,11 @@ pub fn remainder(dividend: Int, by divisor: Int) -> Result(Int, Nil) {
 /// ```gleam
 /// modulo(-13, by: 3)
 /// // -> Ok(2)
+/// ```
+///
+/// ```gleam
+/// modulo(13, by: -3)
+/// // -> Ok(-2)
 /// ```
 ///
 pub fn modulo(dividend: Int, by divisor: Int) -> Result(Int, Nil) {


### PR DESCRIPTION
Lots of people were confused by the apparent difference in behaviour between `int.modulo` and `%` during Day 1 of Advent of Code. The docs were a bit unclear because they recommended `%` as an alternative for `int.modulo` even though they do different things.

I've removed the confusing bit and added a little note specifying the behaviour of `int.modulo`. I've added the same note for `float.modulo`. 