### PR TITLE
Add `trim_prefix` and `trim_suffix` in string.gleam

### DIFF
--- a/src/gleam/string.gleam
+++ b/src/gleam/string.gleam
@@ -888,3 +888,45 @@ pub fn trim_prefix(string: String, prefix prefix: String) -> String
 @external(erlang, "gleam_stdlib", "string_trim_suffix")
 @external(javascript, "../gleam_stdlib.mjs", "string_trim_suffix")
 pub fn trim_suffix(string: String, suffix suffix: String) -> String
+
+/// Removes the given prefix from the start of a `String` if present, and returns an `Ok(String)`.
+///
+/// If the `String` does not start with the given prefix, it is returned as an `Error(Nil)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// assert strip_prefix("gleamlucy", "gleam") == Ok("lucy")
+/// ```
+///
+/// ```gleam
+/// assert strip_prefix("lucygleam", "gleam") == Error(Nil)
+/// ```
+///
+@external(erlang, "gleam_stdlib", "string_strip_prefix")
+@external(javascript, "../gleam_stdlib.mjs", "string_strip_prefix")
+pub fn strip_prefix(
+  string: String,
+  prefix prefix: String,
+) -> Result(String, Nil)
+
+/// Removes the given suffix from the end of a `String` if present, and returns an `Ok(String)`.
+///
+/// If the `String` does not end with the given suffix, it is returned as an `Error(Nil)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// assert strip_suffix("lucygleam", "gleam") == Ok("lucy")
+/// ```
+///
+/// ```gleam
+/// assert strip_suffix("gleamlucy", "gleam") == Error(Nil)
+/// ```
+///
+@external(erlang, "gleam_stdlib", "string_strip_suffix")
+@external(javascript, "../gleam_stdlib.mjs", "string_strip_suffix")
+pub fn strip_suffix(
+  string: String,
+  suffix suffix: String,
+) -> Result(String, Nil)

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -12,7 +12,7 @@
     crop_string/2, base16_encode/1, base16_decode/1, string_replace/3, slice/3,
     bit_array_to_int_and_size/1, bit_array_pad_to_bytes/1, index/2, list/5,
     dict/1, int/1, float/1, bit_array/1, is_null/1, string_trim_prefix/2,
-    string_trim_suffix/2
+    string_trim_suffix/2, string_strip_prefix/2, string_strip_suffix/2
 ]).
 
 %% Taken from OTP's uri_string module
@@ -550,4 +550,30 @@ string_trim_suffix(String, Suffix) ->
     case Suffix == binary_part(String, Size - SuffixSize, SuffixSize) of
         true  -> binary_part(String, 0, Size - SuffixSize);
         false -> String
+    end.
+
+string_strip_prefix(String, <<>>) -> 
+    {ok, String};
+string_strip_prefix(<<>>, _) -> 
+    {error, nil};
+string_strip_prefix(String, Prefix) when byte_size(Prefix) > byte_size(String) ->
+    {error, nil};
+string_strip_prefix(String, Prefix) ->
+    PrefixSize = byte_size(Prefix),
+    case Prefix == binary_part(String, 0, PrefixSize) of
+        true -> {ok, binary_part(String, PrefixSize, byte_size(String) - PrefixSize)};
+        false -> {error, nil}
+    end.
+
+string_strip_suffix(String, <<>>) -> 
+    {ok, String};
+string_strip_suffix(<<>>, _) -> 
+    {error, nil};
+string_strip_suffix(String, Suffix) when byte_size(Suffix) > byte_size(String) -> 
+    {error, nil};
+string_strip_suffix(String, Suffix) ->
+    SuffixSize = byte_size(Suffix),
+    case Suffix == binary_part(String, byte_size(String) - SuffixSize, SuffixSize) of
+        true -> {ok, binary_part(String, 0, byte_size(String) - SuffixSize)};
+        false -> {error, nil}
     end.

--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -1080,3 +1080,35 @@ export function string_trim_suffix(str, suffix) {
 
   return str;
 }
+
+export function string_strip_prefix(str, prefix) {
+  if (prefix == "") {
+    return Result$Ok(str);
+  }
+
+  if (str == "" && prefix.length != 0) {
+    return Result$Error(undefined);
+  }
+
+  if (str.startsWith(prefix)) {
+    return Result$Ok(str.substring(prefix.length));
+  }
+
+  return Result$Error(undefined);
+}
+
+export function string_strip_suffix(str, suffix) {
+  if (suffix == "") {
+    return Result$Ok(str);
+  }
+
+  if (str == "" && suffix.length != 0) {
+    return Result$Error(undefined);
+  }
+
+  if (str.endsWith(suffix)) {
+    return Result$Ok(str.substring(0, str.length - suffix.length));
+  }
+
+  return Result$Error(undefined);
+}

--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -1329,3 +1329,35 @@ pub fn trim_suffix_test() {
 
   assert string.trim_suffix("🦑", "🦑") == ""
 }
+
+pub fn strip_prefix_test() {
+  assert string.strip_prefix("gleamlucy", "gleam") == Ok("lucy")
+
+  assert string.strip_prefix("lucygleam", "gleam") == Error(Nil)
+
+  assert string.strip_prefix("lucygleam", "") == Ok("lucygleam")
+
+  assert string.strip_prefix("", "gleam") == Error(Nil)
+
+  assert string.strip_prefix("gleam", "gleam") == Ok("")
+
+  assert string.strip_prefix("🦑lucy", "🦑") == Ok("lucy")
+
+  assert string.strip_prefix("🦑", "🦑") == Ok("")
+}
+
+pub fn strip_suffix_test() {
+  assert string.strip_suffix("lucygleam", "gleam") == Ok("lucy")
+
+  assert string.strip_suffix("gleamlucy", "gleam") == Error(Nil)
+
+  assert string.strip_suffix("lucygleam", "") == Ok("lucygleam")
+
+  assert string.strip_suffix("", "gleam") == Error(Nil)
+
+  assert string.strip_suffix("gleam", "gleam") == Ok("")
+
+  assert string.strip_suffix("lucy🦑", "🦑") == Ok("lucy")
+
+  assert string.strip_suffix("🦑", "🦑") == Ok("")
+}


### PR DESCRIPTION
See #743

This PR is still a draft and for now I only implement `trim_prefix` and `trim_suffix` that just trim the string without returning any error. (if there is no pattern, it's the same string as input)

(That's the same behavior and API from the golang `strings` package, https://pkg.go.dev/strings#TrimSuffix) 