### PR TITLE
Fix small documentation typos

### DIFF
--- a/src/gleam/dynamic/decode.gleam
+++ b/src/gleam/dynamic/decode.gleam
@@ -1039,7 +1039,7 @@ pub fn failure(placeholder: a, expected name: String) -> Decoder(a) {
 /// `[]`.
 ///
 /// If you were to make a decoder for the `Int` type (rather than using the
-/// build-in `Int` decoder) you would define it like so:
+/// built-in `Int` decoder) you would define it like so:
 ///
 /// ```gleam
 /// pub fn int_decoder() -> decode.Decoder(Int) {

--- a/src/gleam/string_tree.gleam
+++ b/src/gleam/string_tree.gleam
@@ -163,7 +163,7 @@ pub fn replace(
 /// content.
 ///
 /// Comparing two string trees using the `==` operator may return `False` even
-/// if they have the same content as they may have been build in different ways,
+/// if they have the same content as they may have been built in different ways,
 /// so using this function is often preferred.
 ///
 /// ## Examples

--- a/src/gleam/uri.gleam
+++ b/src/gleam/uri.gleam
@@ -13,7 +13,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam/string_tree.{type StringTree}
 
-/// Type representing the parsed components of an URI.
+/// Type representing the parsed components of a URI.
 /// All components of a URI are optional, except the path.
 ///
 pub type Uri {


### PR DESCRIPTION
This fixes three small documentation typos in comments for the URI, StringTree, and dynamic decode modules.

No tests were run locally because this is a documentation-only change and the Gleam executable is not available in this shell.