### PR TITLE
Fix deprecation warnings in OTP 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed deprecation warnings when using OTP 29
+
 ## v1.0.1 - 2026-05-14
 
 - Fixed a bug where `uri.parse_query` would not correctly decode all `+`

--- a/src/gleam_stdlib.erl
+++ b/src/gleam_stdlib.erl
@@ -72,21 +72,24 @@ tuple_get(Data, Index) when Index >= tuple_size(Data) -> {error, nil};
 tuple_get(Data, Index) -> {ok, element(Index + 1, Data)}.
 
 int_from_base_string(String, Base) ->
-    case catch binary_to_integer(String, Base) of
+    try binary_to_integer(String, Base) of
         Int when is_integer(Int) -> {ok, Int};
         _ -> {error, nil}
+    catch _:_ -> {error, nil}
     end.
 
 parse_int(String) ->
-    case catch binary_to_integer(String) of
+    try binary_to_integer(String) of
         Int when is_integer(Int) -> {ok, Int};
         _ -> {error, nil}
+    catch _:_ -> {error, nil}
     end.
 
 parse_float(String) ->
-    case catch binary_to_float(String) of
+    try binary_to_float(String) of
         Float when is_float(Float) -> {ok, Float};
         _ -> {error, nil}
+    catch _:_ -> {error, nil}
     end.
 
 less_than(Lhs, Rhs) ->


### PR DESCRIPTION
I noticed that OTP 29 introduced deprecation warnings that were raised in stdlib

```
  Compiling gleam_stdlib
/Users/jtdowney/code/gleam_stdlib/build/dev/erlang/gleam_stdlib/_gleam_artefacts/gleam_stdlib.erl:75:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   75|     case catch binary_to_integer(String, Base) of
%     |          ^

/Users/jtdowney/code/gleam_stdlib/build/dev/erlang/gleam_stdlib/_gleam_artefacts/gleam_stdlib.erl:81:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   81|     case catch binary_to_integer(String) of
%     |          ^

/Users/jtdowney/code/gleam_stdlib/build/dev/erlang/gleam_stdlib/_gleam_artefacts/gleam_stdlib.erl:87:10: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
Compile directive 'nowarn_deprecated_catch' can be used to suppress
warnings in selected modules.
%   87|     case catch binary_to_float(String) of
%     |          ^
```