### PR TITLE
Remove labelled `precision` argument from float.to_precision()'s docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.68.2 - 2026-01-25
+
+- Fix docs for float.to_precision() to remove the labelled argument.
+
 ## v0.68.1 - 2026-01-10
 
 - Fixed a bug in the dict implementation where using variants without fields

--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -279,12 +279,12 @@ pub fn truncate(x: Float) -> Int
 /// ## Examples
 ///
 /// ```gleam
-/// to_precision(2.43434348473, precision: 2)
+/// to_precision(2.43434348473, 2)
 /// // -> 2.43
 /// ```
 ///
 /// ```gleam
-/// to_precision(547890.453444, precision: -3)
+/// to_precision(547890.453444, -3)
 /// // -> 548000.0
 /// ```
 ///


### PR DESCRIPTION
The docs use a labelled argument, but `to_precision()` doesn't have one.

Fixes #899.