### PR TITLE
Fix parse_query decoding multiple plus signs

### DIFF
--- a/src/gleam_stdlib.mjs
+++ b/src/gleam_stdlib.mjs
@@ -482,7 +482,7 @@ function unsafe_percent_decode(string) {
 }
 
 function unsafe_percent_decode_query(string) {
-  return decodeURIComponent((string || "").replace("+", " "));
+  return decodeURIComponent((string || "").replaceAll("+", " "));
 }
 
 export function percent_decode(string) {

--- a/test/gleam/uri_test.gleam
+++ b/test/gleam/uri_test.gleam
@@ -517,6 +517,11 @@ pub fn parse_query_string_basic_test() {
   assert parsed == [#("weebl bob", "1"), #("city", "örebro")]
 }
 
+pub fn parse_query_string_multiple_spaces_test() {
+  let assert Ok(parsed) = uri.parse_query("one+two+three=four+five+six")
+  assert parsed == [#("one two three", "four five six")]
+}
+
 pub fn parse_query_string_duplicates_test() {
   // Duplicates keys not overridden
   let assert Ok(parsed) = uri.parse_query("a[]=1&a[]=2")


### PR DESCRIPTION
This fixes the JavaScript implementation of uri.parse_query so all plus signs in query keys and values are decoded as spaces, matching the Erlang target.

The previous JavaScript implementation used String.prototype.replace, which only replaced the first plus sign. This now uses replaceAll and adds a regression test for multiple plus signs in both the key and value.

Verification:
- git diff --check
- Node expression confirmed replace only handles the first plus while replaceAll handles all plus signs
- Erlang uri_string:dissect_query confirmed the expected decoded result
