### PR TITLE
inconsistency regression tests

### DIFF
--- a/test/gleam/string_test.gleam
+++ b/test/gleam/string_test.gleam
@@ -92,9 +92,31 @@ pub fn split_once_empty_test() {
   assert string.split_once("", ",") == Error(Nil)
 }
 
+// An empty pattern matches the zero-width gap at the start.
+pub fn split_once_empty_pattern_test() {
+  assert string.split_once("Gleam", "") == Ok(#("", "Gleam"))
+}
+
+pub fn split_once_empty_pattern_empty_string_test() {
+  assert string.split_once("", "") == Ok(#("", ""))
+}
+
 pub fn replace_test() {
   assert string.replace("Gleam,Erlang,Elixir", ",", "++")
     == "Gleam++Erlang++Elixir"
+}
+
+// An empty pattern matches the gap around every grapheme.
+pub fn replace_empty_pattern_test() {
+  assert string.replace("ab", "", "-") == "-a-b-"
+}
+
+pub fn replace_empty_pattern_empty_string_test() {
+  assert string.replace("", "", "-") == "-"
+}
+
+pub fn replace_empty_pattern_grapheme_test() {
+  assert string.replace("👩‍👩‍👦‍👦x", "", "-") == "-👩‍👩‍👦‍👦-x-"
 }
 
 pub fn append_test() {

--- a/test/gleam/string_tree_test.gleam
+++ b/test/gleam/string_tree_test.gleam
@@ -121,6 +121,35 @@ pub fn split_multi_string_test() {
     ]
 }
 
+// An empty pattern splits between every grapheme.
+pub fn split_empty_pattern_test() {
+  assert "abc"
+    |> string_tree.from_string
+    |> string_tree.split("")
+    == [
+      string_tree.from_string("a"),
+      string_tree.from_string("b"),
+      string_tree.from_string("c"),
+    ]
+}
+
+// An empty pattern substitutes around every grapheme.
+pub fn replace_empty_pattern_test() {
+  assert "ab"
+    |> string_tree.from_string
+    |> string_tree.replace(each: "", with: "-")
+    |> string_tree.to_string
+    == "-a-b-"
+}
+
+pub fn replace_empty_pattern_empty_string_test() {
+  assert ""
+    |> string_tree.from_string
+    |> string_tree.replace(each: "", with: "-")
+    |> string_tree.to_string
+    == "-"
+}
+
 pub fn is_equal_different_structure_test() {
   assert string_tree.is_equal(
     string_tree.from_string("12"),


### PR DESCRIPTION
All of these tests behave differently on the BEAM and JavaScript runtimes.
I'm not sure what the correct behaviour is. Happy to work on the fix if we decide what correct behavour is.
I think the choice is really the erl or js implementation.
erl seems to mostly error when given an empty string pattern. js considers empty pattern to match every grapheme gap.