### PR TITLE
use the key as path in decode error if it is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixed a bug where `uri.parse` would incorrectly handle uppercase schemes on
   Erlang.
 - The performance of the `int/bitwise_*` functions has been improved.
+- When the `decode.dict` function returns an error it now uses the key value in
+  the error path if it is a string, a float, or an int.
 
 ## v0.69.0 - 2026-01-26
 

--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -267,6 +267,7 @@
 import gleam/bit_array
 import gleam/dict.{type Dict}
 import gleam/dynamic
+import gleam/float
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -438,20 +439,24 @@ fn push_path(
   layer: #(t, List(DecodeError)),
   path: List(key),
 ) -> #(t, List(DecodeError)) {
-  let decoder = one_of(string, [int |> map(int.to_string)])
-  let path =
-    list.map(path, fn(key) {
-      let key = cast(key)
-      case run(key, decoder) {
-        Ok(key) -> key
-        Error(_) -> "<" <> dynamic.classify(key) <> ">"
-      }
-    })
+  let path = list.map(path, fn(key) { key |> cast |> path_segment_to_string })
   let errors =
     list.map(layer.1, fn(error) {
       DecodeError(..error, path: list.append(path, error.path))
     })
   #(layer.0, errors)
+}
+
+fn path_segment_to_string(key: Dynamic) -> String {
+  let decoder =
+    one_of(string, [
+      int |> map(int.to_string),
+      float |> map(float.to_string),
+    ])
+  case run(key, decoder) {
+    Ok(key) -> key
+    Error(_) -> "<" <> dynamic.classify(key) <> ">"
+  }
 }
 
 /// Finalise a decoder having successfully extracted a value.
@@ -834,10 +839,7 @@ fn fold_dict(
           #(dict, acc.1)
         }
         #(_, errors) -> {
-          let key_identifier = case run(key, one_of(string, [])) {
-            Ok(key) -> key
-            Error(_) -> "values"
-          }
+          let key_identifier = path_segment_to_string(key)
           push_path(#(dict.new(), errors), [key_identifier])
         }
       }

--- a/test/gleam/dynamic/decode_test.gleam
+++ b/test/gleam/dynamic/decode_test.gleam
@@ -373,7 +373,7 @@ pub fn dict_ok_test() {
   assert value == dict.from_list([#("first", 1), #("second", 2)])
 }
 
-pub fn dict_value_error_test() {
+pub fn dict_value_error_float_key_test() {
   let assert Error(value) =
     decode.run(
       dynamic.properties([
@@ -382,7 +382,7 @@ pub fn dict_value_error_test() {
       ]),
       decode.dict(decode.float, decode.string),
     )
-  assert value == [DecodeError("String", "Int", ["values"])]
+  assert value == [DecodeError("String", "Int", ["1.1"])]
 }
 
 pub fn dict_value_error_string_key_test() {
@@ -395,6 +395,30 @@ pub fn dict_value_error_string_key_test() {
       decode.dict(decode.string, decode.string),
     )
   assert value == [DecodeError("String", "Int", ["b"])]
+}
+
+pub fn dict_value_error_int_key_test() {
+  let assert Error(value) =
+    decode.run(
+      dynamic.properties([
+        #(dynamic.int(1), dynamic.string("first")),
+        #(dynamic.int(2), dynamic.int(2)),
+      ]),
+      decode.dict(decode.int, decode.string),
+    )
+  assert value == [DecodeError("String", "Int", ["2"])]
+}
+
+pub fn dict_value_error_bit_array_key_test() {
+  let assert Error(value) =
+    decode.run(
+      dynamic.properties([
+        #(dynamic.bit_array(<<0:5>>), dynamic.string("first")),
+        #(dynamic.bit_array(<<1:5>>), dynamic.int(2)),
+      ]),
+      decode.dict(decode.bit_array, decode.string),
+    )
+  assert value == [DecodeError("String", "Int", ["<BitArray>"])]
 }
 
 pub fn dict_key_error_test() {


### PR DESCRIPTION
This changes makes working with large json data, like an openapi schema, much easier.

We previously had a patch for this in OAS https://github.com/CrowdHailer/oas/pull/1.
Unfortunately using the same approach in the new decode API is not possible as the decoder type is opaque.

I had a look at a previous PR attempting to do something similar https://github.com/gleam-lang/stdlib/pull/746. I didn't follow all the points discussed. I've not updated any function internals apart from the one dealing with dictionaries. 

