### PR TITLE
fix: fold/map overflow

### DIFF
--- a/src/dict.mjs
+++ b/src/dict.mjs
@@ -417,7 +417,9 @@ function nextGeneration(dict) {
     node[generationKey] = 0;
 
     // queue all other referenced nodes
-    const nodeStart = Math.imul(popcount(node.datamap), 2);
+    // We need to query the length from the nodemap, as we don't know if this
+    //  is an overflow node or not! if it is, it will never have datamap set!
+    const nodeStart = data.length - popcount(node.nodemap);
     for (let i = nodeStart; i < node.data.length; ++i) {
       queue.push(node.data[i]);
     }
@@ -521,7 +523,7 @@ function insertIntoNode(transient, node, key, value, hash, shift) {
   const childShift = shift + bits;
 
   let child = emptyNode;
-  child = insertIntoNode(transient, emptyNode, key, value, hash, childShift);
+  child = insertIntoNode(transient, child, key, value, hash, childShift);
 
   const key2 = data[dataidx];
   const value2 = data[dataidx + 1];
@@ -638,7 +640,9 @@ export function map(dict, fun) {
     const node = queue.pop();
     const data = node.data;
     // every node contains popcount(datamap) direct entries
-    const edgesStart = Math.imul(popcount(node.datamap), 2);
+    // We need to query the length from the nodemap, as we don't know if this
+    //  is an overflow node or not! if it is, it will never have datamap set!
+    const edgesStart = data.length - popcount(node.nodemap);
     for (let i = 0; i < edgesStart; i += 2) {
       // we copied the node while queueing it, so direct mutation here is safe.
       data[i + 1] = fun(data[i], data[i + 1]);
@@ -662,7 +666,9 @@ export function fold(dict, state, fun) {
     const node = queue.pop();
     const data = node.data;
     // every node contains popcount(datamap) direct entries
-    const edgesStart = Math.imul(popcount(node.datamap), 2);
+    // We need to query the length from the nodemap, as we don't know if this
+    //  is an overflow node or not! if it is, it will never have datamap set!
+    const edgesStart = data.length - popcount(node.nodemap);
     for (let i = 0; i < edgesStart; i += 2) {
       state = fun(state, data[i], data[i + 1]);
     }

--- a/test/gleam/dict_test.gleam
+++ b/test/gleam/dict_test.gleam
@@ -417,6 +417,70 @@ pub fn hash_collision_overflow_test() {
   assert dict.get(d, CollidingKey2) == Ok(2)
 }
 
+type Colour {
+  Red
+  Green
+  Blue
+}
+
+pub fn hash_collision_fold_test() {
+  let colours =
+    dict.from_list([
+      #(Red, "red"),
+      #(Green, "green"),
+      #(Blue, "blue"),
+    ])
+
+  let str =
+    dict.fold(colours, "", fn(acc, _color, name) { acc <> name <> "\n" })
+  assert string.contains(str, "green\n")
+  assert string.contains(str, "red\n")
+  assert string.contains(str, "blue\n")
+}
+
+pub fn hash_collision_map_test() {
+  let colours =
+    dict.from_list([
+      #(Red, "red"),
+      #(Green, "green"),
+      #(Blue, "blue"),
+    ])
+
+  let uppercase =
+    dict.map_values(colours, fn(_colour, name) { string.uppercase(name) })
+
+  assert dict.size(uppercase) == 3
+  assert dict.get(uppercase, Red) == Ok("RED")
+  assert dict.get(uppercase, Green) == Ok("GREEN")
+  assert dict.get(uppercase, Blue) == Ok("BLUE")
+}
+
+pub fn hash_collision_values_test() {
+  let colours =
+    dict.from_list([
+      #(Red, "red"),
+      #(Green, "green"),
+      #(Blue, "blue"),
+    ])
+
+  assert list.sort(dict.values(colours), string.compare)
+    == ["blue", "green", "red"]
+}
+
+pub fn hash_collision_keys_test() {
+  let colours =
+    dict.from_list([
+      #(Red, "red"),
+      #(Green, "green"),
+      #(Blue, "blue"),
+    ])
+
+  assert dict.keys(colours)
+    |> list.filter_map(dict.get(colours, _))
+    |> list.sort(string.compare)
+    == ["blue", "green", "red"]
+}
+
 fn test_random_operations(
   initial_seed: Int,
   num_ops: Int,


### PR DESCRIPTION
Every node keeps 2 bitmaps around: `datamap` and `nodemap`. Since once we hit overflow (trees of depth 6) we could have many more than 32 data entries per node, we give up on managing those bitmaps entirely, leaving them always as `0`.

In `fold` and `map` (and `nextGeneration`), we do not check for the overflow condition as the loop is organized differently to avoid recursing or keeping track of where we are in the tree.

Once we hit an overflow node, we always check the bitmaps to figure out what to do next - which data fields to visit and which nodes to queue. Here's the problem: We based that off of `datamap`, which meant according to fold, each overflow node _only contained child nodes_, so it was exactly the wrong value! So now we use the other map `nodemap` to base that decision on.

`nodemap` and `datamap` are always entirely exclusive, so if one bit is set in one map, it cannot be set in the other. That makes just switching this save in all cases.

fix #896
