### PR TITLE
docs: fix exponential doc examples to match return type

### DIFF
--- a/src/gleam/float.gleam
+++ b/src/gleam/float.gleam
@@ -605,15 +605,15 @@ fn do_log(x: Float) -> Float
 /// ## Examples
 ///
 /// ```gleam
-/// assert exponential(0.0) == Ok(1.0)
+/// assert exponential(0.0) == 1.0
 /// ```
 ///
 /// ```gleam
-/// assert exponential(1.0) == Ok(2.718281828459045)
+/// assert exponential(1.0) == 2.718281828459045
 /// ```
 ///
 /// ```gleam
-/// assert exponential(-1.0) == Ok(0.36787944117144233)
+/// assert exponential(-1.0) == 0.36787944117144233
 /// ```
 ///
 @external(erlang, "math", "exp")


### PR DESCRIPTION
The documentation comment for `float.exponential` has mismatched signature and examples. The signature declares a return type of `Float`, but the example assertions wrap results in `Ok(...)` as if it returned a `Result`. This PR removes the incorrect `Ok` wrappings.